### PR TITLE
VOXEDIT: add FlatSurface select mode with deviation

### DIFF
--- a/src/modules/voxelutil/VolumeVisitor.h
+++ b/src/modules/voxelutil/VolumeVisitor.h
@@ -8,10 +8,12 @@
 #include "color/ColorUtil.h"
 #include "core/GLM.h"
 #include "core/Trace.h"
+#include "core/collection/DynamicArray.h"
 #include "core/collection/DynamicSet.h"
 #include "core/concurrent/Atomic.h"
 #include "palette/Palette.h"
 #include "voxel/Connectivity.h"
+#include "math/Axis.h"
 #include "voxel/Face.h"
 #include "voxel/Region.h"
 #include "voxel/Voxel.h"
@@ -1104,6 +1106,132 @@ int visitConnectedByCondition(const Volume &volume, const glm::ivec3 &position, 
 	const voxel::Voxel voxel = volume.voxel(position);
 	VisitedSet visited;
 	return visitConnectedByVoxel_r(volume, voxel, position, visitor, condition, visited);
+}
+
+/**
+ * @brief Condition for flat-surface flood fill.
+ *
+ * A voxel qualifies if it is solid, its given face is exposed (the neighbor in the face
+ * direction is air), and its coordinate along the face axis is within @p deviation of the
+ * start voxel. Pass as the Condition argument to visitFlatSurface.
+ */
+struct VisitFlatSurface {
+	voxel::FaceBits _faceBit;
+	int _faceAxis;    ///< 0=X, 1=Y, 2=Z
+	int _startCoord;  ///< start position coordinate on the face axis
+	int _deviation;   ///< max allowed distance from start along the face axis
+
+	VisitFlatSurface(voxel::FaceNames face, const glm::ivec3 &startPos, int deviation = 0)
+		: _faceBit(voxel::faceBits(face)),
+		  _faceAxis(math::getIndexForAxis(voxel::faceToAxis(face))),
+		  _startCoord(startPos[_faceAxis]),
+		  _deviation(deviation) {}
+
+	template<class Sampler>
+	bool operator()(const Sampler &sampler) const {
+		if (voxel::isAir(sampler.voxel().getMaterial())) {
+			return false;
+		}
+		if (glm::abs(sampler.position()[_faceAxis] - _startCoord) > _deviation) {
+			return false;
+		}
+		return (voxel::visibleFaces(sampler) & _faceBit) != voxel::FaceBits::None;
+	}
+};
+
+/**
+ * @brief Flood-fill starting at @p position, visiting connected voxels accepted by @p condition.
+ *
+ * Explores the 4 neighbors perpendicular to @p face. When @p deviation > 0 the search also
+ * probes candidates at offset face-axis coordinates (within [startCoord±deviation]) so small
+ * height steps can be traversed. Use visitFlatSurface(volume, position, face, deviation, visitor)
+ * for the common case; this overload allows a custom condition functor.
+ *
+ * @param volume     The volume to query
+ * @param position   Start voxel position (must satisfy condition)
+ * @param face       Defines the perpendicular plane and deviation search direction
+ * @param deviation  How many units above/below start to also consider at each step
+ * @param visitor    Called with (x, y, z, voxel) for every accepted voxel including start
+ * @param condition  Callable(Sampler) → bool
+ * @return Number of voxels visited
+ */
+template<class Volume, class Visitor, class Condition>
+int visitFlatSurface(const Volume &volume, const glm::ivec3 &position, voxel::FaceNames face,
+					 int deviation, Visitor &&visitor, Condition &&condition) {
+	if (face == voxel::FaceNames::Max) {
+		return 0;
+	}
+	typename Volume::Sampler startSampler(volume);
+	if (!startSampler.setPosition(position)) {
+		return 0;
+	}
+	if (!condition(startSampler)) {
+		return 0;
+	}
+	const int faceAxis   = math::getIndexForAxis(voxel::faceToAxis(face));
+	const int startCoord = position[faceAxis];
+	// 4 directions perpendicular to the face normal
+	const int perpAxis1 = (faceAxis + 1) % 3;
+	const int perpAxis2 = (faceAxis + 2) % 3;
+	glm::ivec3 perpOffsets[4] = {};
+	perpOffsets[0][perpAxis1] =  1;
+	perpOffsets[1][perpAxis1] = -1;
+	perpOffsets[2][perpAxis2] =  1;
+	perpOffsets[3][perpAxis2] = -1;
+	VisitedSet visited;
+	visited.insert(position);
+	visitor(position.x, position.y, position.z, startSampler.voxel());
+	int n = 1;
+	constexpr size_t InitialQueueReserve = 64u;
+	core::DynamicArray<glm::ivec3> queue;
+	queue.reserve(InitialQueueReserve);
+	queue.push_back(position);
+	typename Volume::Sampler sampler(volume);
+	while (!queue.empty()) {
+		const glm::ivec3 current = queue.back();
+		queue.pop();
+		for (int i = 0; i < 4; ++i) {
+			const glm::ivec3 neighborBase = current + perpOffsets[i];
+			// Probe same level first, then ±1, ±2 … up to deviation from start.
+			for (int step = 0; step <= deviation; ++step) {
+				bool claimedAtStep = false;
+				const int ds[2] = {step, -step};
+				const int count  = (step == 0) ? 1 : 2;
+				for (int j = 0; j < count; ++j) {
+					glm::ivec3 neighbor = neighborBase;
+					neighbor[faceAxis]  = startCoord + ds[j];
+					if (!visited.insert(neighbor)) {
+						claimedAtStep = true;
+						break;
+					}
+					if (!sampler.setPosition(neighbor)) {
+						continue;
+					}
+					if (!condition(sampler)) {
+						continue;
+					}
+					visitor(neighbor.x, neighbor.y, neighbor.z, sampler.voxel());
+					++n;
+					queue.push_back(neighbor);
+					claimedAtStep = true;
+					break;
+				}
+				if (claimedAtStep) {
+					break;
+				}
+			}
+		}
+	}
+	return n;
+}
+
+/// Convenience overload: constructs a VisitFlatSurface condition with the given deviation.
+template<class Volume, class Visitor = EmptyVisitor>
+int visitFlatSurface(const Volume &volume, const glm::ivec3 &position, voxel::FaceNames face,
+					 int deviation = 0, Visitor &&visitor = Visitor()) {
+	return visitFlatSurface(volume, position, face, deviation,
+							core::forward<Visitor>(visitor),
+							VisitFlatSurface(face, position, deviation));
 }
 
 } // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeVisitorTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeVisitorTest.cpp
@@ -168,6 +168,35 @@ TEST_F(VolumeVisitorTest, testVisitVisibleSurface) {
 	EXPECT_EQ(3, cnt);
 }
 
+TEST_F(VolumeVisitorTest, testVisitFlatSurface) {
+	// Flat 3x3 surface at y=0 with an exposed top face (PositiveY).
+	// All voxels are on the same plane so deviation=0 should visit all 9.
+	const voxel::Region region(0, 0, 0, 2, 2, 2);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	for (int x = 0; x < 3; ++x) {
+		for (int z = 0; z < 3; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	int cnt = visitFlatSurface(volume, glm::ivec3(1, 0, 1), voxel::FaceNames::PositiveY);
+	EXPECT_EQ(9, cnt);
+
+	// With a step of 1 at z=1, deviation=0 should not follow the step.
+	voxel::RawVolume volume2(region);
+	for (int x = 0; x < 3; ++x) {
+		volume2.setVoxel(x, 0, 0, solid);
+		volume2.setVoxel(x, 0, 1, solid);
+		volume2.setVoxel(x, 0, 2, solid);
+		volume2.setVoxel(x, 1, 2, solid); // one step up at z=2
+	}
+	int cntNoDeviation = visitFlatSurface(volume2, glm::ivec3(1, 0, 1), voxel::FaceNames::PositiveY, 0);
+	EXPECT_EQ(6, cntNoDeviation); // only the 6 voxels whose PositiveY face is exposed
+
+	int cntWithDeviation = visitFlatSurface(volume2, glm::ivec3(1, 0, 1), voxel::FaceNames::PositiveY, 1);
+	EXPECT_EQ(9, cntWithDeviation); // all 9, including the 3 at y=1
+}
+
 class VolumeVisitorParamTest : public app::AbstractTest, public ::testing::WithParamInterface<VisitorOrder> {};
 
 class VolumeVisitorOrderTest : public VolumeVisitorParamTest {};

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -246,7 +246,7 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 
 	const char *SelectModeStr[] = {C_("SelectMode", "All"), C_("SelectMode", "Surface"), C_("SelectMode", "Same Color"),
 								   C_("SelectMode", "Fuzzy Color"), C_("SelectMode", "Connected"),
-								   C_("SelectMode", "3D Box")};
+								   C_("SelectMode", "Flat Surface"), C_("SelectMode", "3D Box")};
 	static_assert(lengthof(SelectModeStr) == (int)SelectMode::Max, "Array size mismatch");
 
 	if (ImGui::Combo(_("Select mode"), &selectModeInt, SelectModeStr, (int)SelectMode::Max)) {
@@ -259,6 +259,30 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 			brush.setColorThreshold(threshold);
 		}
 		ImGui::TooltipTextUnformatted(_("Color distance threshold for fuzzy matching (0 = exact, higher = more similar colors)"));
+	}
+
+	if (brush.selectMode() == SelectMode::FlatSurface) {
+		int deviation = brush.flatDeviation();
+		const float btnW = ImGui::GetFrameHeight();
+		const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+		ImGui::TextUnformatted(_("Accepted deviation"));
+		ImGui::TooltipTextUnformatted(_("How many voxels above or below the clicked face the fill may deviate from the start position"));
+		ImGui::PushID("flatdeviation");
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			deviation = glm::max(deviation - 1, 0);
+			brush.setFlatDeviation(deviation);
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("##flatdeviation", &deviation, 0, SelectBrush::MaxFlatDeviation)) {
+			brush.setFlatDeviation(deviation);
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			deviation = glm::min(deviation + 1, SelectBrush::MaxFlatDeviation);
+			brush.setFlatDeviation(deviation);
+		}
+		ImGui::PopID();
 	}
 
 	const int nodeId = _sceneMgr->sceneGraph().activeNode();

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -582,8 +582,13 @@ void SceneManager::modified(int nodeId, const voxel::Region& modifiedRegion, Sce
 	}
 	if (_selectionCacheNodeId == nodeId) {
 		_selectionCacheNodeId = -1;
-		if (_modifierFacade.brushType() == BrushType::Select &&
-			_modifierFacade.selectBrush().selectMode() == SelectMode::Box3D) {
+	}
+	if (_modifierFacade.brushType() == BrushType::Select && nodeId == _sceneGraph.activeNode()) {
+		const SelectMode selectMode = _modifierFacade.selectBrush().selectMode();
+		if (selectMode == SelectMode::Box3D) {
+			const scenegraph::SceneGraphNode *node = sceneGraphNode(nodeId);
+			_sceneRenderer->updateSelectionGizmo(node ? node->selectionRegion() : voxel::Region::InvalidRegion);
+		} else if (selectMode == SelectMode::FlatSurface) {
 			_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(nodeId));
 		}
 	}
@@ -3485,6 +3490,9 @@ bool SceneManager::update(double nowSeconds) {
 		_lastSelectMode = currentSelectMode;
 		const int activeNodeId = _sceneGraph.activeNode();
 		if (currentBrushType == BrushType::Select && currentSelectMode == SelectMode::Box3D) {
+			const scenegraph::SceneGraphNode *node = sceneGraphNode(activeNodeId);
+			_sceneRenderer->updateSelectionGizmo(node ? node->selectionRegion() : voxel::Region::InvalidRegion);
+		} else if (currentBrushType == BrushType::Select && currentSelectMode == SelectMode::FlatSurface) {
 			_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(activeNodeId));
 		} else {
 			_sceneRenderer->updateSelectionGizmo(voxel::Region::InvalidRegion);

--- a/src/tools/voxedit/modules/voxedit-util/SceneRenderer.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneRenderer.cpp
@@ -450,6 +450,7 @@ void SceneRenderer::renderUI(voxelrender::RenderContext &renderContext, const vi
 			_shapeBuilder.clear();
 			_shapeBuilder.axis(signVec * scale);
 			_shapeRenderer.createOrUpdate(_selectionGizmoMeshIndex, _shapeBuilder);
+			video::ScopedState noDepthTest(video::State::DepthTest, false);
 			_shapeRenderer.render(_selectionGizmoMeshIndex, camera, glm::translate(model, bestCorner));
 		}
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
@@ -4,6 +4,7 @@
 
 #include "SelectBrush.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/Face.h"
 #include "voxel/Voxel.h"
 #include "voxelutil/VolumeVisitor.h"
 #include "palette/Palette.h"
@@ -13,7 +14,8 @@ namespace voxedit {
 
 voxel::Region SelectBrush::calcRegion(const BrushContext &ctx) const {
 	if (_selectMode == SelectMode::Connected || _selectMode == SelectMode::SameColor ||
-		_selectMode == SelectMode::Surface || _selectMode == SelectMode::FuzzyColor) {
+		_selectMode == SelectMode::Surface || _selectMode == SelectMode::FuzzyColor ||
+		_selectMode == SelectMode::FlatSurface) {
 		return ctx.targetVolumeRegion;
 	}
 	return Super::calcRegion(ctx);
@@ -78,6 +80,17 @@ void SelectBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWra
 			wrapper.setFlagAt(startPos.x, startPos.y, startPos.z, voxel::FlagOutline);
 		}
 		voxelutil::visitConnectedByCondition(wrapper, startPos, func);
+		break;
+	}
+	case SelectMode::FlatSurface: {
+		if (ctx.cursorFace == voxel::FaceNames::Max) {
+			return;
+		}
+		const glm::ivec3 &startPos = ctx.cursorPosition;
+		if (voxel::isAir(wrapper.voxel(startPos).getMaterial())) {
+			return;
+		}
+		voxelutil::visitFlatSurface(wrapper, startPos, ctx.cursorFace, _flatDeviation, func);
 		break;
 	}
 	case SelectMode::Box3D: {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
@@ -8,6 +8,7 @@
 #include "color/ColorUtil.h"
 #include "voxedit-util/modifier/ModifierType.h"
 #include "voxel/Region.h"
+#include <glm/common.hpp>
 #include <glm/vec3.hpp>
 
 namespace voxedit {
@@ -27,6 +28,8 @@ enum class SelectMode : uint8_t {
 	FuzzyColor,
 	/** Select voxels connected to the clicked voxel with the same color (flood fill) */
 	Connected,
+	/** Flood-fill select all connected solid voxels that share the same exposed face as the clicked voxel */
+	FlatSurface,
 	/** Replace the current selection with all solid voxels in the drawn 3D box region */
 	Box3D,
 
@@ -41,6 +44,7 @@ private:
 	using Super = AABBBrush;
 	SelectMode _selectMode = SelectMode::All;
 	float _colorThreshold = color::ApproximationDistanceModerate;
+	int _flatDeviation = 0;
 
 	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
 				  const voxel::Region &region) override;
@@ -68,6 +72,16 @@ public:
 
 	float colorThreshold() const {
 		return _colorThreshold;
+	}
+
+	static constexpr int MaxFlatDeviation = 32;
+
+	void setFlatDeviation(int deviation) {
+		_flatDeviation = glm::clamp(deviation, 0, MaxFlatDeviation);
+	}
+
+	int flatDeviation() const {
+		return _flatDeviation;
 	}
 };
 

--- a/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
@@ -24,12 +24,13 @@ protected:
 		brush.step(ctx);
 	}
 
-	void executeSelect(SelectBrush &brush, scenegraph::SceneGraphNode &node, const BrushContext &ctx,
+	void executeSelect(SelectBrush &brush, scenegraph::SceneGraphNode &node, BrushContext &ctx,
 					   ModifierType modifierType = ModifierType::Override) {
 		scenegraph::SceneGraph sceneGraph;
 		ModifierVolumeWrapper wrapper(node, modifierType);
 		brush.preExecute(ctx, wrapper.volume());
 		brush.execute(sceneGraph, wrapper, ctx);
+		brush.endBrush(ctx);
 	}
 };
 
@@ -242,6 +243,163 @@ TEST_F(SelectBrushTest, testSelectRemove) {
 	EXPECT_FALSE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
 		<< "Interior voxel at (0,0,0) should be deselected";
 
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeFlatSurface) {
+	// 5x5 flat floor at y=0 with PositiveY face exposed (nothing above)
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -2; z <= 2; ++z) {
+		for (int x = -2; x <= 2; ++x) {
+			volume.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::FlatSurface);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// All 5x5 floor voxels should be selected
+	for (int z = -2; z <= 2; ++z) {
+		for (int x = -2; x <= 2; ++x) {
+			EXPECT_TRUE((volume.voxel(x, 0, z).getFlags() & voxel::FlagOutline) != 0)
+				<< "Floor voxel at (" << x << ",0," << z << ") should be selected";
+		}
+	}
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeFlatSurface_stopsAtCoveredVoxel) {
+	// A line of floor voxels at y=0 along the X axis
+	// One voxel's PositiveY face is blocked by a voxel above it
+	voxel::RawVolume volume({-5, 5});
+	for (int x = -3; x <= 3; ++x) {
+		volume.setVoxel(x, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	}
+	// Block PositiveY face of (0,0,0) by placing a solid voxel above it
+	volume.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::FlatSurface);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	// Start from the left end of the line
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(-3, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// Left side (before the blocked voxel) should be selected
+	for (int x = -3; x <= -1; ++x) {
+		EXPECT_TRUE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Voxel at (" << x << ",0,0) should be selected";
+	}
+	// The voxel with a blocked PositiveY face should NOT be selected
+	EXPECT_FALSE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Covered voxel (0,0,0) should not be selected";
+	// Right side (beyond the barrier) should also NOT be selected
+	for (int x = 1; x <= 3; ++x) {
+		EXPECT_FALSE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Voxel at (" << x << ",0,0) should not be selected (beyond blocked voxel)";
+	}
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeFlatSurface_deviation) {
+	// Stepped floor: y=0 for x in [-2..0], y=1 for x in [1..3], both along z=0
+	voxel::RawVolume volume({-5, 5});
+	for (int x = -2; x <= 0; ++x) {
+		volume.setVoxel(x, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	}
+	for (int x = 1; x <= 3; ++x) {
+		volume.setVoxel(x, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::FlatSurface);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// With deviation=0: only the lower floor (y=0) should be selected
+	brush.setFlatDeviation(0);
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	for (int x = -2; x <= 0; ++x) {
+		EXPECT_TRUE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Lower voxel at (" << x << ",0,0) should be selected with deviation=0";
+	}
+	for (int x = 1; x <= 3; ++x) {
+		EXPECT_FALSE((volume.voxel(x, 1, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Upper voxel at (" << x << ",1,0) should NOT be selected with deviation=0";
+	}
+
+	// Clear selection flags for the next part of the test
+	for (int x = -2; x <= 0; ++x) {
+		voxel::Voxel v = volume.voxel(x, 0, 0);
+		v.setFlags(v.getFlags() & ~voxel::FlagOutline);
+		volume.setVoxel(x, 0, 0, v);
+	}
+
+	// With deviation=1: both floors should be reachable (step of 1 in Y from start)
+	brush.setFlatDeviation(1);
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	for (int x = -2; x <= 0; ++x) {
+		EXPECT_TRUE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Lower voxel at (" << x << ",0,0) should be selected with deviation=1";
+	}
+	for (int x = 1; x <= 3; ++x) {
+		EXPECT_TRUE((volume.voxel(x, 1, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Upper voxel at (" << x << ",1,0) should be selected with deviation=1";
+	}
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeFlatSurface_invalidFace) {
+	voxel::RawVolume volume({-5, 5});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::FlatSurface);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::Max; // invalid face
+	executeSelect(brush, node, ctx);
+
+	// Nothing should be selected when face is invalid
+	EXPECT_FALSE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "No voxel should be selected when face is Max";
 	brush.shutdown();
 }
 


### PR DESCRIPTION
● Summary                                                                                                                                                                               
                                                                                                                                                                                        
  - FlatSurface select mode: flood-fills all connected solid voxels that share the same exposed face as the clicked voxel. Useful for selecting floor tiles, walls, or any coplanar surface without picking up buried interior voxels.
  - Accepted deviation slider: shown in BrushPanel when FlatSurface is active; lets the fill cross height steps of ±N voxels along the face-normal axis, so stairs and ramps can be selected in one click. 
  - visitFlatSurface() in VolumeVisitor.h: iterative 4-connected flood fill in the plane perpendicular to the hit face, with a VisitFlatSurface condition that checks both face exposure and the deviation bound. Two overloads keep call sites clean. 
  - Box3D gizmo fix: the axis gizmo now reliably appears after drawing a Box3D selection. The gizmo update in SceneManager::modified() was previously gated behind a cache invalidation that could suppress it; it now reads node->selectionRegion() directly and always fires for the active node in Box3D mode.  
  - Gizmo in FlatSurface mode: the same axis guide is now shown after a FlatSurface selection, displaying the bounding box of the selected region.  
  - Unit tests in SelectBrushTest: basic floor selection, fill stopping at a face-blocked voxel, deviation=0 vs deviation=1 on a stepped floor, invalid face (FaceNames::Max). Fixed a beginBrush() double-call bug in executeSelect() by adding endBrush() at the end of each select execution. 

  Test plan

  - Select brush → FlatSurface mode → click the top face of a flat floor: all connected floor tiles with an exposed top face are selected  
  - Same with a staircase and deviation=1: the step is crossed and both levels are selected; deviation=0 stops at the edge 
  - Box3D select: draw a region — axis gizmo appears immediately, including over an empty (all-air) region 
  - FlatSurface select: axis gizmo appears after clicking, showing the bounding box of the flat selection 
  - Switch away from Select brush: gizmo disappears 
  - All SelectBrushTest and ModifierTest unit tests pass 