### PR TITLE
VOXEDIT: add ExtrudeBrush for face-based extrusion and carving

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -25,8 +25,10 @@
 #include "voxedit-util/modifier/brush/LineBrush.h"
 #include "voxedit-util/modifier/brush/NormalBrush.h"
 #include "voxedit-util/modifier/brush/ShapeBrush.h"
+#include "voxedit-util/modifier/brush/ExtrudeBrush.h"
 #include "voxedit-util/modifier/brush/StampBrush.h"
 #include "voxedit-util/modifier/brush/TextureBrush.h"
+#include "voxel/Face.h"
 #include "voxel/RawVolume.h"
 #include "voxel/Region.h"
 #include "voxel/Voxel.h"
@@ -42,7 +44,7 @@ static constexpr const char *BrushTypeIcons[] = {
 	ICON_LC_PIPETTE,	ICON_LC_BOXES,	   ICON_LC_GROUP,
 	ICON_LC_STAMP,		ICON_LC_PEN_LINE,  ICON_LC_FOOTPRINTS,
 	ICON_LC_PAINTBRUSH, ICON_LC_TEXT_WRAP, ICON_LC_SQUARE_DASHED_MOUSE_POINTER,
-	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT};
+	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT, ICON_LC_EXPAND};
 static_assert(lengthof(BrushTypeIcons) == (int)BrushType::Max, "BrushTypeIcons size mismatch");
 
 void BrushPanel::init() {
@@ -716,6 +718,77 @@ void BrushPanel::createPopups(command::CommandExecutionListener &listener) {
 	}
 }
 
+void BrushPanel::executeExtrudeBrush() {
+	Modifier &modifier = _sceneMgr->modifier();
+	if (!modifier.beginBrushFromPanel()) {
+		return;
+	}
+	_sceneMgr->nodeForeachGroup([&](int nodeId) {
+		if (scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId)) {
+			if (!node->visible()) {
+				return;
+			}
+			auto callback = [&](const voxel::Region &region, ModifierType type, SceneModifiedFlags flags) {
+				_sceneMgr->modified(nodeId, region, flags);
+			};
+			modifier.execute(_sceneMgr->sceneGraph(), *node, callback);
+		}
+	});
+	modifier.endBrush();
+}
+
+void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &listener) {
+	Modifier &modifier = _sceneMgr->modifier();
+	ExtrudeBrush &brush = modifier.extrudeBrush();
+
+	const scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(_sceneMgr->sceneGraph().activeNode());
+
+	// Fallback used before a node is loaded; overridden by actual node dimensions below.
+	static constexpr int DefaultMaxExtrudeDepth = 128;
+	int maxDepth = DefaultMaxExtrudeDepth;
+	if (node && node->volume()) {
+		const voxel::Region &r = node->volume()->region();
+		maxDepth = glm::max(r.getWidthInVoxels(), glm::max(r.getHeightInVoxels(), r.getDepthInVoxels()));
+	}
+
+	int depth = brush.depth();
+	ImGui::TextUnformatted(_("Depth"));
+	if (ImGui::Button("-##extrude_depth")) {
+		brush.setDepth(depth - 1);
+		executeExtrudeBrush();
+	}
+	ImGui::SameLine();
+	if (ImGui::SliderInt("##extrude_depth_slider", &depth, -maxDepth, maxDepth)) {
+		brush.setDepth(depth);
+	}
+	if (ImGui::IsItemDeactivatedAfterEdit()) {
+		executeExtrudeBrush();
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("+##extrude_depth")) {
+		brush.setDepth(depth + 1);
+		executeExtrudeBrush();
+	}
+
+	bool fillSides = brush.fillSides();
+	if (ImGui::Checkbox(_("Fill sides (keep manifold)"), &fillSides)) {
+		brush.setFillSides(fillSides);
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::SetTooltip("%s", _("Fill the perpendicular walls of the extruded region to prevent open edges"));
+	}
+
+	const voxel::FaceNames extrudeFace = brush.face();
+	if (extrudeFace == voxel::FaceNames::Max) {
+		ImGui::TextWrappedUnformatted(_("Click a voxel face in the viewport to set the extrusion direction"));
+	} else {
+		ImGui::Text(_("Direction: %s"), voxel::faceNameString(extrudeFace));
+	}
+	if (depth == 0 && (!node || !node->hasSelection())) {
+		ImGui::TextWrappedUnformatted(_("No selection active - use the Select brush first"));
+	}
+}
+
 void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 	const Modifier &modifier = _sceneMgr->modifier();
 	const BrushType brushType = modifier.brushType();
@@ -740,6 +813,8 @@ void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 			updateTextureBrushPanel(listener);
 		} else if (brushType == BrushType::Normal) {
 			updateNormalBrushPanel(listener);
+		} else if (brushType == BrushType::Extrude) {
+			updateExtrudeBrushPanel(listener);
 		}
 	}
 

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
@@ -52,6 +52,8 @@ private:
 	void updateSelectBrushPanel(command::CommandExecutionListener &listener);
 	void updateTextureBrushPanel(command::CommandExecutionListener &listener);
 	void updateNormalBrushPanel(command::CommandExecutionListener &listener);
+	void updateExtrudeBrushPanel(command::CommandExecutionListener &listener);
+	void executeExtrudeBrush();
 
 	void addBrushClampingOption(Brush &brush);
 	void aabbBrushOptions(command::CommandExecutionListener &listener, AABBBrush &brush);

--- a/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
+++ b/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
 	modifier/brush/StampBrush.cpp modifier/brush/StampBrush.h
 	modifier/brush/TextBrush.cpp modifier/brush/TextBrush.h
 	modifier/brush/SelectBrush.cpp modifier/brush/SelectBrush.h
+	modifier/brush/ExtrudeBrush.cpp modifier/brush/ExtrudeBrush.h
 	modifier/brush/TextureBrush.cpp modifier/brush/TextureBrush.h
 
 	modifier/IModifierRenderer.h
@@ -99,6 +100,7 @@ engine_add_module(TARGET ${LIB} SRCS ${SRCS} DEPENDENCIES ${DEPENDENCIES})
 set(TEST_SRCS
 	tests/AbstractBrushTest.cpp tests/AbstractBrushTest.h
 	tests/ClipboardTest.cpp
+	tests/ExtrudeBrushTest.cpp
 	tests/LineBrushTest.cpp
 	tests/ModifierTest.cpp
 	tests/ModifierVolumeWrapperTest.cpp

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -42,6 +42,7 @@ Modifier::Modifier(SceneManager *sceneMgr, const ModifierRendererPtr &modifierRe
 	_brushes.push_back(&_selectBrush);
 	_brushes.push_back(&_textureBrush);
 	_brushes.push_back(&_normalBrush);
+	_brushes.push_back(&_extrudeBrush);
 	core_assert(_brushes.size() == (int)BrushType::Max - 1);
 }
 
@@ -193,6 +194,15 @@ void Modifier::reset() {
 bool Modifier::beginBrush() {
 	if (Brush *brush = currentBrush()) {
 		return brush->beginBrush(_brushContext);
+	}
+	return false;
+}
+
+bool Modifier::beginBrushFromPanel() {
+	if (Brush *brush = currentBrush()) {
+		BrushContext ctx = _brushContext;
+		ctx.cursorFace = voxel::FaceNames::Max;
+		return brush->beginBrush(ctx);
 	}
 	return false;
 }
@@ -449,6 +459,9 @@ BrushType Modifier::setBrushType(BrushType type) {
 		// ensure the modifier type is compatible with the brush
 		setModifierType(currentBrush()->modifierType(_brushContext.modifierType));
 	}
+	if (_brushType == BrushType::Extrude) {
+		_extrudeBrush.reset();
+	}
 	return _brushType;
 }
 
@@ -495,6 +508,9 @@ bool Modifier::previewNeedsExistingVolume() const {
 	}
 	if (_brushType == BrushType::Plane) {
 		return isMode(ModifierType::Place);
+	}
+	if (_brushType == BrushType::Extrude) {
+		return true;
 	}
 	return false;
 }

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
@@ -14,6 +14,7 @@
 #include "brush/PaintBrush.h"
 #include "brush/PathBrush.h"
 #include "brush/PlaneBrush.h"
+#include "brush/ExtrudeBrush.h"
 #include "brush/SelectBrush.h"
 #include "brush/ShapeBrush.h"
 #include "brush/StampBrush.h"
@@ -95,6 +96,7 @@ protected:
 	SelectBrush _selectBrush;
 	TextureBrush _textureBrush;
 	NormalBrush _normalBrush;
+	ExtrudeBrush _extrudeBrush;
 
 	ModifierButton _actionExecuteButton;
 	ModifierButton _deleteExecuteButton;
@@ -172,6 +174,11 @@ public:
 	 * @brief Pick the start position of the modifier execution bounding box
 	 */
 	bool beginBrush();
+	/**
+	 * @brief Like beginBrush() but passes FaceNames::Max so the brush does not update its stored
+	 * face direction. Use when triggering execution from a UI panel rather than a viewport click.
+	 */
+	bool beginBrushFromPanel();
 protected:
 	void preExecuteBrush(const voxel::RawVolume *volume);
 
@@ -216,6 +223,7 @@ public:
 	SelectBrush &selectBrush();
 	TextureBrush &textureBrush();
 	NormalBrush &normalBrush();
+	ExtrudeBrush &extrudeBrush();
 	const BrushContext &brushContext() const;
 
 	/**
@@ -323,6 +331,10 @@ inline SelectBrush &Modifier::selectBrush() {
 
 inline TextureBrush &Modifier::textureBrush() {
 	return _textureBrush;
+}
+
+inline ExtrudeBrush &Modifier::extrudeBrush() {
+	return _extrudeBrush;
 }
 
 inline int Modifier::gridResolution() const {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
@@ -13,13 +13,13 @@ namespace voxedit {
  *
  * Each brush type provides a different way to place, modify, or select voxels in the scene.
  */
-enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Max };
+enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Extrude, Max };
 
 /**
  * @brief String representation of brush types for UI display and command registration
  */
-static constexpr const char *BrushTypeStr[] = {"None", "Shape", "Plane", "Stamp",  "Line",
-											   "Path", "Paint", "Text",	 "Select", "Texture", "Normal"};
+static constexpr const char *BrushTypeStr[] = {"None",  "Shape", "Plane",   "Stamp",  "Line",   "Path",
+											   "Paint", "Text",  "Select",  "Texture", "Normal", "Extrude"};
 static_assert(lengthof(BrushTypeStr) == (int)BrushType::Max, "BrushTypeStr size mismatch");
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file
+ */
+
+#include "ExtrudeBrush.h"
+#include "math/Axis.h"
+#include "voxedit-util/modifier/ModifierType.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Region.h"
+#include "voxel/Voxel.h"
+
+namespace voxedit {
+
+void ExtrudeBrush::reset() {
+	Super::reset();
+	_depth = 0;
+	_face = voxel::FaceNames::Max;
+	_active = false;
+	_history.clear();
+}
+
+bool ExtrudeBrush::beginBrush(const BrushContext &ctx) {
+	if (_active) {
+		return false;
+	}
+	// Only update the stored face when the cursor is actually over a voxel face.
+	// When triggered from the panel (cursorFace == Max), keep the last face from a viewport click.
+	if (ctx.cursorFace != voxel::FaceNames::Max) {
+		_face = ctx.cursorFace;
+	}
+	_active = true;
+	return true;
+}
+
+void ExtrudeBrush::endBrush(BrushContext &) {
+	_active = false;
+	// _face is intentionally kept: the user sets it by clicking a voxel face in the viewport,
+	// then adjusts depth via the panel without needing to hover the viewport again.
+}
+
+bool ExtrudeBrush::active() const {
+	return _active;
+}
+
+voxel::Region ExtrudeBrush::calcRegion(const BrushContext &ctx) const {
+	return ctx.targetVolumeRegion;
+}
+
+void ExtrudeBrush::setDepth(int depth) {
+	_depth = depth;
+}
+
+void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+							const voxel::Region &) {
+	voxel::RawVolume *vol = wrapper.volume();
+	const voxel::Region &volRegion = vol->region();
+
+	// Restore all positions from a previous extrude in this session before re-applying.
+	// This makes depth changes fully reversible without touching the undo stack.
+	for (const HistoryEntry &entry : _history) {
+		if (vol->setVoxel(entry.pos, entry.original)) {
+			wrapper.addToDirtyRegion(entry.pos);
+		}
+	}
+	_history.clear();
+
+	if (_depth == 0 || _face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	const math::Axis axis = voxel::faceToAxis(_face);
+	const int axisIdx = math::getIndexForAxis(axis);
+	const int faceSign = voxel::isNegativeFace(_face) ? -1 : 1;
+
+	// Positive depth → extrude outward (along face normal, place voxels)
+	// Negative depth → carve inward   (opposite to face normal, erase voxels)
+	const bool carving = _depth < 0;
+	const int steps = glm::abs(_depth);
+	const int dirSign = carving ? -faceSign : faceSign;
+
+	glm::ivec3 dir(0);
+	dir[axisIdx] = dirSign;
+
+	// Save original voxel at pos (only once per session) then write the new voxel.
+	auto writeVoxel = [&](const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
+		if (!volRegion.containsPoint(pos)) {
+			return;
+		}
+		// Linear search — history is small enough that this is fine.
+		bool alreadySaved = false;
+		for (const HistoryEntry &entry : _history) {
+			if (entry.pos == pos) {
+				alreadySaved = true;
+				break;
+			}
+		}
+		if (!alreadySaved) {
+			_history.push_back({pos, vol->voxel(pos)});
+		}
+		if (vol->setVoxel(pos, newVoxel)) {
+			wrapper.addToDirtyRegion(pos);
+		}
+	};
+
+	const voxel::Voxel air{};
+
+	// Compute the bounding box of selected (FlagOutline) voxels so the loops below
+	// only scan the relevant sub-region instead of the full volume (which can be 256³+).
+	glm::ivec3 selLo(volRegion.getUpperCorner());
+	glm::ivec3 selHi(volRegion.getLowerCorner());
+	{
+		const glm::ivec3 &vlo = volRegion.getLowerCorner();
+		const glm::ivec3 &vhi = volRegion.getUpperCorner();
+		for (int z = vlo.z; z <= vhi.z; ++z) {
+			for (int y = vlo.y; y <= vhi.y; ++y) {
+				for (int x = vlo.x; x <= vhi.x; ++x) {
+					const voxel::Voxel v = vol->voxel(x, y, z);
+					if (!voxel::isAir(v.getMaterial()) && (v.getFlags() & voxel::FlagOutline)) {
+						selLo = glm::min(selLo, glm::ivec3(x, y, z));
+						selHi = glm::max(selHi, glm::ivec3(x, y, z));
+					}
+				}
+			}
+		}
+	}
+	if (selLo.x > selHi.x) {
+		return; // no selected voxels
+	}
+	const glm::ivec3 &lo = selLo;
+	const glm::ivec3 &hi = selHi;
+
+	// Carve or extrude each selected voxel along dir.
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				const voxel::Voxel v = vol->voxel(x, y, z);
+				if (voxel::isAir(v.getMaterial()) || !(v.getFlags() & voxel::FlagOutline)) {
+					continue;
+				}
+					// Carving starts at the selected voxel itself (step=0) so the surface layer
+					// becomes air. Extrusion starts at step=1 to place new voxels outward.
+				const int stepFirst = carving ? 0 : 1;
+				const int stepLast = carving ? steps - 1 : steps;
+				for (int step = stepFirst; step <= stepLast; ++step) {
+					const glm::ivec3 newPos(x + dir.x * step, y + dir.y * step, z + dir.z * step);
+					if (!volRegion.containsPoint(newPos)) {
+						break;
+					}
+					writeVoxel(newPos, carving ? air : ctx.cursorVoxel);
+				}
+			}
+		}
+	}
+
+	// Fill perpendicular side walls — only meaningful when adding material outward.
+	if (_fillSides && !carving) {
+		static constexpr int NumAxes = 3;
+		static constexpr int NumPerpOffsets = 4; // 2 perpendicular axes × 2 directions each
+		const int perp1 = (axisIdx + 1) % NumAxes;
+		const int perp2 = (axisIdx + 2) % NumAxes;
+
+		glm::ivec3 perpOffsets[NumPerpOffsets] = {};
+		perpOffsets[0][perp1] = 1;
+		perpOffsets[1][perp1] = -1;
+		perpOffsets[2][perp2] = 1;
+		perpOffsets[3][perp2] = -1;
+
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					const voxel::Voxel &sv = vol->voxel(x, y, z);
+					if (voxel::isAir(sv.getMaterial()) || !(sv.getFlags() & voxel::FlagOutline)) {
+						continue;
+					}
+					for (int pi = 0; pi < NumPerpOffsets; ++pi) {
+						const glm::ivec3 neighborPos(x + perpOffsets[pi].x,
+													 y + perpOffsets[pi].y,
+													 z + perpOffsets[pi].z);
+						if (volRegion.containsPoint(neighborPos)) {
+							const voxel::Voxel &nv = vol->voxel(neighborPos);
+							if (!voxel::isAir(nv.getMaterial()) && (nv.getFlags() & voxel::FlagOutline)) {
+								continue; // neighbor is also selected — no open edge
+							}
+						}
+						for (int step = 1; step <= steps; ++step) {
+							const glm::ivec3 sidePos(x + perpOffsets[pi].x + dir.x * step,
+													 y + perpOffsets[pi].y + dir.y * step,
+													 z + perpOffsets[pi].z + dir.z * step);
+							if (!volRegion.containsPoint(sidePos)) {
+								break;
+							}
+							writeVoxel(sidePos, ctx.cursorVoxel);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// For outward extrusion: remove any voxel that is now fully interior
+	// (all 6 axis-aligned neighbors solid and within bounds) — invisible voxels waste sparse storage.
+	// Running after fill-sides gives accurate neighbor state before pruning.
+	// Pruned selected (FlagOutline) voxels are saved to history so depth changes restore them.
+	if (!carving) {
+		static constexpr int NumNeighborAxes = 6;
+		static const glm::ivec3 neighborOffsets[NumNeighborAxes] = {
+			{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}};
+
+		auto isInterior = [&](const glm::ivec3 &pos) {
+			for (int ni = 0; ni < NumNeighborAxes; ++ni) {
+				const glm::ivec3 nb = pos + neighborOffsets[ni];
+				if (!volRegion.containsPoint(nb) || voxel::isAir(vol->voxel(nb).getMaterial())) {
+					return false;
+				}
+			}
+			return true;
+		};
+
+		// Prune newly placed voxels (already in history).
+		for (const HistoryEntry &entry : _history) {
+			const glm::ivec3 &pos = entry.pos;
+			if (!voxel::isAir(vol->voxel(pos).getMaterial()) && isInterior(pos)) {
+				vol->setVoxel(pos, air);
+				wrapper.addToDirtyRegion(pos);
+			}
+		}
+
+		// Prune original selected voxels that outward extrusion has now surrounded.
+		// Save them to history first so a depth change can restore them.
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					const voxel::Voxel &sv = vol->voxel(x, y, z);
+					if (voxel::isAir(sv.getMaterial()) || !(sv.getFlags() & voxel::FlagOutline)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					if (!isInterior(pos)) {
+						continue;
+					}
+					bool alreadySaved = false;
+					for (const HistoryEntry &e : _history) {
+						if (e.pos == pos) {
+							alreadySaved = true;
+							break;
+						}
+					}
+					if (!alreadySaved) {
+						_history.push_back({pos, sv});
+					}
+					vol->setVoxel(pos, air);
+					wrapper.addToDirtyRegion(pos);
+				}
+			}
+		}
+	}
+}
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
@@ -1,0 +1,71 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "Brush.h"
+#include "core/collection/DynamicArray.h"
+#include "voxel/Face.h"
+#include "voxel/Voxel.h"
+#include <glm/vec3.hpp>
+
+namespace voxedit {
+
+/**
+ * @brief Extrudes the current voxel selection along the clicked face normal
+ *
+ * In Place mode voxels are added outward from the selection by @c _depth steps.
+ * Optionally the perpendicular "side walls" are filled to keep the model manifold.
+ * In Erase mode the outermost selected layer facing the cursor is removed.
+ *
+ * @ingroup Brushes
+ */
+class ExtrudeBrush : public Brush {
+private:
+	using Super = Brush;
+	voxel::FaceNames _face = voxel::FaceNames::Max;
+	bool _active = false;
+	bool _fillSides = false;
+	int _depth = 0;
+	struct HistoryEntry {
+		glm::ivec3 pos;
+		voxel::Voxel original;
+	};
+	// For each position overwritten by the current extrude session, stores the original voxel.
+	// Cleared in reset() when the brush is deselected.
+	core::DynamicArray<HistoryEntry> _history;
+
+protected:
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region) override;
+
+public:
+	ExtrudeBrush()
+		: Super(BrushType::Extrude, ModifierType::Place, ModifierType::Place | ModifierType::Erase) {}
+	virtual ~ExtrudeBrush() = default;
+
+	void reset() override;
+	bool beginBrush(const BrushContext &ctx) override;
+	void endBrush(BrushContext &ctx) override;
+	bool active() const override;
+	voxel::Region calcRegion(const BrushContext &ctx) const override;
+
+	void setDepth(int depth);
+	int depth() const {
+		return _depth;
+	}
+
+	voxel::FaceNames face() const {
+		return _face;
+	}
+
+	void setFillSides(bool fill) {
+		_fillSides = fill;
+	}
+	bool fillSides() const {
+		return _fillSides;
+	}
+};
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
@@ -1,0 +1,333 @@
+/**
+ * @file
+ */
+
+#include "../modifier/brush/ExtrudeBrush.h"
+#include "app/tests/AbstractTest.h"
+#include "scenegraph/SceneGraph.h"
+#include "scenegraph/SceneGraphNode.h"
+#include "voxedit-util/modifier/ModifierType.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Voxel.h"
+
+namespace voxedit {
+
+// Direction convention:
+//   positive depth  → outward (along face normal, place voxels)
+//   negative depth  → inward  (opposite to face normal, erase voxels)
+//
+// Example: face = PositiveX (normal = +X), selected voxel at x=0
+//   depth=+1 → new voxel at x=+1  (outward)
+//   depth=-1 → voxel at x=-1 erased (inward / carve)
+//
+// FlagOutline is NOT transferred: selected voxels keep their flags unchanged,
+// newly placed voxels use cursorVoxel as-is.
+
+class ExtrudeBrushTest : public app::AbstractTest {
+protected:
+	static voxel::Voxel selectedVoxel(uint8_t color = 1) {
+		voxel::Voxel v = voxel::createVoxel(voxel::VoxelType::Generic, color);
+		v.setFlags(voxel::FlagOutline);
+		return v;
+	}
+
+	void executeExtrude(ExtrudeBrush &brush, scenegraph::SceneGraphNode &node, BrushContext &ctx,
+						ModifierType modifierType = ModifierType::Place) {
+		ctx.modifierType = modifierType;
+		scenegraph::SceneGraph sceneGraph;
+		ModifierVolumeWrapper wrapper(node, modifierType);
+		brush.preExecute(ctx, wrapper.volume());
+		brush.execute(sceneGraph, wrapper, ctx);
+		brush.endBrush(ctx);
+	}
+};
+
+// depth=-1, face=PositiveX → carves inward: voxel at x=-1 is erased
+TEST_F(ExtrudeBrushTest, testExtrudeCarveInward) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// Solid block filling x=-3..0; surface voxel at x=0 is selected.
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	for (int x = -3; x <= 0; ++x) {
+		volume.setVoxel(x, 0, 0, x == 0 ? selectedVoxel() : solid);
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(-1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Inward from PositiveX face, depth=-1: selected voxel at x=0 is erased (step=0)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Selected voxel at (0,0,0) should be carved";
+	// Next layer inward: untouched with depth=-1
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-1, 0, 0).getMaterial()))
+		<< "Voxel at (-1,0,0) should be untouched with depth=-1";
+	// Outward side: nothing added
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 0, 0).getMaterial()))
+		<< "No voxel should be placed outward at (1,0,0)";
+
+	brush.shutdown();
+}
+
+// depth=+1, face=PositiveX → new voxel placed outward at x=+1
+TEST_F(ExtrudeBrushTest, testExtrudePlaceOutward) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Outward from PositiveX face: x+1
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Voxel should be placed outward at (1,0,0)";
+	// Inward side: nothing placed
+	EXPECT_TRUE(voxel::isAir(volume.voxel(-1, 0, 0).getMaterial()))
+		<< "No voxel should be placed inward at (-1,0,0)";
+
+	brush.shutdown();
+}
+
+// depth=-2: two steps carved inward
+TEST_F(ExtrudeBrushTest, testExtrudeCarveDepth2Inward) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	for (int x = -5; x <= 0; ++x) {
+		volume.setVoxel(x, 0, 0, x == 0 ? selectedVoxel() : solid);
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(-2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// depth=-2: step=0 erases (0,0,0), step=1 erases (-1,0,0)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial())) << "Selected voxel at (0,0,0) should be carved";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(-1, 0, 0).getMaterial())) << "Voxel at (-1,0,0) should be carved";
+	// Third layer untouched
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-2, 0, 0).getMaterial())) << "Voxel at (-2,0,0) should be untouched";
+
+	brush.shutdown();
+}
+
+// Non-selected voxels must not be carved or extruded
+TEST_F(ExtrudeBrushTest, testExtrudeOnlySelected) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+	volume.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1)); // no FlagOutline
+	// Solid material behind the selection to carve
+	volume.setVoxel(-1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(-1); // inward for PositiveX → x=-1
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// depth=-1: selected voxel (0,0,0) is erased; (-1,0,0) is untouched
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Selected voxel at (0,0,0) should be carved";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-1, 0, 0).getMaterial()))
+		<< "Voxel behind selection (-1,0,0) should be untouched with depth=-1";
+	// Non-selected voxel at (0,1,0) must not be touched
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Non-selected voxel (0,1,0) itself must be untouched";
+
+	brush.shutdown();
+}
+
+// After push inward (+), push outward (-) should restore carved voxel and add outward
+TEST_F(ExtrudeBrushTest, testExtrudePushThenPull) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// Solid block behind the selection so inward carve has material to remove
+	volume.setVoxel(-1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Inward carve (-1): selected voxel (0,0,0) is erased
+	brush.setDepth(-1);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial())) << "Selected voxel at (0,0,0) should be carved";
+
+	// Push outward (+1) from same selection: history restores (0,0,0), places at x=+1
+	brush.setDepth(1);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Restored selected voxel at (0,0,0) after direction reversal";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Outward voxel at (1,0,0) expected";
+
+	brush.shutdown();
+}
+
+// Fill sides: outward push (-) on 3x3 face should add side caps
+TEST_F(ExtrudeBrushTest, testExtrudeFillSidesOutward) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			volume.setVoxel(x, y, 0, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(1); // outward for PositiveZ → z+1
+	brush.setFillSides(true);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Outward slab at z=1
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Outward voxel at (0,0,1) expected";
+	// Side caps adjacent to slab
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 1).getMaterial())) << "Side cap at (2,0,1) expected";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-2, 0, 1).getMaterial())) << "Side cap at (-2,0,1) expected";
+
+	brush.shutdown();
+}
+
+// Without fill sides: no side caps
+TEST_F(ExtrudeBrushTest, testExtrudeNoFillSides) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			volume.setVoxel(x, y, 0, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(1); // outward
+	brush.setFillSides(false);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Outward voxel at (0,0,1) expected";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 0, 1).getMaterial())) << "No side cap at (2,0,1) expected";
+
+	brush.shutdown();
+}
+
+// beginBrush with no valid face succeeds but does not update the stored face
+TEST_F(ExtrudeBrushTest, testBeginBrushNoFace) {
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = voxel::Region(0, 5);
+	ctx.cursorFace = voxel::FaceNames::Max;
+
+	EXPECT_TRUE(brush.beginBrush(ctx)) << "beginBrush with no face should still succeed";
+	EXPECT_EQ(brush.face(), voxel::FaceNames::Max) << "Face should remain Max when beginBrush called with Max";
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+// Double beginBrush without endBrush fails
+TEST_F(ExtrudeBrushTest, testBeginBrushDoubleBegin) {
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = voxel::Region(0, 5);
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_FALSE(brush.beginBrush(ctx)) << "Second beginBrush without endBrush should fail";
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+// endBrush resets active state but preserves depth and face (for panel usage)
+TEST_F(ExtrudeBrushTest, testEndBrushResetsState) {
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(3);
+
+	BrushContext ctx;
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_TRUE(brush.active());
+	brush.endBrush(ctx);
+
+	EXPECT_FALSE(brush.active());
+	EXPECT_EQ(brush.depth(), 3) << "Depth should be preserved across endBrush";
+	EXPECT_EQ(brush.face(), voxel::FaceNames::PositiveX) << "Face should be preserved across endBrush for panel +/- usage";
+	// beginBrush should work again after endBrush
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+} // namespace voxedit


### PR DESCRIPTION
● ## Summary  

  Adds a new **Extrude brush** that works on the current voxel selection to  push geometry outward or carve it inward along a chosen face direction.

  ### How it works

  1. Use the **Select brush** to mark voxels (sets `FlagOutline`)
  2. Switch to the **Extrude brush** and click a voxel face in the viewport to set the extrusion direction — displayed in the brush panel as e.g. `PositiveX`
  3. Adjust depth with the **+/−** buttons or the slider:
     - **positive** → extrude outward along the face normal (place voxels)
     - **negative** → carve inward starting from the selected surface layer (erase voxels)
  4. Optional **Fill sides** checkbox adds perpendicular side walls to keep the mesh manifold (off by default)

  ### Session undo

  Depth changes are fully reversible within a session without touching the undo stack. Every position written is saved to an in-brush history list; each `generate()` call restores that list first, then re-applies from scratch.
  Switching away from the brush discards the history.

  ### Sparse storage

  After outward extrusion, voxels that are fully interior (all 6 axis-aligned neighbours solid) are pruned — both newly placed voxels and original selected voxels that the extrusion has surrounded. This keeps the sparse voxel tree lean.

  ### Performance

  The loops only scan the bounding box of the selected voxels, not the full volume, so performance scales with selection size rather than total volume size.

  ### Integration

  - `brushextrude` command registered automatically (same mechanism as all other brushes)
  - Toolbar button added via the existing `BrushType::Max` loop (`ICON_LC_EXPAND`)
  - `Modifier::beginBrushFromPanel()` ensures panel +/− presses never overwrite the stored face direction set by a viewport click

  ## Test plan

  - [ ] Select a group of voxels, switch to Extrude brush, click a face → panel shows direction
  - [ ] Press `+` repeatedly → voxels grow outward, interior voxels pruned
  - [ ] Press `−` repeatedly → surface layer carved inward step by step
  - [ ] Press `+` then `−` back to 0 → model identical to start
  - [ ] Enable Fill sides, extrude → side walls appear; disable → no side walls
  - [ ] Switch to another brush and back → depth resets to 0, face resets to Max
  - [ ] `brushextrude` command activates the brush (bindable in keybindings)
  - [ ] Unit tests: `cmake --build build --target voxedit-util-test`