### PR TITLE
Reference the old AppStream IDs as they are meant to be constant

### DIFF
--- a/contrib/installer/linux/io.github.vengi_voxel.vengi.voxbrowser.metainfo.xml
+++ b/contrib/installer/linux/io.github.vengi_voxel.vengi.voxbrowser.metainfo.xml
@@ -43,4 +43,10 @@
   <url type="donation">https://www.paypal.me/MartinGerhardy</url>
   <content_rating type="oars-1.1"/>
   <launchable type="desktop-id">vengi-voxbrowser.desktop</launchable>
+  <provides>
+    <id>io.github.mgerhardy.vengi.voxbrowser</id>
+  </provides>
+  <replaces>
+    <id>io.github.mgerhardy.vengi.voxbrowser</id>
+  </replaces>
 </component>

--- a/contrib/installer/linux/io.github.vengi_voxel.vengi.voxedit.metainfo.xml
+++ b/contrib/installer/linux/io.github.vengi_voxel.vengi.voxedit.metainfo.xml
@@ -127,4 +127,10 @@
   <url type="donation">https://www.paypal.me/MartinGerhardy</url>
   <content_rating type="oars-1.1"/>
   <launchable type="desktop-id">vengi-voxedit.desktop</launchable>
+  <provides>
+    <id>io.github.mgerhardy.vengi.voxedit</id>
+  </provides>
+  <replaces>
+    <id>io.github.mgerhardy.vengi.voxedit</id>
+  </replaces>
 </component>


### PR DESCRIPTION
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#renaming-id-tag