### PR TITLE
LINUX: Fix desktop ID

### DIFF
--- a/contrib/installer/linux/io.github.vengi_voxel.vengi.voxbrowser.metainfo.xml
+++ b/contrib/installer/linux/io.github.vengi_voxel.vengi.voxbrowser.metainfo.xml
@@ -42,5 +42,5 @@
   <url type="bugtracker">https://github.com/vengi-voxel/vengi/issues</url>
   <url type="donation">https://www.paypal.me/MartinGerhardy</url>
   <content_rating type="oars-1.1"/>
-  <launchable type="desktop-id">voxbrowser.desktop</launchable>
+  <launchable type="desktop-id">vengi-voxbrowser.desktop</launchable>
 </component>

--- a/contrib/installer/linux/io.github.vengi_voxel.vengi.voxedit.metainfo.xml
+++ b/contrib/installer/linux/io.github.vengi_voxel.vengi.voxedit.metainfo.xml
@@ -126,5 +126,5 @@
   <url type="bugtracker">https://github.com/vengi-voxel/vengi/issues</url>
   <url type="donation">https://www.paypal.me/MartinGerhardy</url>
   <content_rating type="oars-1.1"/>
-  <launchable type="desktop-id">voxedit.desktop</launchable>
+  <launchable type="desktop-id">vengi-voxedit.desktop</launchable>
 </component>


### PR DESCRIPTION
as it gets renamed in the installation process. Required for https://github.com/flathub/io.github.mgerhardy.vengi.voxedit/pull/10.