### PR TITLE
VOXEDIT: add visual masking - gray non-selected voxels

### DIFF
--- a/src/modules/voxel/MeshState.cpp
+++ b/src/modules/voxel/MeshState.cpp
@@ -456,4 +456,18 @@ void MeshState::gray(int idx, bool gray) {
 	_volumeData[idx]._gray = gray;
 }
 
+bool MeshState::hasSelection(int idx) const {
+	if (idx < 0 || idx >= MAX_VOLUMES) {
+		return false;
+	}
+	return _volumeData[idx]._hasSelection;
+}
+
+void MeshState::setHasSelection(int idx, bool hasSelection) {
+	if (idx < 0 || idx >= MAX_VOLUMES) {
+		return;
+	}
+	_volumeData[idx]._hasSelection = hasSelection;
+}
+
 } // namespace voxel

--- a/src/modules/voxel/MeshState.h
+++ b/src/modules/voxel/MeshState.h
@@ -48,6 +48,7 @@ private:
 		core::Optional<palette::NormalPalette> _normalPalette;
 		bool _hidden = false;
 		bool _gray = false;
+		bool _hasSelection = false;
 		// if all axes scale positive: cull the back face
 		// if one or three axes are negative, then cull the front face
 		video::Face _cullFace = video::Face::Back;
@@ -193,6 +194,8 @@ public:
 	bool hidden(int idx) const;
 	void gray(int idx, bool gray);
 	bool grayed(int idx) const;
+	void setHasSelection(int idx, bool hasSelection);
+	bool hasSelection(int idx) const;
 
 	// for scaling on 1 or 3 axes negative we need to flip the face culling
 	video::Face cullFace(int idx) const;

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -624,6 +624,7 @@ void RawVolumeRenderer::renderOpaque(const voxel::MeshStatePtr &meshState, const
 		_voxelShaderVertData.viewprojection = camera.viewProjectionMatrix();
 		_voxelShaderVertData.model = meshState->model(idx);
 		_voxelShaderVertData.gray = meshState->grayed(idx);
+		_voxelShaderVertData.hasSelection = meshState->hasSelection(idx);
 		core_assert_always(_voxelData.update(_voxelShaderVertData));
 
 		video::cullFace(meshState->cullFace(idx));
@@ -690,6 +691,7 @@ void RawVolumeRenderer::renderTransparency(const voxel::MeshStatePtr &meshState,
 		updatePalette(meshState, idx);
 		_voxelShaderVertData.model = meshState->model(idx);
 		_voxelShaderVertData.gray = meshState->grayed(idx);
+		_voxelShaderVertData.hasSelection = meshState->hasSelection(idx);
 		core_assert_always(_voxelData.update(_voxelShaderVertData));
 
 		video::ScopedFaceCull scopedFaceCull(meshState->cullFace(idx));

--- a/src/modules/voxelrender/SceneGraphRenderer.cpp
+++ b/src/modules/voxelrender/SceneGraphRenderer.cpp
@@ -206,6 +206,7 @@ void SceneGraphRenderer::updateNodeState(const voxel::MeshStatePtr &meshState, c
 	} else {
 		meshState->gray(idx, false);
 	}
+	meshState->setHasSelection(idx, node.hasSelection());
 }
 
 void SceneGraphRenderer::prepareReferenceNodes(const voxel::MeshStatePtr &meshState, const RenderContext &renderContext) const {

--- a/src/modules/voxelrender/shaders/_sharedvert.glsl
+++ b/src/modules/voxelrender/shaders/_sharedvert.glsl
@@ -10,7 +10,7 @@ layout(std140) uniform u_vert {
 	mat4 u_viewprojection;
 	mat4 u_model;
 	int u_gray;
-	int u_padding1;
+	int u_has_selection;
 	int u_padding2;
 	int u_padding3;
 };

--- a/src/modules/voxelrender/shaders/voxel.vert
+++ b/src/modules/voxelrender/shaders/voxel.vert
@@ -24,10 +24,15 @@ void main(void) {
 	v_normal = normal.xyz;
 	v_flags = 0u;
 
+	if (u_has_selection == 0) {
 #if r_renderoutline == 0
-	if ((a_flags & FLAGOUTLINE) != 0u)
-#endif
+		if ((a_flags & FLAGOUTLINE) != 0u) {
+			v_flags |= FLAGOUTLINE;
+		}
+#else
 		v_flags |= FLAGOUTLINE;
+#endif
+	}
 
 	if (normalIndex > 0) { // NO_NORMAL
 		v_flags |= FLAGHASNORMALPALETTECOLOR;
@@ -40,7 +45,7 @@ void main(void) {
 #endif
 	}
 
-	if (u_gray != 0) {
+	if (u_gray != 0 || (u_has_selection != 0 && (a_flags & FLAGOUTLINE) == 0u)) {
 		float gray = (0.21 * materialColor.r + 0.72 * materialColor.g + 0.07 * materialColor.b) / 3.0;
 		v_color = vec4(gray, gray, gray, materialColor.a);
 	} else {

--- a/src/modules/voxelrender/shaders/voxelnorm.vert
+++ b/src/modules/voxelrender/shaders/voxelnorm.vert
@@ -19,12 +19,17 @@ void main(void) {
 	vec4 materialColor = u_materialcolor[materialColorIndex];
 	vec4 glowColor = u_glowcolor[materialColorIndex];
 	v_flags = 0u;
+	if (u_has_selection == 0) {
 #if r_renderoutline == 0
-	if ((a_flags & FLAGOUTLINE) != 0u)
-#endif
+		if ((a_flags & FLAGOUTLINE) != 0u) {
+			v_flags |= FLAGOUTLINE;
+		}
+#else
 		v_flags |= FLAGOUTLINE;
+#endif
+	}
 
-	if (u_gray != 0) {
+	if (u_gray != 0 || (u_has_selection != 0 && (a_flags & FLAGOUTLINE) == 0u)) {
 		float gray = (0.21 * materialColor.r + 0.72 * materialColor.g + 0.07 * materialColor.b) / 3.0;
 		v_color = vec4(gray, gray, gray, materialColor.a);
 	} else {

--- a/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
@@ -161,9 +161,7 @@ bool MenuBar::update(ui::IMGUIApp *app, command::CommandExecutionListener &liste
 			}
 			ImGui::EndMenu();
 		}
-		if (ImGui::BeginIconMenu(ICON_LC_SQUARE, _("Select"))) {
-			ImGui::CommandIconMenuItem(ICON_LC_PIPETTE, _("Color picker"), "actioncolorpicker", true, &listener);
-			ImGui::Separator();
+		if (ImGui::BeginIconMenu(ICON_LC_SCAN, _("Mask"))) {
 			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("None"), "select none", true, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_SQUARE_DASHED_MOUSE_POINTER, _("Select"), "brushselect", true, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("Invert"), "select invert", true, &listener);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -350,6 +350,7 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	}
 	_brushContext.cursorVoxel = voxel;
 	brush->execute(sceneGraph, wrapper, _brushContext);
+	wrapper.growSelectionToNewVoxels();
 	const voxel::Region &modifiedRegion = wrapper.dirtyRegion();
 	if (modifiedRegion.isValid()) {
 		voxel::logRegion("Dirty region", modifiedRegion);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ModifierVolumeWrapper.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ModifierVolumeWrapper.h
@@ -6,8 +6,10 @@
 
 #include "ModifierType.h"
 #include "scenegraph/SceneGraphNode.h"
+#include "voxel/Connectivity.h"
 #include "voxel/RawVolumeWrapper.h"
 #include "voxel/Voxel.h"
+#include "voxelutil/VolumeVisitor.h"
 
 namespace voxedit {
 
@@ -40,9 +42,28 @@ private:
 		if (_selectionRegion.isValid() && _selectionRegion.containsPoint(pos)) {
 			return false;
 		}
-		// Check if the voxel has the FlagOutline (selected) flag set
 		const voxel::Voxel &voxel = _volume->voxel(pos.x, pos.y, pos.z);
-		return (voxel.getFlags() & voxel::FlagOutline) == 0;
+		// Voxel is explicitly selected
+		if (voxel.getFlags() & voxel::FlagOutline) {
+			return false;
+		}
+		// Air position: allow only if directly adjacent to a selected solid voxel (Place mode only).
+		// Override/Paint/Erase operate on existing voxels, so air is always skipped.
+		if (voxel::isAir(voxel.getMaterial())) {
+			if (_override) {
+				return true;
+			}
+			for (const auto &off : voxel::arrayPathfinderFaces) {
+				const glm::ivec3 n(pos.x + off.x, pos.y + off.y, pos.z + off.z);
+				const voxel::Voxel &nv = _volume->voxel(n.x, n.y, n.z);
+				if (!voxel::isAir(nv.getMaterial()) && (nv.getFlags() & voxel::FlagOutline)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		// Solid voxel without FlagOutline
+		return true;
 	}
 
 public:
@@ -86,7 +107,7 @@ public:
 					*_currentVoxel = voxel;
 				}
 			}
-			// Restore the FlagOutline if it was set on the original voxel
+			// Restore FlagOutline from original solid voxel
 			if (existingFlags & voxel::FlagOutline) {
 				_currentVoxel->setFlags(existingFlags);
 			}
@@ -206,6 +227,20 @@ public:
 			_dirtyRegion = voxel::Region(x, y, z, x, y, z);
 		}
 		return true;
+	}
+
+	/**
+	 * @brief After a brush stroke, mark newly placed voxels as selected if they are
+	 * adjacent to an originally selected voxel. Called once per brush execution.
+	 */
+	void growSelectionToNewVoxels() {
+		if (!_hasSelection || !_dirtyRegion.isValid()) {
+			return;
+		}
+		auto func = [this](int x, int y, int z, const voxel::Voxel & /*solidVoxel*/) {
+			setFlagAt(x, y, z, voxel::FlagOutline);
+		};
+		voxelutil::visitVolumeParallel(*this, _dirtyRegion, func, voxelutil::VisitSolid());
 	}
 
 	bool setVoxel(int x, int y, int z, const voxel::Voxel &voxel) override {

--- a/src/tools/voxedit/modules/voxedit-util/tests/ModifierTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ModifierTest.cpp
@@ -163,6 +163,121 @@ TEST_F(ModifierTest, testModifierSelection) {
 	modifier.shutdown();
 }
 
+TEST_F(ModifierTest, testMaskBlocksNonAdjacentPlace) {
+	// With a selection active, placing a voxel that is not adjacent to any
+	// selected voxel must be blocked entirely.
+	voxel::RawVolume volume({-10, 10});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SceneManager mgr(core::make_shared<core::TimeProvider>(), _testApp->filesystem(),
+					 core::make_shared<ISceneRenderer>(), core::make_shared<IModifierRenderer>());
+	Modifier modifier(&mgr, core::make_shared<IModifierRenderer>());
+	modifier.construct();
+	ASSERT_TRUE(modifier.init());
+	select(node, modifier, glm::ivec3(0), glm::ivec3(0));
+
+	// (3,0,0) is two steps away from the selected voxel — not adjacent
+	prepare(modifier, glm::ivec3(3, 0, 0), glm::ivec3(3, 0, 0), ModifierType::Place, BrushType::Shape);
+	scenegraph::SceneGraph sceneGraph;
+	int callbackCount = 0;
+	modifier.execute(sceneGraph, node,
+					 [&](const voxel::Region &, ModifierType, SceneModifiedFlags) { ++callbackCount; });
+	EXPECT_EQ(0, callbackCount) << "Place outside mask (non-adjacent) should not modify anything";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Voxel should not be placed outside the mask";
+	modifier.shutdown();
+}
+
+TEST_F(ModifierTest, testMaskAllowsAdjacentPlace) {
+	// Placing a voxel directly adjacent to a selected voxel must succeed, and
+	// the new voxel must inherit the selection flag (FlagOutline).
+	voxel::RawVolume volume({-10, 10});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SceneManager mgr(core::make_shared<core::TimeProvider>(), _testApp->filesystem(),
+					 core::make_shared<ISceneRenderer>(), core::make_shared<IModifierRenderer>());
+	Modifier modifier(&mgr, core::make_shared<IModifierRenderer>());
+	modifier.construct();
+	ASSERT_TRUE(modifier.init());
+	select(node, modifier, glm::ivec3(0), glm::ivec3(0));
+
+	// (1,0,0) is directly adjacent to the selected voxel at (0,0,0)
+	prepare(modifier, glm::ivec3(1, 0, 0), glm::ivec3(1, 0, 0), ModifierType::Place, BrushType::Shape);
+	scenegraph::SceneGraph sceneGraph;
+	bool callbackFired = false;
+	modifier.execute(sceneGraph, node,
+					 [&](const voxel::Region &, ModifierType, SceneModifiedFlags) { callbackFired = true; });
+	EXPECT_TRUE(callbackFired) << "Place adjacent to mask should succeed";
+	EXPECT_FALSE(voxel::isAir(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Voxel should be placed at the adjacent position";
+	EXPECT_TRUE((volume.voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Newly placed adjacent voxel should inherit the selection flag";
+	modifier.shutdown();
+}
+
+TEST_F(ModifierTest, testMaskEraseOnlySelectedVoxels) {
+	// Erase over a region containing both selected and non-selected voxels:
+	// only the selected voxel should be removed.
+	voxel::RawVolume volume({-10, 10});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0)); // will be selected
+	volume.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0)); // not selected
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SceneManager mgr(core::make_shared<core::TimeProvider>(), _testApp->filesystem(),
+					 core::make_shared<ISceneRenderer>(), core::make_shared<IModifierRenderer>());
+	Modifier modifier(&mgr, core::make_shared<IModifierRenderer>());
+	modifier.construct();
+	ASSERT_TRUE(modifier.init());
+	select(node, modifier, glm::ivec3(0), glm::ivec3(0));
+
+	// Erase over both voxels
+	prepare(modifier, glm::ivec3(0, 0, 0), glm::ivec3(1, 0, 0), ModifierType::Erase, BrushType::Shape);
+	scenegraph::SceneGraph sceneGraph;
+	modifier.execute(sceneGraph, node);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Selected voxel should be erased";
+	EXPECT_FALSE(voxel::isAir(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Non-selected voxel should not be erased";
+	modifier.shutdown();
+}
+
+TEST_F(ModifierTest, testMaskOverrideOnlyAffectsSelectedVoxels) {
+	// Override brush over a region with both selected and non-selected voxels:
+	// only the selected voxel should change color (cursor voxel = color 1 set by prepare()).
+	voxel::RawVolume volume({-10, 10});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0)); // will be selected
+	volume.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 0)); // not selected
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SceneManager mgr(core::make_shared<core::TimeProvider>(), _testApp->filesystem(),
+					 core::make_shared<ISceneRenderer>(), core::make_shared<IModifierRenderer>());
+	Modifier modifier(&mgr, core::make_shared<IModifierRenderer>());
+	modifier.construct();
+	ASSERT_TRUE(modifier.init());
+	select(node, modifier, glm::ivec3(0), glm::ivec3(0));
+
+	// Override both voxels; prepare() sets the cursor voxel to color index 1
+	prepare(modifier, glm::ivec3(0, 0, 0), glm::ivec3(1, 0, 0), ModifierType::Override, BrushType::Shape);
+	scenegraph::SceneGraph sceneGraph;
+	int callbackCount = 0;
+	modifier.execute(sceneGraph, node,
+					 [&](const voxel::Region &, ModifierType, SceneModifiedFlags) { ++callbackCount; });
+
+	EXPECT_GT(callbackCount, 0) << "Override brush should have modified at least one voxel";
+	EXPECT_EQ(1, (int)volume.voxel(0, 0, 0).getColor())
+		<< "Selected voxel should have its color changed to cursor color";
+	EXPECT_EQ(0, (int)volume.voxel(1, 0, 0).getColor())
+		<< "Non-selected voxel color should be unchanged";
+	modifier.shutdown();
+}
+
 TEST_F(ModifierTest, testClamp) {
 	scenegraph::SceneGraph sceneGraph;
 	SceneManager mgr(core::make_shared<core::TimeProvider>(), _testApp->filesystem(),


### PR DESCRIPTION
## Summary

- Adds per-node visual masking: when a selection (mask) exists on a model node, voxels **outside** the selection are rendered dark gray (same appearance as inactive geometry nodes), while voxels **inside** the selection render normally with no tinting
- New `u_has_selection` UBO uniform replaces `u_padding1` in the vertex shader; both `voxel.vert` and `voxelnorm.vert` implement the per-voxel gray logic based on `FlagOutline`
- `MeshState` tracks `_hasSelection` per node; `SceneGraphRenderer::updateNodeState` sets it from `node.hasSelection()`; `RawVolumeRenderer` passes it to the shader

**Mask-aware brush placement:**
- Brushes can edit existing selected (FlagOutline) voxels as before
- New voxels may only be placed in air **adjacent** to a selected solid voxel — prevents drawing outside the mask entirely
- After each brush stroke a post-pass (`growSelectionToNewVoxels`) marks newly placed voxels that touch the original selection, so they render normally and extend the mask by one layer
- The mask grows naturally as the user draws; chain-reactions within a single stroke are prevented because FlagOutline is not applied until after the stroke completes

**UI changes:**
- "Select" main menu renamed to "Mask"
- Color Picker removed from that menu (it is a tool mode unrelated to masking, available in the toolbar)
- 3D box selection bounds panel hidden unless "3D Box" select mode is active

**Bug fix:**
- Override mode no longer expands the selection into adjacent air voxels; it now only affects existing solid selected voxels (Place mode still allows growing into adjacent air)

## Unit tests added (ModifierTest)

- `testMaskBlocksNonAdjacentPlace` — Place brush on air not adjacent to any selected voxel is fully blocked
- `testMaskAllowsAdjacentPlace` — Place brush on air directly adjacent to a selected voxel succeeds and the new voxel inherits FlagOutline
- `testMaskEraseOnlySelectedVoxels` — Erase brush over a mixed region only removes selected voxels; non-selected solid voxels are untouched
- `testMaskOverrideOnlyAffectsSelectedVoxels` — Override brush changes the color of selected voxels only; non-selected solid voxels keep their original color

## Test plan

- [ ] Open a model, make a selection with the select brush, verify voxels outside selection appear dark gray and inside appear normal
- [ ] Paint / erase / override within the selection — should work; outside should be blocked
- [ ] Use shape brush starting inside the mask — new voxels placed and gray correctly
- [ ] Use shape brush starting outside the mask — nothing placed
- [ ] Use shape brush touching the mask boundary by 1 voxel — only the adjacent layer is placed, no chain growth within the stroke
- [ ] Clear selection — all voxels return to normal rendering
- [ ] Verify "Mask" menu contains None / Select / Invert / All and no Color Picker
- [ ] Switch to 3D Box select mode — bounds UI appears; switch to any other mode — bounds UI hidden
- [ ] Test with both cubic and marching cubes mesh modes