### PR TITLE
VOXEDIT: add configurable selection tint color for selected voxels

### DIFF
--- a/src/modules/core/ConfigVar.h
+++ b/src/modules/core/ConfigVar.h
@@ -52,6 +52,7 @@ constexpr const char *ClientDebugShadow = "cl_debug_shadow";
 constexpr const char *RenderCullBuffers = "r_cullbuffers";
 constexpr const char *RenderCullNodes = "r_cullnodes";
 constexpr const char *RenderOutline = "r_renderoutline";
+constexpr const char *RenderSelectionTint = "r_selectiontint";
 constexpr const char *RenderNormals = "r_normals";
 constexpr const char *ToneMapping = "r_tonemapping";
 constexpr const char *RenderCheckerBoard = "r_checkerboard";

--- a/src/modules/core/Var.cpp
+++ b/src/modules/core/Var.cpp
@@ -166,6 +166,25 @@ void Var::vec3Val(float out[3]) const {
 	out[2] = z;
 }
 
+void Var::vec4Val(float out[4]) const {
+	float x, y, z, w;
+#ifdef _MSC_VER
+	if (::sscanf_s(strVal().c_str(), "%f:%f:%f:%f", &x, &y, &z, &w) != 4) {
+		if (::sscanf_s(strVal().c_str(), "%f %f %f %f", &x, &y, &z, &w) != 4) {
+#else
+	if (::sscanf(strVal().c_str(), "%f:%f:%f:%f", &x, &y, &z, &w) != 4) {
+		if (::sscanf(strVal().c_str(), "%f %f %f %f", &x, &y, &z, &w) != 4) {
+#endif
+			out[0] = out[1] = out[2] = out[3] = 0.0f;
+			return;
+		}
+	}
+	out[0] = x;
+	out[1] = y;
+	out[2] = z;
+	out[3] = w;
+}
+
 VarPtr Var::findVar(const core::String& name) {
 	ScopedLock lock(_lock);
 	VarMap::iterator i = _vars.find(name);

--- a/src/modules/core/Var.h
+++ b/src/modules/core/Var.h
@@ -279,6 +279,7 @@ public:
 	bool boolVal() const;
 	void toggleBool();
 	void vec3Val(float out[3]) const;
+	void vec4Val(float out[4]) const;
 	/**
 	 * @return @c true if the value was set, @c false otherwise
 	 */

--- a/src/modules/ui/IMGUIEx.cpp
+++ b/src/modules/ui/IMGUIEx.cpp
@@ -590,6 +590,20 @@ bool ColorEdit3Var(const char *varName) {
 	return false;
 }
 
+bool ColorEdit4Var(const char *varName) {
+	glm::vec4 col;
+	const core::VarPtr &var = core::getVar(varName);
+	const core::String label = _priv::varLabel(var);
+	var->vec4Val(&col[0]);
+	if (ImGui::ColorEdit4(label.c_str(), glm::value_ptr(col))) {
+		const core::String &c = core::String::format("%f %f %f %f", col.x, col.y, col.z, col.w);
+		var->setVal(c);
+		return true;
+	}
+	_priv::varTooltip(var);
+	return false;
+}
+
 float CalcTextWidth(const char *label, bool withPadding) {
 	const float w = ImGui::CalcTextSize(label).x;
 	if (!withPadding) {

--- a/src/modules/ui/IMGUIEx.h
+++ b/src/modules/ui/IMGUIEx.h
@@ -76,6 +76,7 @@ IMGUI_API bool SliderVarFloat(const core::VarPtr &var,
 IMGUI_API bool SliderVarFloat(const char *varName,
 							  const char *format = "%.3f", ImGuiSliderFlags flags = 0);
 IMGUI_API bool ColorEdit3Var(const char *varName);
+IMGUI_API bool ColorEdit4Var(const char *varName);
 IMGUI_API bool InputVec3Var(const char *varName);
 IMGUI_API bool InputFileVar(const char *varName, const io::FormatDescription *descriptions, ImGuiInputTextFlags flags = 0u, const video::FileDialogOptions &options = {});
 IMGUI_API bool InputFileVar(const core::VarPtr &var, const io::FormatDescription *descriptions, ImGuiInputTextFlags flags = 0u, const video::FileDialogOptions &options = {});

--- a/src/modules/video/WindowedApp.cpp
+++ b/src/modules/video/WindowedApp.cpp
@@ -571,6 +571,8 @@ app::AppState WindowedApp::onConstruct() {
 	core::Var::registerVar(clientOpenGLVersion);
 	const core::VarDef renderOutline(cfg::RenderOutline, false, N_("Outlines"), _("Render voxel outline"), core::CV_SHADER);
 	core::Var::registerVar(renderOutline);
+	const core::VarDef renderSelectionTint(cfg::RenderSelectionTint, "0 1 0 0.4", N_("Selection tint"), _("Color tint applied to selected voxels (RGBA)"));
+	core::Var::registerVar(renderSelectionTint);
 	const core::VarDef renderNormals(cfg::RenderNormals, false, N_("Normals"), _("Render voxel normals"), core::CV_SHADER);
 	core::Var::registerVar(renderNormals);
 	const core::VarDef toneMapping(cfg::ToneMapping, 0, 0, 3, N_("Tone mapping"), _("Activate tone mapping"), core::CV_SHADER);

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -128,6 +128,7 @@ bool RawVolumeRenderer::init(bool normals) {
 	_bloom = core::getVar(cfg::ClientBloom);
 	_cullBuffers = core::getVar(cfg::RenderCullBuffers);
 	_cullNodes = core::getVar(cfg::RenderCullNodes);
+	_selectionTint = core::getVar(cfg::RenderSelectionTint);
 
 	if (!_voxelShader.setup()) {
 		Log::error("Failed to initialize the voxel shader");
@@ -852,6 +853,11 @@ void RawVolumeRenderer::render(const voxel::MeshStatePtr &meshState, RenderConte
 		_voxelShaderFragData.distances[i] = _shadow.distances()[i];
 	}
 	_voxelShaderFragData.lightdir = _shadow.sunDirection();
+	{
+		float t[4];
+		_selectionTint->vec4Val(t);
+		_voxelShaderFragData.selectiontint = glm::vec4(t[0], t[1], t[2], t[3]);
+	}
 	core_assert_always(_voxelData.update(_voxelShaderFragData));
 
 	const voxel::SurfaceExtractionType meshMode = meshState->meshMode();

--- a/src/modules/voxelrender/RawVolumeRenderer.h
+++ b/src/modules/voxelrender/RawVolumeRenderer.h
@@ -67,6 +67,7 @@ protected:
 	core::VarPtr _bloom;
 	core::VarPtr _cullBuffers;
 	core::VarPtr _cullNodes;
+	core::VarPtr _selectionTint;
 
 	void updatePalette(const voxel::MeshStatePtr &meshState, int idx);
 	enum UpdateBufferFlags : uint8_t {

--- a/src/modules/voxelrender/shaders/_sharedfrag.glsl
+++ b/src/modules/voxelrender/shaders/_sharedfrag.glsl
@@ -6,6 +6,7 @@ layout(std140) uniform u_frag {
 	vec2 u_depthsize;
 	vec4 u_distances;
 	mat4 u_cascades[4];
+	vec4 u_selectiontint;
 };
 
 layout(location = 0) $out vec4 o_color;
@@ -173,6 +174,8 @@ vec4 brighten(vec4 color) {
 
 // pos is in object space
 vec4 outline(vec3 pos, vec4 color, vec3 normal) {
+	// Apply selection tint over the full face
+	color.rgb = mix(color.rgb, u_selectiontint.rgb, u_selectiontint.a);
 #if 0
 	vec3 f = fract(pos);
 	float edge;

--- a/src/tools/voxedit/modules/voxedit-ui/OptionsPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/OptionsPanel.cpp
@@ -63,9 +63,10 @@ bool OptionsPanel::categoryHasMatch(OptionCategory category) const {
 			   matchesVarFilter(cfg::VoxEditShowBones) || matchesVarFilter(cfg::VoxEditShowPlane) ||
 			   matchesVarFilter(cfg::VoxEditPlaneSize);
 	case OptionCategory::Rendering:
-		return matchesVarFilter(cfg::RenderOutline) || matchesVarFilter(cfg::RenderNormals) ||
-			   matchesVarFilter(cfg::RenderCheckerBoard) || matchesVarFilter(cfg::VoxEditShadingMode) ||
-			   matchesVarFilter(cfg::ClientBloom) || matchesVarFilter(cfg::ToneMapping);
+		return matchesVarFilter(cfg::RenderOutline) || matchesVarFilter(cfg::RenderSelectionTint) ||
+			   matchesVarFilter(cfg::RenderNormals) || matchesVarFilter(cfg::RenderCheckerBoard) ||
+			   matchesVarFilter(cfg::VoxEditShadingMode) || matchesVarFilter(cfg::ClientBloom) ||
+			   matchesVarFilter(cfg::ToneMapping);
 	case OptionCategory::Renderer:
 		return matchesVarFilter(cfg::ClientShadowMapSize) || matchesVarFilter(cfg::ClientGamma) ||
 			   matchesVarFilter(cfg::ClientVSync);
@@ -215,6 +216,9 @@ void OptionsPanel::renderRendering() {
 	ImGui::BeginDisabled(isMarchingCubes);
 	if (matchesVarFilter(cfg::RenderOutline)) {
 		ImGui::IconCheckboxVar(ICON_LC_BOX, cfg::RenderOutline);
+	}
+	if (matchesVarFilter(cfg::RenderSelectionTint)) {
+		ImGui::ColorEdit4Var(cfg::RenderSelectionTint);
 	}
 	if (matchesVarFilter(cfg::RenderNormals)) {
 		if (viewModeNormalPalette(core::getVar(cfg::VoxEditViewMode)->intVal())) {


### PR DESCRIPTION
  Problem                                                                                                                                                                               
                                                                                                                                                                                        
  Selected voxels were only indicated by a subtle edge darkening/brightening effect (the existing outline() shader function). On gray or similarly-colored models this was nearly       
  invisible.                                                                                                                                                                            
                                                                                                                                                                                        
  Solution                                                                                                                                                                              
                                                                                                                                                                                        
  Selected voxels now receive a full-face color tint (default: green at 40% blend) on top of the existing edge outline, making selections clearly visible regardless of model color.    
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - Shader (_sharedfrag.glsl): Added vec4 u_selectiontint to the u_frag UBO. The outline() function now mixes the voxel face color with the tint before applying the edge effect.       
  - Config var (r_selectiontint): Persisted RGBA string cvar, default "0 1 0 0.4" (green, 40% blend). Registered in WindowedApp alongside the other render cvars.                       
  - RawVolumeRenderer: Reads the cvar each frame and uploads it to the shader via the FragData UBO.                                                                                     
  - Var: Added vec4Val() for parsing 4-component float strings (mirrors existing vec3Val()).                                                                                            
  - IMGUIEx: Added ColorEdit4Var() RGBA color picker widget (mirrors existing ColorEdit3Var()).                                                                                         
  - Options panel: Added the tint color picker under Options → Rendering, searchable, alongside the existing outline toggle.                                                            
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - Select voxels on a gray model — tint should be clearly visible                                                                                                                      
  - Open Options → Rendering → change Selection tint color and alpha — updates live
  - Set alpha to 0 — reverts to original edge-only outline behavior
  - Restart editor — color setting is persisted

No automated unit tests added — the feature depends on SDL relative mouse mode and camera input handling which require a running window to test meaningfully.