### PR TITLE
IO: fixed natural scrolling, now respects system setting

### DIFF
--- a/src/modules/video/EventHandler.cpp
+++ b/src/modules/video/EventHandler.cpp
@@ -85,10 +85,6 @@ bool EventHandler::handleEvent(SDL_Event &event) {
 		}
 		int x = event.wheel.x;
 		int y = event.wheel.y;
-		if (event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED) {
-			x *= -1;
-			y *= -1;
-		}
 		x = glm::clamp(x, -1, 1);
 		y = glm::clamp(y, -1, 1);
 		mouseWheel(x, y);


### PR DESCRIPTION
It turns out `event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED` is actually telling you that the provided `x` and `y` have already been flipped. You can undo this by multiplying by `-1` but you don't need to do that if you want to respect the operating system option.

**This PR removes the multiplying and now the system setting is preserved**