### PR TITLE
VOXEDIT: Add +move_up and +move_down camera movement commands

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -44,7 +44,7 @@ function(gtest_suite_begin name)
 		# add googletest lib dependency
 		if (GTEST_FOUND)
 			target_include_directories(${name} PRIVATE ${GTEST_INCLUDE_DIRS})
-			target_link_libraries(${name} ${GTEST_LIBRARIES})
+			target_link_libraries(${name} PUBLIC ${GTEST_LIBRARIES})
 		endif()
 	endif()
 endfunction()

--- a/src/modules/util/Movement.cpp
+++ b/src/modules/util/Movement.cpp
@@ -24,6 +24,8 @@ void Movement::construct() {
 	command::Command::registerActionButton("move_backward", _moveBackward);
 	command::Command::registerActionButton("move_left", _moveLeft);
 	command::Command::registerActionButton("move_right", _moveRight);
+	command::Command::registerActionButton("move_up", _moveUp);
+	command::Command::registerActionButton("move_down", _moveDown);
 	command::Command::registerActionButton("jump", _jump);
 }
 
@@ -32,11 +34,15 @@ void Movement::shutdown() {
 	command::Command::unregisterActionButton("move_backward");
 	command::Command::unregisterActionButton("move_left");
 	command::Command::unregisterActionButton("move_right");
+	command::Command::unregisterActionButton("move_up");
+	command::Command::unregisterActionButton("move_down");
 	command::Command::unregisterActionButton("jump");
 	_moveLeft.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
 	_moveRight.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
 	_moveForward.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
 	_moveBackward.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
+	_moveUp.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
+	_moveDown.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
 	_jump.handleUp(command::ACTION_BUTTON_ALL_KEYS, 0ul);
 }
 

--- a/src/modules/util/Movement.h
+++ b/src/modules/util/Movement.h
@@ -22,6 +22,8 @@ protected:
 	command::ActionButton _moveRight;
 	command::ActionButton _moveBackward;
 	command::ActionButton _moveForward;
+	command::ActionButton _moveUp;
+	command::ActionButton _moveDown;
 	command::ActionButton _jump;
 
 	glm::vec3 calculateDelta(double speed) const;
@@ -38,6 +40,8 @@ public:
 	bool right() const;
 	bool forward() const;
 	bool backward() const;
+	bool up() const;
+	bool down() const;
 	bool jump() const;
 
 	bool moving() const;
@@ -51,7 +55,7 @@ public:
 };
 
 inline bool Movement::moving() const {
-	return left() || right() || forward() || backward();
+	return left() || right() || forward() || backward() || up() || down();
 }
 
 inline bool Movement::jump() const {
@@ -72,6 +76,14 @@ inline bool Movement::forward() const {
 
 inline bool Movement::backward() const {
 	return _moveBackward.pressed();
+}
+
+inline bool Movement::up() const {
+	return _moveUp.pressed();
+}
+
+inline bool Movement::down() const {
+	return _moveDown.pressed();
 }
 
 } // namespace util

--- a/src/modules/voxelrender/CameraMovement.cpp
+++ b/src/modules/voxelrender/CameraMovement.cpp
@@ -4,6 +4,7 @@
 
 #include "CameraMovement.h"
 #include "app/I18N.h"
+#include "core/GLM.h"
 #include "core/Log.h"
 #include "core/Var.h"
 #include "scenegraph/Physics.h"
@@ -95,6 +96,12 @@ void CameraMovement::update(double nowSeconds, video::Camera *camera, const scen
 		}
 		if (_movement.right()) {
 			direction += camRight;
+		}
+		if (_movement.up()) {
+			direction += glm::up();
+		}
+		if (_movement.down()) {
+			direction += glm::down();
 		}
 
 		if (glm::dot(direction, direction) > 0.0f) {


### PR DESCRIPTION
Adds two new action button commands for vertical camera movement: `+move_up` and `+move_down`. These follow the same pattern as the existing `+move_forward`, `+move_backward`, `+move_left`, `+move_right` commands.