### PR TITLE
VOXEDIT: add Box3D select mode with bounds UI

### DIFF
--- a/src/modules/scenegraph/SceneGraphNode.cpp
+++ b/src/modules/scenegraph/SceneGraphNode.cpp
@@ -475,6 +475,15 @@ void SceneGraphNode::clearSelection() {
 		return;
 	}
 	_volume->removeFlags(_volume->region(), voxel::FlagOutline);
+	_selectionRegion = voxel::Region::InvalidRegion;
+}
+
+const voxel::Region &SceneGraphNode::selectionRegion() const {
+	return _selectionRegion;
+}
+
+void SceneGraphNode::setSelectionRegion(const voxel::Region &region) {
+	_selectionRegion = region;
 }
 
 void SceneGraphNode::select(const voxel::Region &region) {

--- a/src/modules/scenegraph/SceneGraphNode.h
+++ b/src/modules/scenegraph/SceneGraphNode.h
@@ -106,6 +106,7 @@ protected:
 	mutable core::Optional<palette::Palette> _palette;
 	mutable core::Optional<palette::NormalPalette> _normalPalette;
 	core::Optional<IKConstraint> _ikConstraint;
+	voxel::Region _selectionRegion = voxel::Region::InvalidRegion;
 
 	/**
 	 * @brief Called in emplace() if a parent id is given
@@ -247,6 +248,8 @@ public:
 	void clearSelection();
 	void select(const voxel::Region &region);
 	void unselect(const voxel::Region &region);
+	const voxel::Region &selectionRegion() const;
+	void setSelectionRegion(const voxel::Region &region);
 
 	const SceneGraphNodeChildren &children() const;
 	const SceneGraphNodeProperties &properties() const;

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -28,6 +28,7 @@
 #include "voxedit-util/modifier/brush/StampBrush.h"
 #include "voxedit-util/modifier/brush/TextureBrush.h"
 #include "voxel/RawVolume.h"
+#include "voxel/Region.h"
 #include "voxel/Voxel.h"
 
 #include <glm/common.hpp>
@@ -244,7 +245,8 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 	int selectModeInt = (int)brush.selectMode();
 
 	const char *SelectModeStr[] = {C_("SelectMode", "All"), C_("SelectMode", "Surface"), C_("SelectMode", "Same Color"),
-								   C_("SelectMode", "Fuzzy Color"), C_("SelectMode", "Connected")};
+								   C_("SelectMode", "Fuzzy Color"), C_("SelectMode", "Connected"),
+								   C_("SelectMode", "3D Box")};
 	static_assert(lengthof(SelectModeStr) == (int)SelectMode::Max, "Array size mismatch");
 
 	if (ImGui::Combo(_("Select mode"), &selectModeInt, SelectModeStr, (int)SelectMode::Max)) {
@@ -257,6 +259,72 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 			brush.setColorThreshold(threshold);
 		}
 		ImGui::TooltipTextUnformatted(_("Color distance threshold for fuzzy matching (0 = exact, higher = more similar colors)"));
+	}
+
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	const scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	if (node && node->hasSelection()) {
+		voxel::Region sel = _sceneMgr->selectionCalculateRegion(nodeId);
+		if (sel.isValid()) {
+			ImGui::SeparatorText(_("Selection bounds"));
+			const voxel::Region &vol = node->region();
+			const glm::ivec3 &vMins = vol.getLowerCorner();
+			const glm::ivec3 &vMaxs = vol.getUpperCorner();
+			glm::ivec3 mins = sel.getLowerCorner();
+			glm::ivec3 maxs = sel.getUpperCorner();
+			bool changed = false;
+
+			// Slider with -/+ buttons for fine single-step adjustment
+			auto selSlider = [&changed](const char *id, int *val, int lo, int hi) {
+				ImGui::PushID(id);
+				const float btnW = ImGui::GetFrameHeight();
+				const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+				if (ImGui::Button("-", ImVec2(btnW, 0))) {
+					*val = glm::max(*val - 1, lo);
+					changed = true;
+				}
+				ImGui::SameLine(0, spacing);
+				ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+				changed |= ImGui::SliderInt("", val, lo, hi);
+				ImGui::SameLine(0, spacing);
+				if (ImGui::Button("+", ImVec2(btnW, 0))) {
+					*val = glm::min(*val + 1, hi);
+					changed = true;
+				}
+				ImGui::PopID();
+			};
+
+			if (ImGui::BeginTable("##selbounds", 3, ImGuiTableFlags_SizingStretchProp)) {
+				ImGui::TableSetupColumn("##axis", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableSetupColumn(_("Min"));
+				ImGui::TableSetupColumn(_("Max"));
+				ImGui::TableHeadersRow();
+
+				ImGui::TableNextColumn(); ImGui::AxisButtonX(ImVec2(ImGui::GetFrameHeight(), 0));
+				ImGui::TableNextColumn(); selSlider("##minx", &mins.x, vMins.x, vMaxs.x);
+				ImGui::TableNextColumn(); selSlider("##maxx", &maxs.x, vMins.x, vMaxs.x);
+
+				ImGui::TableNextColumn(); ImGui::AxisButtonY(ImVec2(ImGui::GetFrameHeight(), 0));
+				ImGui::TableNextColumn(); selSlider("##miny", &mins.y, vMins.y, vMaxs.y);
+				ImGui::TableNextColumn(); selSlider("##maxy", &maxs.y, vMins.y, vMaxs.y);
+
+				ImGui::TableNextColumn(); ImGui::AxisButtonZ(ImVec2(ImGui::GetFrameHeight(), 0));
+				ImGui::TableNextColumn(); selSlider("##minz", &mins.z, vMins.z, vMaxs.z);
+				ImGui::TableNextColumn(); selSlider("##maxz", &maxs.z, vMins.z, vMaxs.z);
+
+				ImGui::EndTable();
+			}
+
+			if (changed) {
+				// ensure min <= max after independent dragging
+				const glm::ivec3 newMins = glm::min(mins, maxs);
+				const glm::ivec3 newMaxs = glm::max(mins, maxs);
+				_sceneMgr->selectionSetBounds(nodeId, voxel::Region(newMins, newMaxs));
+			}
+
+			const glm::ivec3 size = sel.getDimensionsInVoxels();
+			ImGui::Text(_("Size: %d x %d x %d"), size.x, size.y, size.z);
+		}
 	}
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/ISceneRenderer.h
+++ b/src/tools/voxedit/modules/voxedit-util/ISceneRenderer.h
@@ -71,6 +71,8 @@ public:
 	virtual bool isSliceModeActive() const {
 		return sliceRegion().isValid();
 	}
+	virtual void updateSelectionGizmo(const voxel::Region &region) {
+	}
 	virtual RendererStats rendererStats() const {
 		return {};
 	}

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -580,6 +580,13 @@ void SceneManager::modified(int nodeId, const voxel::Region& modifiedRegion, Sce
 		Log::debug("Modify region for nodeid %i", nodeId);
 		_sceneRenderer->updateNodeRegion(nodeId, modifiedRegion, renderRegionMillis);
 	}
+	if (_selectionCacheNodeId == nodeId) {
+		_selectionCacheNodeId = -1;
+		if (_modifierFacade.brushType() == BrushType::Select &&
+			_modifierFacade.selectBrush().selectMode() == SelectMode::Box3D) {
+			_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(nodeId));
+		}
+	}
 	markDirty();
 	const bool resetTrace = (flags & SceneModifiedFlags::ResetTrace) == SceneModifiedFlags::ResetTrace;
 	if (resetTrace) {
@@ -1364,6 +1371,7 @@ void SceneManager::selectionInvert(int nodeId) {
 	volume->toggleFlags(volume->region(), voxel::FlagOutline);
 	// Mark mesh dirty to trigger re-extraction with updated FlagOutline
 	modified(nodeId, node->region(), SceneModifiedFlags::NoUndo);
+	_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(nodeId));
 }
 
 void SceneManager::selectionUnselect(int nodeId) {
@@ -1371,9 +1379,12 @@ void SceneManager::selectionUnselect(int nodeId) {
 	if (node == nullptr) {
 		return;
 	}
+	// Only re-extract where voxels actually had FlagOutline set
+	const voxel::Region dirtyRegion = selectionCalculateRegion(nodeId);
 	node->clearSelection();
-	// Mark mesh dirty to trigger re-extraction with updated FlagOutline
-	modified(nodeId, node->region(), SceneModifiedFlags::NoUndo);
+	_selectionCacheNodeId = -1;
+	modified(nodeId, dirtyRegion.isValid() ? dirtyRegion : node->region(), SceneModifiedFlags::NoUndo);
+	_sceneRenderer->updateSelectionGizmo(voxel::Region::InvalidRegion);
 }
 
 void SceneManager::selectionSelectAll(int nodeId) {
@@ -1388,6 +1399,7 @@ void SceneManager::selectionSelectAll(int nodeId) {
 	node->select(volume->region());
 	// Mark mesh dirty to trigger re-extraction with updated FlagOutline
 	modified(nodeId, node->region(), SceneModifiedFlags::NoUndo);
+	_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(nodeId));
 }
 
 bool SceneManager::isSelected(int nodeId, const glm::ivec3 &pos) const {
@@ -1404,6 +1416,9 @@ bool SceneManager::isSelected(int nodeId, const glm::ivec3 &pos) const {
 }
 
 voxel::Region SceneManager::selectionCalculateRegion(int nodeId) const {
+	if (_selectionCacheNodeId == nodeId) {
+		return _selectionRegionCache;
+	}
 	const scenegraph::SceneGraphNode *node = sceneGraphNode(nodeId);
 	if (node == nullptr || !node->isModelNode()) {
 		return voxel::Region::InvalidRegion;
@@ -1413,6 +1428,8 @@ voxel::Region SceneManager::selectionCalculateRegion(int nodeId) const {
 		return voxel::Region::InvalidRegion;
 	}
 	if (!node->hasSelection()) {
+		_selectionCacheNodeId = nodeId;
+		_selectionRegionCache = voxel::Region::InvalidRegion;
 		return voxel::Region::InvalidRegion;
 	}
 
@@ -1436,7 +1453,44 @@ voxel::Region SceneManager::selectionCalculateRegion(int nodeId) const {
 			}
 		}
 	}
+	_selectionCacheNodeId = nodeId;
+	_selectionRegionCache = selectionRegion;
 	return selectionRegion;
+}
+
+void SceneManager::selectionSetBounds(int nodeId, const voxel::Region &region) {
+	scenegraph::SceneGraphNode *node = sceneGraphModelNode(nodeId);
+	if (node == nullptr) {
+		return;
+	}
+	const voxel::Region &vol = node->region();
+	const voxel::Region clamped(glm::max(region.getLowerCorner(), vol.getLowerCorner()),
+								glm::min(region.getUpperCorner(), vol.getUpperCorner()));
+	if (!clamped.isValid()) {
+		return;
+	}
+	// Only re-extract the union of old + new selection: those are the only voxels
+	// whose FlagOutline bit changes. Everything outside is unchanged, so no mesh
+	// re-extraction is needed there.
+	voxel::Region dirtyRegion = clamped;
+	const voxel::Region oldRegion = selectionCalculateRegion(nodeId);
+	if (oldRegion.isValid()) {
+		dirtyRegion.accumulate(oldRegion);
+	}
+	node->clearSelection();
+	node->select(clamped);
+	if (_modifierFacade.selectBrush().selectMode() == SelectMode::Box3D) {
+		node->setSelectionRegion(clamped);
+	}
+	// Pre-clear the cache so modified() doesn't trigger an expensive re-scan
+	_selectionCacheNodeId = -1;
+	modified(nodeId, dirtyRegion, SceneModifiedFlags::NoUndo);
+	// Populate cache directly since we know the exact new selection
+	_selectionCacheNodeId = nodeId;
+	_selectionRegionCache = clamped;
+	if (_modifierFacade.selectBrush().selectMode() == SelectMode::Box3D) {
+		_sceneRenderer->updateSelectionGizmo(clamped);
+	}
 }
 
 void SceneManager::resetLastTrace() {
@@ -3422,6 +3476,20 @@ bool SceneManager::update(double nowSeconds) {
 	// TODO: Set to InvalidFrameIndex if transforms should not get applied
 	_camMovement.update(_nowSeconds, camera, _sceneGraph, frameIdx);
 	_modifierFacade.update(nowSeconds, camera);
+
+	// Show selection gizmo only in Select/Box3D mode; hide it otherwise
+	const BrushType currentBrushType = _modifierFacade.brushType();
+	const SelectMode currentSelectMode = _modifierFacade.selectBrush().selectMode();
+	if (currentBrushType != _lastBrushType || currentSelectMode != _lastSelectMode) {
+		_lastBrushType = currentBrushType;
+		_lastSelectMode = currentSelectMode;
+		const int activeNodeId = _sceneGraph.activeNode();
+		if (currentBrushType == BrushType::Select && currentSelectMode == SelectMode::Box3D) {
+			_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(activeNodeId));
+		} else {
+			_sceneRenderer->updateSelectionGizmo(voxel::Region::InvalidRegion);
+		}
+	}
 
 	updateDirtyRendererStates();
 

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -104,6 +104,11 @@ protected:
 	// this is basically the same as the dirty state, but we stop
 	// auto-saving once we saved a dirty state
 	bool _needAutoSave = false;
+
+	mutable voxel::Region _selectionRegionCache = voxel::Region::InvalidRegion;
+	mutable int _selectionCacheNodeId = -1;
+	BrushType _lastBrushType = BrushType::Max;
+	SelectMode _lastSelectMode = SelectMode::Max;
 	bool _traceViaMouse = true;
 
 	voxelgenerator::lsystem::LSystemConfig _lsystemConfig;
@@ -387,6 +392,7 @@ public:
 	void selectionInvert(int nodeId);
 	void selectionUnselect(int nodeId);
 	void selectionSelectAll(int nodeId);
+	void selectionSetBounds(int nodeId, const voxel::Region &region);
 	bool isSelected(int nodeId, const glm::ivec3 &pos) const;
 	voxel::Region selectionCalculateRegion(int nodeId) const;
 

--- a/src/tools/voxedit/modules/voxedit-util/SceneRenderer.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneRenderer.cpp
@@ -19,6 +19,10 @@
 #include "voxel/RawVolume.h"
 #include "voxelrender/RawVolumeRenderer.h"
 #include "voxelrender/SceneGraphRenderer.h"
+#ifndef GLM_ENABLE_EXPERIMENTAL
+#define GLM_ENABLE_EXPERIMENTAL
+#endif
+#include <glm/gtx/transform.hpp>
 
 namespace voxedit {
 
@@ -110,6 +114,7 @@ void SceneRenderer::shutdown() {
 	_aabbMeshIndex = -1;
 	_boneMeshIndex = -1;
 	_highlightMeshIndex = -1;
+	_selectionGizmoMeshIndex = -1;
 }
 
 void SceneRenderer::updateGridRegion(const voxel::Region &region) {
@@ -341,6 +346,14 @@ void SceneRenderer::updateSliceRegionMesh() {
 	_shapeRenderer.createOrUpdate(_sliceRegionMeshIndex, _shapeBuilder);
 }
 
+void SceneRenderer::updateSelectionGizmo(const voxel::Region &region) {
+	_selectionGizmoRegion = region;
+	if (!region.isValid() && _selectionGizmoMeshIndex != -1) {
+		_shapeRenderer.deleteMesh(_selectionGizmoMeshIndex);
+		_selectionGizmoMeshIndex = -1;
+	}
+}
+
 void SceneRenderer::renderScene(voxelrender::RenderContext &renderContext, const video::Camera &camera) {
 	core_trace_scoped(RenderScene);
 	if (renderContext.sceneGraph == nullptr) {
@@ -399,6 +412,45 @@ void SceneRenderer::renderUI(voxelrender::RenderContext &renderContext, const vi
 
 		if (isSliceModeActive()) {
 			_shapeRenderer.render(_sliceRegionMeshIndex, camera, model);
+		}
+
+		if (_selectionGizmoRegion.isValid()) {
+			// Pick the AABB corner closest to the camera so the gizmo is always visible
+			const glm::ivec3 lo = _selectionGizmoRegion.getLowerCorner();
+			const glm::ivec3 hi = _selectionGizmoRegion.getUpperCorner() + 1;
+			const glm::vec3 corners[8] = {
+				{(float)lo.x, (float)lo.y, (float)lo.z}, {(float)hi.x, (float)lo.y, (float)lo.z},
+				{(float)lo.x, (float)hi.y, (float)lo.z}, {(float)hi.x, (float)hi.y, (float)lo.z},
+				{(float)lo.x, (float)lo.y, (float)hi.z}, {(float)hi.x, (float)lo.y, (float)hi.z},
+				{(float)lo.x, (float)hi.y, (float)hi.z}, {(float)hi.x, (float)hi.y, (float)hi.z},
+			};
+			const glm::vec3 camPos = camera.worldPosition();
+			float minDist = 1e30f;
+			int closestIdx = 0;
+			for (int i = 0; i < 8; ++i) {
+				const glm::vec3 worldCorner = glm::vec3(model * glm::vec4(corners[i], 1.0f));
+				const float dist = glm::distance(camPos, worldCorner);
+				if (dist < minDist) {
+					minDist = dist;
+					closestIdx = i;
+				}
+			}
+			const glm::vec3 &bestCorner = corners[closestIdx];
+			const glm::vec3 center = (glm::vec3(lo) + glm::vec3(hi)) * 0.5f;
+			// Arrow signs: point away from selection center at this corner.
+			// X and Y use glm::right()={1,0,0} and glm::up()={0,1,0}, sign matches.
+			// Z uses glm::forward()={0,0,-1}, so negate the Z sign to point outward.
+			const glm::vec3 signVec(
+				bestCorner.x >= center.x ? 1.0f : -1.0f,
+				bestCorner.y >= center.y ? 1.0f : -1.0f,
+				bestCorner.z >= center.z ? -1.0f : 1.0f
+			);
+			const glm::ivec3 dims = _selectionGizmoRegion.getDimensionsInVoxels();
+			const float scale = (float)glm::max(5, glm::max(dims.x, glm::max(dims.y, dims.z)) / 4);
+			_shapeBuilder.clear();
+			_shapeBuilder.axis(signVec * scale);
+			_shapeRenderer.createOrUpdate(_selectionGizmoMeshIndex, _shapeBuilder);
+			_shapeRenderer.render(_selectionGizmoMeshIndex, camera, glm::translate(model, bestCorner));
 		}
 
 		const core::TimeProviderPtr &timeProvider = app::App::getInstance()->timeProvider();

--- a/src/tools/voxedit/modules/voxedit-util/SceneRenderer.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneRenderer.h
@@ -52,6 +52,8 @@ private:
 	int32_t _aabbMeshIndex = -1;
 	int32_t _boneMeshIndex = -1;
 	int32_t _sliceRegionMeshIndex = -1;
+	int32_t _selectionGizmoMeshIndex = -1;
+	voxel::Region _selectionGizmoRegion = voxel::Region::InvalidRegion;
 
 	using TimedRegion = core::TimedValue<voxel::Region>;
 	TimedRegion _highlightRegion;
@@ -85,6 +87,7 @@ public:
 	const voxel::Region &sliceRegion() const override;
 	void setSliceRegion(const voxel::Region &region) override;
 	bool isSliceModeActive() const override;
+	void updateSelectionGizmo(const voxel::Region &region) override;
 	RendererStats rendererStats() const override;
 };
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ModifierVolumeWrapper.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ModifierVolumeWrapper.h
@@ -29,10 +29,15 @@ private:
 	bool _paint;
 	bool _normalPaint;
 	bool _hasSelection;
+	voxel::Region _selectionRegion;
 
 	// if we have a selection, we only handle voxels inside the selection
 	bool skip(const glm::aligned_ivec4 &pos) const {
 		if (!_hasSelection) {
+			return false;
+		}
+		// Box3D region: allow editing anywhere inside the region (including air positions)
+		if (_selectionRegion.isValid() && _selectionRegion.containsPoint(pos)) {
 			return false;
 		}
 		// Check if the voxel has the FlagOutline (selected) flag set
@@ -102,6 +107,7 @@ public:
 		_paint = _modifierType == ModifierType::Paint;
 		_normalPaint = _modifierType == ModifierType::NormalPaint;
 		_hasSelection = _node.hasSelection();
+		_selectionRegion = _node.selectionRegion();
 	}
 	scenegraph::SceneGraphNode &node() const {
 		return _node;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
@@ -26,6 +26,9 @@ void SelectBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWra
 		selectionRegion.cropTo(ctx.targetVolumeRegion);
 	}
 
+	// Clear box region by default; Box3D case sets it below
+	wrapper.node().setSelectionRegion(voxel::Region::InvalidRegion);
+
 	auto func = [&wrapper](int x, int y, int z, const voxel::Voxel &voxel) {
 		if (wrapper.modifierType() == ModifierType::Erase) {
 			wrapper.removeFlagAt(x, y, z, voxel::FlagOutline);
@@ -75,6 +78,19 @@ void SelectBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWra
 			wrapper.setFlagAt(startPos.x, startPos.y, startPos.z, voxel::FlagOutline);
 		}
 		voxelutil::visitConnectedByCondition(wrapper, startPos, func);
+		break;
+	}
+	case SelectMode::Box3D: {
+		wrapper.removeFlags(wrapper.region(), voxel::FlagOutline);
+		voxelutil::VisitSolid condition;
+		voxelutil::visitVolumeParallel(wrapper, selectionRegion, func, condition);
+		// Store the exact box region so ModifierVolumeWrapper::skip() allows
+		// editing any position inside the box (including air voxels)
+		if (wrapper.modifierType() == ModifierType::Erase) {
+			wrapper.node().setSelectionRegion(voxel::Region::InvalidRegion);
+		} else {
+			wrapper.node().setSelectionRegion(selectionRegion);
+		}
 		break;
 	}
 	case SelectMode::Max:

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
@@ -27,6 +27,8 @@ enum class SelectMode : uint8_t {
 	FuzzyColor,
 	/** Select voxels connected to the clicked voxel with the same color (flood fill) */
 	Connected,
+	/** Replace the current selection with all solid voxels in the drawn 3D box region */
+	Box3D,
 
 	Max
 };


### PR DESCRIPTION
  Summary         
                                                                                                                                                                                        
  - New Box3D select mode: drag a 3D box with the select brush to mark all solid voxels inside the region. 
  - Selection bounds panel: when a 3dBoxSelect is active, the brush panel shows per-axis min/max sliders with −/+ fine-adjustment buttons and axis-colored labels (red/green/blue background, consistent with existing UI style).
  - Axis gizmo: a three-arrow XYZ gizmo is rendered at the AABB corner closest to the camera while in Box3D select mode, giving spatial orientation feedback.
  - Air-position editing fix: the selected box region is stored on SceneGraphNode so ModifierVolumeWrapper::skip() allows placing voxels at any position inside the box — including air positions — not just where solid voxels already existed.
  - Performance: selection region is cached per node; slider adjustments only re-extract the union of the old and new selection regions rather than the full volume.

  Test plan

  - Select "Select" mode from main menu
  - Draw a Box3D selection over part of a model; confirm only solid voxels in the box are highlighted
  - Adjust min/max sliders and −/+ buttons; confirm selection updates immediately with no visible lag
  - Place voxels inside a Box3D selection; confirm multiple voxels can be stacked in empty space within the box
  - Switch away from Select brush; confirm gizmo disappears
  - Switch to a non-Box3D select mode (All, Surface, etc.); confirm gizmo does not appear and bounds panel is shown only when a selection exists
  - Use copy/cut within a Box3D selection; confirm all selected solid voxels are captured

No automated unit tests added.