### PR TITLE
VOXEDIT: add camera_mouselook command for FPS-style navigation

### DIFF
--- a/src/tools/voxedit/VoxEdit.cpp
+++ b/src/tools/voxedit/VoxEdit.cpp
@@ -37,7 +37,7 @@ VoxEdit::VoxEdit(const io::FilesystemPtr &filesystem, const core::TimeProviderPt
 	core::registerBindingContext("model", core::BindingContext::Context2);
 	core::registerBindingContext("game", core::BindingContext::Context3);
 	core::registerBindingContext("editing", core::BindingContext::Context1 + core::BindingContext::Context2 + core::BindingContext::Context3);
-	_allowRelativeMouseMode = false;
+	_allowRelativeMouseMode = true;
 	_iniVersion = 11;
 	_keybindingsVersion = 4;
 	_wantCrashLogs = true;
@@ -139,6 +139,13 @@ app::AppState VoxEdit::onConstruct() {
 		.setHandler([this](const command::CommandArgs &args) {
 			toggleScene();
 		}).setHelp(_("Toggle scene mode on/off"));
+
+	command::Command::registerCommand("camera_mouselook")
+		.setHandler([this](const command::CommandArgs &args) {
+			const bool active = !isRelativeMouseMode();
+			setRelativeMouseMode(active);
+			_sceneMgr->setMouseLook(active);
+		}).setHelp(_("Toggle locked mouse look (FPS-style camera rotation)"));
 
 	command::Command::registerCommand("save")
 		.addArg({"file", command::ArgType::String, true, "", "Output file path"})
@@ -564,6 +571,10 @@ app::AppState VoxEdit::onRunning() {
 	app::AppState state = Super::onRunning();
 	if (state != app::AppState::Running) {
 		return state;
+	}
+
+	if (isRelativeMouseMode()) {
+		_sceneMgr->setMouseDelta((int)_mouseRelativePos.x, (int)_mouseRelativePos.y);
 	}
 
 	_collectionMgr->update(_nowSeconds);

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -515,6 +515,14 @@ bool SceneManager::load(const io::FileDescription& file, const uint8_t *data, si
 }
 
 void SceneManager::setMousePos(int x, int y) {
+	if (_mouseLookActive) {
+		// In mouselook mode, delta comes from relative mouse input via setMouseDelta().
+		// Still update the cursor position so ray casting / brush placement works.
+		_mouseCursor.x = x;
+		_mouseCursor.y = y;
+		_traceViaMouse = true;
+		return;
+	}
 	if (_mouseCursor.x == x && _mouseCursor.y == y) {
 		_mouseCursorDelta.x = 0;
 		_mouseCursorDelta.y = 0;
@@ -527,6 +535,30 @@ void SceneManager::setMousePos(int x, int y) {
 	// moving the mouse would trigger mouse tracing again
 	// TODO: maybe only do this if a mouse button was pressed?
 	_traceViaMouse = true;
+}
+
+void SceneManager::setMouseLook(bool active) {
+	_mouseLookActive = active;
+	if (active) {
+		if (_camera != nullptr) {
+			_preMouselookRotationType = _camera->rotationType();
+			_camera->setRotationType(video::CameraRotationType::Eye);
+		}
+	} else {
+		if (_camera != nullptr) {
+			if (_preMouselookRotationType == video::CameraRotationType::Target) {
+				const glm::vec3 newTarget = _camera->worldPosition() + _camera->forward() * _camera->targetDistance();
+				_camera->setTarget(newTarget);
+			}
+			_camera->setRotationType(_preMouselookRotationType);
+		}
+		_mouseCursorDelta = {0, 0};
+	}
+}
+
+void SceneManager::setMouseDelta(int dx, int dy) {
+	_mouseCursorDelta.x = dx;
+	_mouseCursorDelta.y = dy;
 }
 
 glm::mat4 SceneManager::worldMatrix(scenegraph::FrameIndex frameIdx, bool applyTransforms) const {
@@ -3324,6 +3356,8 @@ bool SceneManager::update(double nowSeconds) {
 		_rotate.execute(nowSeconds, 0.0, [&] () {
 			_camMovement.rotate(*_camera, (float)_mouseCursorDelta.x, (float)_mouseCursorDelta.y);
 		});
+	} else if (_mouseLookActive && _camera != nullptr && !_fixedCamera) {
+		_camMovement.rotate(*_camera, (float)_mouseCursorDelta.x, (float)_mouseCursorDelta.y);
 	}
 
 	animateFrames(nowSeconds);

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -135,6 +135,8 @@ protected:
 	int _initialized = 0;
 	glm::ivec2 _mouseCursor{0};
 	glm::ivec2 _mouseCursorDelta{0};
+	bool _mouseLookActive = false;
+	video::CameraRotationType _preMouselookRotationType = video::CameraRotationType::Target;
 
 	command::ActionButton _move[lengthof(DIRECTIONS)];
 	command::ActionButton _rotate;
@@ -297,6 +299,8 @@ public:
 	 * @brief Update the cursor position used for tracing
 	 */
 	void setMousePos(int x, int y);
+	void setMouseLook(bool active);
+	void setMouseDelta(int dx, int dy);
 
 	/**
 	 * @brief world matrix for the current active node


### PR DESCRIPTION
## Summary

- Adds a bindable `camera_mouselook` command that toggles FPS-style locked mouse look
- Captures the mouse so movement rotates the camera directly without holding a button
- Switches to Eye rotation mode while active so rotation pivots from the camera position
- Restores the previous rotation mode and updates the orbit target on exit so the camera stays in place
- Brush placement and ray casting continue to work while active

## Test plan

- [ ] Bind a key to `camera_mouselook` and toggle it on/off
- [ ] Camera rotates from eye position, not around a distant target
- [ ] Camera stays in same position when toggling off
- [ ] Brush/voxel selection works while mouselook is active

No automated unit tests added — the feature depends on SDL relative mouse mode and camera input handling which require a running window to test meaningfully.