### PR TITLE
VOXEDIT: add transform brush for selected voxels

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -26,6 +26,7 @@
 #include "voxedit-util/modifier/brush/NormalBrush.h"
 #include "voxedit-util/modifier/brush/ShapeBrush.h"
 #include "voxedit-util/modifier/brush/ExtrudeBrush.h"
+#include "voxedit-util/modifier/brush/TransformBrush.h"
 #include "voxedit-util/modifier/brush/StampBrush.h"
 #include "voxedit-util/modifier/brush/TextureBrush.h"
 #include "voxel/Face.h"
@@ -44,7 +45,7 @@ static constexpr const char *BrushTypeIcons[] = {
 	ICON_LC_PIPETTE,	ICON_LC_BOXES,	   ICON_LC_GROUP,
 	ICON_LC_STAMP,		ICON_LC_PEN_LINE,  ICON_LC_FOOTPRINTS,
 	ICON_LC_PAINTBRUSH, ICON_LC_TEXT_WRAP, ICON_LC_SQUARE_DASHED_MOUSE_POINTER,
-	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT, ICON_LC_EXPAND};
+	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT, ICON_LC_EXPAND, ICON_LC_MOVE_3D};
 static_assert(lengthof(BrushTypeIcons) == (int)BrushType::Max, "BrushTypeIcons size mismatch");
 
 void BrushPanel::init() {
@@ -789,6 +790,155 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 	}
 }
 
+void BrushPanel::executeTransformBrush() {
+	Modifier &modifier = _sceneMgr->modifier();
+	if (!modifier.beginBrushFromPanel()) {
+		return;
+	}
+	_sceneMgr->nodeForeachGroup([&](int nodeId) {
+		if (scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId)) {
+			if (!node->visible()) {
+				return;
+			}
+			auto callback = [&](const voxel::Region &region, ModifierType type, SceneModifiedFlags flags) {
+				_sceneMgr->modified(nodeId, region, flags);
+			};
+			modifier.execute(_sceneMgr->sceneGraph(), *node, callback);
+		}
+	});
+	modifier.endBrush();
+}
+
+void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &listener) {
+	Modifier &modifier = _sceneMgr->modifier();
+	TransformBrush &brush = modifier.transformBrush();
+
+	const scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(_sceneMgr->sceneGraph().activeNode());
+	if (!node || !node->hasSelection()) {
+		ImGui::TextWrappedUnformatted(_("No selection active - use the Select brush first"));
+		return;
+	}
+
+	int modeInt = (int)brush.transformMode();
+	const char *TransformModeUIStr[(int)TransformMode::Max];
+	for (int idx = 0; idx < (int)TransformMode::Max; ++idx) {
+		TransformModeUIStr[idx] = C_("Transform Modes", TransformModeStr[idx]);
+	}
+
+	if (ImGui::Combo(_("Transform mode"), &modeInt, TransformModeUIStr, (int)TransformMode::Max)) {
+		brush.setTransformMode((TransformMode)modeInt);
+	}
+
+	const float btnW = ImGui::GetFrameHeight();
+	const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+
+	// Callback that syncs current UI values to the brush before executing the transform.
+	// This is necessary because the brush parameters must be up-to-date before generate() runs.
+	auto syncAndExecute = [&]() {
+		switch (brush.transformMode()) {
+		case TransformMode::Move:
+			brush.setMoveOffset(_transformMoveOffset);
+			break;
+		case TransformMode::Shear:
+			brush.setShearOffset(_transformShearOffset);
+			break;
+		case TransformMode::Scale:
+			brush.setScale(_transformScale);
+			break;
+		case TransformMode::Rotate:
+			brush.setRotationDegrees(_transformRotation);
+			break;
+		default:
+			break;
+		}
+		executeTransformBrush();
+	};
+
+	auto intSlider = [&](const char *label, const char *id, int *val, int lo, int hi) {
+		ImGui::TextUnformatted(label);
+		ImGui::PushID(id);
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			*val = glm::max(*val - 1, lo);
+			syncAndExecute();
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("", val, lo, hi)) {
+		}
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			syncAndExecute();
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			*val = glm::min(*val + 1, hi);
+			syncAndExecute();
+		}
+		ImGui::PopID();
+	};
+
+	auto floatSlider = [&](const char *label, const char *id, float *val, float lo, float hi, const char *fmt = "%.1f") {
+		ImGui::TextUnformatted(label);
+		ImGui::PushID(id);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+		if (ImGui::SliderFloat("", val, lo, hi, fmt)) {
+		}
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			syncAndExecute();
+		}
+		ImGui::PopID();
+	};
+
+	switch (brush.transformMode()) {
+	case TransformMode::Move: {
+		_transformMoveOffset = brush.moveOffset();
+		intSlider(_("X offset"), "##move_x", &_transformMoveOffset.x, -TransformBrush::MaxMoveOffset, TransformBrush::MaxMoveOffset);
+		intSlider(_("Y offset"), "##move_y", &_transformMoveOffset.y, -TransformBrush::MaxMoveOffset, TransformBrush::MaxMoveOffset);
+		intSlider(_("Z offset"), "##move_z", &_transformMoveOffset.z, -TransformBrush::MaxMoveOffset, TransformBrush::MaxMoveOffset);
+		brush.setMoveOffset(_transformMoveOffset);
+		break;
+	}
+
+	case TransformMode::Shear: {
+		_transformShearOffset = brush.shearOffset();
+		intSlider(_("X shear"), "##shear_x", &_transformShearOffset.x, -TransformBrush::MaxShearOffset, TransformBrush::MaxShearOffset);
+		intSlider(_("Y shear"), "##shear_y", &_transformShearOffset.y, -TransformBrush::MaxShearOffset, TransformBrush::MaxShearOffset);
+		intSlider(_("Z shear"), "##shear_z", &_transformShearOffset.z, -TransformBrush::MaxShearOffset, TransformBrush::MaxShearOffset);
+		brush.setShearOffset(_transformShearOffset);
+		break;
+	}
+
+	case TransformMode::Scale: {
+		_transformScale = brush.scale();
+		floatSlider(_("X scale"), "##scale_x", &_transformScale.x, 0.01f, 4.0f, "%.2f");
+		floatSlider(_("Y scale"), "##scale_y", &_transformScale.y, 0.01f, 4.0f, "%.2f");
+		floatSlider(_("Z scale"), "##scale_z", &_transformScale.z, 0.01f, 4.0f, "%.2f");
+		brush.setScale(_transformScale);
+
+		int samplingInt = (int)brush.scaleSampling();
+		const char *SamplingUIStr[(int)ScaleSampling::Max];
+		for (int idx = 0; idx < (int)ScaleSampling::Max; ++idx) {
+			SamplingUIStr[idx] = C_("Scale Sampling", ScaleSamplingStr[idx]);
+		}
+		if (ImGui::Combo(_("Sampling"), &samplingInt, SamplingUIStr, (int)ScaleSampling::Max)) {
+			brush.setScaleSampling((ScaleSampling)samplingInt);
+		}
+		break;
+	}
+
+	case TransformMode::Rotate: {
+		_transformRotation = brush.rotationDegrees();
+		floatSlider(_("X rotation"), "##rot_x", &_transformRotation.x, -360.0f, 360.0f, "%.1f");
+		floatSlider(_("Y rotation"), "##rot_y", &_transformRotation.y, -360.0f, 360.0f, "%.1f");
+		floatSlider(_("Z rotation"), "##rot_z", &_transformRotation.z, -360.0f, 360.0f, "%.1f");
+		brush.setRotationDegrees(_transformRotation);
+		break;
+	}
+
+	default:
+		break;
+	}
+}
+
 void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 	const Modifier &modifier = _sceneMgr->modifier();
 	const BrushType brushType = modifier.brushType();
@@ -815,6 +965,8 @@ void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 			updateNormalBrushPanel(listener);
 		} else if (brushType == BrushType::Extrude) {
 			updateExtrudeBrushPanel(listener);
+		} else if (brushType == BrushType::Transform) {
+			updateTransformBrushPanel(listener);
 		}
 	}
 

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
@@ -10,6 +10,7 @@
 #include "scenegraph/SceneGraphNode.h"
 #include "ui/Panel.h"
 #include "video/TexturePool.h"
+#include <glm/vec3.hpp>
 
 namespace command {
 struct CommandExecutionListener;
@@ -33,6 +34,12 @@ private:
 	core::VarPtr _renderNormals;
 	core::VarPtr _viewMode;
 
+	// Cached transform UI values - synced to brush before execute
+	glm::ivec3 _transformMoveOffset{0};
+	glm::ivec3 _transformShearOffset{0};
+	glm::vec3 _transformScale{1.0f};
+	glm::vec3 _transformRotation{0.0f};
+
 	void createPopups(command::CommandExecutionListener &listener);
 
 	void addModifiers(command::CommandExecutionListener &listener);
@@ -54,6 +61,8 @@ private:
 	void updateNormalBrushPanel(command::CommandExecutionListener &listener);
 	void updateExtrudeBrushPanel(command::CommandExecutionListener &listener);
 	void executeExtrudeBrush();
+	void updateTransformBrushPanel(command::CommandExecutionListener &listener);
+	void executeTransformBrush();
 
 	void addBrushClampingOption(Brush &brush);
 	void aabbBrushOptions(command::CommandExecutionListener &listener, AABBBrush &brush);

--- a/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
+++ b/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRCS
 	modifier/brush/TextBrush.cpp modifier/brush/TextBrush.h
 	modifier/brush/SelectBrush.cpp modifier/brush/SelectBrush.h
 	modifier/brush/ExtrudeBrush.cpp modifier/brush/ExtrudeBrush.h
+	modifier/brush/TransformBrush.cpp modifier/brush/TransformBrush.h
 	modifier/brush/TextureBrush.cpp modifier/brush/TextureBrush.h
 
 	modifier/IModifierRenderer.h
@@ -101,6 +102,7 @@ set(TEST_SRCS
 	tests/AbstractBrushTest.cpp tests/AbstractBrushTest.h
 	tests/ClipboardTest.cpp
 	tests/ExtrudeBrushTest.cpp
+	tests/TransformBrushTest.cpp
 	tests/LineBrushTest.cpp
 	tests/ModifierTest.cpp
 	tests/ModifierVolumeWrapperTest.cpp

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -43,6 +43,7 @@ Modifier::Modifier(SceneManager *sceneMgr, const ModifierRendererPtr &modifierRe
 	_brushes.push_back(&_textureBrush);
 	_brushes.push_back(&_normalBrush);
 	_brushes.push_back(&_extrudeBrush);
+	_brushes.push_back(&_transformBrush);
 	core_assert(_brushes.size() == (int)BrushType::Max - 1);
 }
 
@@ -360,7 +361,9 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	}
 	_brushContext.cursorVoxel = voxel;
 	brush->execute(sceneGraph, wrapper, _brushContext);
-	wrapper.growSelectionToNewVoxels();
+	if (brush->type() != BrushType::Transform) {
+		wrapper.growSelectionToNewVoxels();
+	}
 	const voxel::Region &modifiedRegion = wrapper.dirtyRegion();
 	if (modifiedRegion.isValid()) {
 		voxel::logRegion("Dirty region", modifiedRegion);
@@ -461,6 +464,9 @@ BrushType Modifier::setBrushType(BrushType type) {
 	}
 	if (_brushType == BrushType::Extrude) {
 		_extrudeBrush.reset();
+	}
+	if (_brushType == BrushType::Transform) {
+		_transformBrush.reset();
 	}
 	return _brushType;
 }

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
@@ -16,6 +16,7 @@
 #include "brush/PlaneBrush.h"
 #include "brush/ExtrudeBrush.h"
 #include "brush/SelectBrush.h"
+#include "brush/TransformBrush.h"
 #include "brush/ShapeBrush.h"
 #include "brush/StampBrush.h"
 #include "brush/TextBrush.h"
@@ -97,6 +98,7 @@ protected:
 	TextureBrush _textureBrush;
 	NormalBrush _normalBrush;
 	ExtrudeBrush _extrudeBrush;
+	TransformBrush _transformBrush;
 
 	ModifierButton _actionExecuteButton;
 	ModifierButton _deleteExecuteButton;
@@ -224,6 +226,7 @@ public:
 	TextureBrush &textureBrush();
 	NormalBrush &normalBrush();
 	ExtrudeBrush &extrudeBrush();
+	TransformBrush &transformBrush();
 	const BrushContext &brushContext() const;
 
 	/**
@@ -335,6 +338,10 @@ inline TextureBrush &Modifier::textureBrush() {
 
 inline ExtrudeBrush &Modifier::extrudeBrush() {
 	return _extrudeBrush;
+}
+
+inline TransformBrush &Modifier::transformBrush() {
+	return _transformBrush;
 }
 
 inline int Modifier::gridResolution() const {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
@@ -13,13 +13,14 @@ namespace voxedit {
  *
  * Each brush type provides a different way to place, modify, or select voxels in the scene.
  */
-enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Extrude, Max };
+enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Extrude, Transform, Max };
 
 /**
  * @brief String representation of brush types for UI display and command registration
  */
-static constexpr const char *BrushTypeStr[] = {"None",  "Shape", "Plane",   "Stamp",  "Line",   "Path",
-											   "Paint", "Text",  "Select",  "Texture", "Normal", "Extrude"};
+static constexpr const char *BrushTypeStr[] = {"None",  "Shape", "Plane",   "Stamp",    "Line",   "Path",
+											   "Paint", "Text",  "Select",  "Texture",  "Normal", "Extrude",
+											   "Transform"};
 static_assert(lengthof(BrushTypeStr) == (int)BrushType::Max, "BrushTypeStr size mismatch");
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
@@ -1,0 +1,490 @@
+/**
+ * @file
+ */
+
+#include "TransformBrush.h"
+#include "core/collection/DynamicSet.h"
+#include "math/Axis.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/Connectivity.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Region.h"
+#include "voxel/Voxel.h"
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/rotate_vector.hpp>
+#include <glm/trigonometric.hpp>
+#include <glm/common.hpp>
+
+namespace voxedit {
+
+using PositionSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+
+void TransformBrush::reset() {
+	Super::reset();
+	_active = false;
+	_hasSnapshot = false;
+	_snapshot.clear();
+	_snapshotLookup.clear();
+	_history.clear();
+	_historyPositions.clear();
+	_snapshotRegion = voxel::Region::InvalidRegion;
+	_snapshotCenter = glm::vec3(0.0f);
+	_moveOffset = glm::ivec3(0);
+	_shearOffset = glm::ivec3(0);
+	_scale = glm::vec3(1.0f);
+	_rotationDegrees = glm::vec3(0.0f);
+	_transformMode = TransformMode::Move;
+	_scaleSampling = ScaleSampling::Nearest;
+}
+
+bool TransformBrush::beginBrush(const BrushContext &ctx) {
+	if (_active) {
+		return false;
+	}
+	_active = true;
+	return true;
+}
+
+void TransformBrush::endBrush(BrushContext &) {
+	_active = false;
+}
+
+bool TransformBrush::active() const {
+	return _active;
+}
+
+voxel::Region TransformBrush::calcRegion(const BrushContext &ctx) const {
+	return ctx.targetVolumeRegion;
+}
+
+void TransformBrush::captureSnapshot(voxel::RawVolume *volume, const voxel::Region &volRegion) {
+	_snapshot.clear();
+	_snapshotLookup.clear();
+	glm::ivec3 selLo(volRegion.getUpperCorner());
+	glm::ivec3 selHi(volRegion.getLowerCorner());
+
+	const glm::ivec3 &regionLo = volRegion.getLowerCorner();
+	const glm::ivec3 &regionHi = volRegion.getUpperCorner();
+	for (int z = regionLo.z; z <= regionHi.z; ++z) {
+		for (int y = regionLo.y; y <= regionHi.y; ++y) {
+			for (int x = regionLo.x; x <= regionHi.x; ++x) {
+				const voxel::Voxel currentVoxel = volume->voxel(x, y, z);
+				if (voxel::isAir(currentVoxel.getMaterial())) {
+					continue;
+				}
+				if (!(currentVoxel.getFlags() & voxel::FlagOutline)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				const int index = (int)_snapshot.size();
+				_snapshot.push_back({pos, currentVoxel});
+				_snapshotLookup.put(pos, index);
+				selLo = glm::min(selLo, pos);
+				selHi = glm::max(selHi, pos);
+			}
+		}
+	}
+
+	if (_snapshot.empty()) {
+		_hasSnapshot = false;
+		return;
+	}
+
+	_snapshotRegion = voxel::Region(selLo, selHi);
+	_snapshotCenter = glm::vec3(selLo + selHi) * 0.5f;
+	_hasSnapshot = true;
+}
+
+void TransformBrush::restoreHistory(voxel::RawVolume *volume, ModifierVolumeWrapper &wrapper) {
+	for (const HistoryEntry &entry : _history) {
+		if (volume->setVoxel(entry.pos, entry.original)) {
+			wrapper.addToDirtyRegion(entry.pos);
+		}
+	}
+	_history.clear();
+	_historyPositions.clear();
+}
+
+glm::ivec3 TransformBrush::transformPosition(const glm::ivec3 &pos) const {
+	const glm::vec3 center = _snapshotCenter;
+	glm::vec3 result(pos);
+
+	switch (_transformMode) {
+	case TransformMode::Move:
+		result += glm::vec3(_moveOffset);
+		break;
+
+	case TransformMode::Shear: {
+		// Shear transform: each slice along a perpendicular axis shifts proportionally
+		// to its distance from the center — like pushing the top of a bread stack sideways.
+		// X shear: each Y-layer shifts in X (top goes +X, bottom goes -X)
+		// Y shear: each Z-layer shifts in Y (front goes +Y, back goes -Y)
+		// Z shear: each X-layer shifts in Z (right goes +Z, left goes -Z)
+		const glm::vec3 relative = result - center;
+		const glm::vec3 halfSize = glm::vec3(_snapshotRegion.getDimensionsInVoxels()) * 0.5f;
+
+		if (halfSize.y > 0.0f && _shearOffset.x != 0) {
+			result.x += (relative.y / halfSize.y) * (float)_shearOffset.x;
+		}
+		if (halfSize.z > 0.0f && _shearOffset.y != 0) {
+			result.y += (relative.z / halfSize.z) * (float)_shearOffset.y;
+		}
+		if (halfSize.x > 0.0f && _shearOffset.z != 0) {
+			result.z += (relative.x / halfSize.x) * (float)_shearOffset.z;
+		}
+		break;
+	}
+
+	case TransformMode::Scale: {
+		const glm::vec3 relative = result - center;
+		result = center + relative * _scale;
+		break;
+	}
+
+	case TransformMode::Rotate: {
+		glm::vec3 relative = result - center;
+		if (_rotationDegrees.x != 0.0f) {
+			relative = glm::rotateX(relative, glm::radians(_rotationDegrees.x));
+		}
+		if (_rotationDegrees.y != 0.0f) {
+			relative = glm::rotateY(relative, glm::radians(_rotationDegrees.y));
+		}
+		if (_rotationDegrees.z != 0.0f) {
+			relative = glm::rotateZ(relative, glm::radians(_rotationDegrees.z));
+		}
+		result = center + relative;
+		break;
+	}
+
+	default:
+		break;
+	}
+
+	return glm::ivec3(glm::round(result));
+}
+
+glm::vec3 TransformBrush::inverseTransformPosition(const glm::ivec3 &pos) const {
+	const glm::vec3 center = _snapshotCenter;
+	glm::vec3 result(pos);
+
+	switch (_transformMode) {
+	case TransformMode::Scale: {
+		// Inverse of: result = center + relative * scale
+		const glm::vec3 relative = result - center;
+		result = center + relative / _scale;
+		break;
+	}
+
+	case TransformMode::Rotate: {
+		// Inverse rotation: apply in reverse order with negated angles
+		glm::vec3 relative = result - center;
+		if (_rotationDegrees.z != 0.0f) {
+			relative = glm::rotateZ(relative, glm::radians(-_rotationDegrees.z));
+		}
+		if (_rotationDegrees.y != 0.0f) {
+			relative = glm::rotateY(relative, glm::radians(-_rotationDegrees.y));
+		}
+		if (_rotationDegrees.x != 0.0f) {
+			relative = glm::rotateX(relative, glm::radians(-_rotationDegrees.x));
+		}
+		result = center + relative;
+		break;
+	}
+
+	default:
+		break;
+	}
+
+	return result;
+}
+
+void TransformBrush::saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos) {
+	if (_historyPositions.has(pos)) {
+		return;
+	}
+	_historyPositions.insert(pos);
+	_history.push_back({pos, vol->voxel(pos)});
+}
+
+void TransformBrush::writeVoxel(voxel::RawVolume *vol, ModifierVolumeWrapper &wrapper,
+								const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
+	if (!vol->region().containsPoint(pos)) {
+		return;
+	}
+	saveToHistory(vol, pos);
+	if (vol->setVoxel(pos, newVoxel)) {
+		wrapper.addToDirtyRegion(pos);
+	}
+}
+
+const TransformBrush::VoxelEntry *TransformBrush::findNearestSnapshotVoxel(const glm::vec3 &srcPos) const {
+	// Half-diagonal of a unit cube — maximum distance for nearest-neighbor sampling
+	static constexpr float MaxSampleDistance = 0.87f;
+
+	const glm::ivec3 rounded = glm::ivec3(glm::round(srcPos));
+	// Fast path: exact match via hash lookup
+	auto iter = _snapshotLookup.find(rounded);
+	if (iter != _snapshotLookup.end()) {
+		return &_snapshot[iter->value];
+	}
+
+	// Check immediate neighbors (3x3x3 cube around the rounded position)
+	const VoxelEntry *best = nullptr;
+	float bestDist = MaxSampleDistance + 1.0f;
+	for (int dz = -1; dz <= 1; ++dz) {
+		for (int dy = -1; dy <= 1; ++dy) {
+			for (int dx = -1; dx <= 1; ++dx) {
+				const glm::ivec3 neighbor(rounded.x + dx, rounded.y + dy, rounded.z + dz);
+				auto neighborIter = _snapshotLookup.find(neighbor);
+				if (neighborIter == _snapshotLookup.end()) {
+					continue;
+				}
+				const float dist = glm::length(glm::vec3(neighbor) - srcPos);
+				if (dist < bestDist) {
+					bestDist = dist;
+					best = &_snapshot[neighborIter->value];
+				}
+			}
+		}
+	}
+
+	if (best && bestDist <= MaxSampleDistance) {
+		return best;
+	}
+	return nullptr;
+}
+
+const TransformBrush::VoxelEntry *TransformBrush::findLinearSnapshotVoxel(const glm::vec3 &srcPos) const {
+	// Trilinear-style sampling for voxels: check the 2x2x2 cell containing srcPos.
+	// Since voxel materials are discrete, we pick the most common non-air material
+	// (majority vote) among the 8 corners of the cell.
+	const glm::ivec3 base = glm::ivec3(glm::floor(srcPos));
+	static constexpr int CellSize = 2;
+	static constexpr int CellCorners = 8;
+
+	// Count occurrences of each material in the 2x2x2 cell
+	struct MaterialCount {
+		const VoxelEntry *entry;
+		int count;
+	};
+	static constexpr int MaxMaterials = CellCorners;
+	MaterialCount materials[MaxMaterials] = {};
+	int materialCount = 0;
+
+	for (int dz = 0; dz < CellSize; ++dz) {
+		for (int dy = 0; dy < CellSize; ++dy) {
+			for (int dx = 0; dx < CellSize; ++dx) {
+				const glm::ivec3 pos(base.x + dx, base.y + dy, base.z + dz);
+				auto iter = _snapshotLookup.find(pos);
+				if (iter == _snapshotLookup.end()) {
+					continue;
+				}
+				const VoxelEntry *entry = &_snapshot[iter->value];
+				const uint8_t color = entry->voxel.getColor();
+				bool found = false;
+				for (int mi = 0; mi < materialCount; ++mi) {
+					if (materials[mi].entry->voxel.getColor() == color) {
+						materials[mi].count++;
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					materials[materialCount++] = {entry, 1};
+				}
+			}
+		}
+	}
+
+	if (materialCount == 0) {
+		return nullptr;
+	}
+
+	// Return the material with the highest count
+	int bestIdx = 0;
+	for (int mi = 1; mi < materialCount; ++mi) {
+		if (materials[mi].count > materials[bestIdx].count) {
+			bestIdx = mi;
+		}
+	}
+	return materials[bestIdx].entry;
+}
+
+const TransformBrush::VoxelEntry *TransformBrush::findCubicSnapshotVoxel(const glm::vec3 &srcPos) const {
+	// Cubic sampling: check a 4x4x4 neighborhood centered on srcPos.
+	// Each source voxel votes with a weight inversely proportional to its distance.
+	// The material with the highest total weight wins.
+	static constexpr int HalfExtent = 2;
+	static constexpr float MaxCubicDistance = 3.5f;
+
+	const glm::ivec3 center = glm::ivec3(glm::round(srcPos));
+
+	struct MaterialWeight {
+		const VoxelEntry *entry;
+		float weight;
+	};
+	static constexpr int MaxMaterials = 64; // 4x4x4 worst case
+	MaterialWeight materials[MaxMaterials] = {};
+	int materialCount = 0;
+
+	for (int dz = -HalfExtent + 1; dz <= HalfExtent; ++dz) {
+		for (int dy = -HalfExtent + 1; dy <= HalfExtent; ++dy) {
+			for (int dx = -HalfExtent + 1; dx <= HalfExtent; ++dx) {
+				const glm::ivec3 pos(center.x + dx, center.y + dy, center.z + dz);
+				auto iter = _snapshotLookup.find(pos);
+				if (iter == _snapshotLookup.end()) {
+					continue;
+				}
+				const float dist = glm::length(glm::vec3(pos) - srcPos);
+				if (dist > MaxCubicDistance) {
+					continue;
+				}
+				// Weight: inverse distance (closer voxels contribute more)
+				const float weight = 1.0f / (dist + 0.001f);
+				const VoxelEntry *entry = &_snapshot[iter->value];
+				const uint8_t color = entry->voxel.getColor();
+				bool found = false;
+				for (int mi = 0; mi < materialCount; ++mi) {
+					if (materials[mi].entry->voxel.getColor() == color) {
+						materials[mi].weight += weight;
+						found = true;
+						break;
+					}
+				}
+				if (!found && materialCount < MaxMaterials) {
+					materials[materialCount++] = {entry, weight};
+				}
+			}
+		}
+	}
+
+	if (materialCount == 0) {
+		return nullptr;
+	}
+
+	// Return the material with the highest accumulated weight
+	int bestIdx = 0;
+	for (int mi = 1; mi < materialCount; ++mi) {
+		if (materials[mi].weight > materials[bestIdx].weight) {
+			bestIdx = mi;
+		}
+	}
+	return materials[bestIdx].entry;
+}
+
+const TransformBrush::VoxelEntry *TransformBrush::sampleSnapshotVoxel(const glm::vec3 &srcPos) const {
+	switch (_scaleSampling) {
+	case ScaleSampling::Linear:
+		return findLinearSnapshotVoxel(srcPos);
+	case ScaleSampling::Cubic:
+		return findCubicSnapshotVoxel(srcPos);
+	case ScaleSampling::Nearest:
+	default:
+		return findNearestSnapshotVoxel(srcPos);
+	}
+}
+
+void TransformBrush::applyTransform(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
+	voxel::RawVolume *vol = wrapper.volume();
+	const voxel::Region &volRegion = vol->region();
+	const voxel::Voxel air;
+
+	// Erase all original selected voxels (saving to history)
+	for (const VoxelEntry &entry : _snapshot) {
+		if (volRegion.containsPoint(entry.pos)) {
+			writeVoxel(vol, wrapper, entry.pos, air);
+		}
+	}
+
+	const bool useInverseMapping = (_transformMode == TransformMode::Scale ||
+									_transformMode == TransformMode::Rotate);
+
+	if (useInverseMapping) {
+		// Inverse mapping: compute the destination bounding box by transforming all
+		// 8 corners of the snapshot region, then iterate every destination position
+		// and inverse-map back into the source to find the voxel that fills it.
+		const glm::ivec3 &srcLo = _snapshotRegion.getLowerCorner();
+		const glm::ivec3 &srcHi = _snapshotRegion.getUpperCorner();
+		glm::ivec3 dstLo(INT_MAX);
+		glm::ivec3 dstHi(INT_MIN);
+
+		static constexpr int NumCorners = 8;
+		for (int corner = 0; corner < NumCorners; ++corner) {
+			const glm::ivec3 cornerPos(
+				(corner & 1) ? srcHi.x : srcLo.x,
+				(corner & 2) ? srcHi.y : srcLo.y,
+				(corner & 4) ? srcHi.z : srcLo.z);
+			const glm::ivec3 transformed = transformPosition(cornerPos);
+			dstLo = glm::min(dstLo, transformed);
+			dstHi = glm::max(dstHi, transformed);
+		}
+
+		// Clamp to volume bounds
+		dstLo = glm::max(dstLo, volRegion.getLowerCorner());
+		dstHi = glm::min(dstHi, volRegion.getUpperCorner());
+
+		for (int dz = dstLo.z; dz <= dstHi.z; ++dz) {
+			for (int dy = dstLo.y; dy <= dstHi.y; ++dy) {
+				for (int dx = dstLo.x; dx <= dstHi.x; ++dx) {
+					const glm::ivec3 dstPos(dx, dy, dz);
+					const glm::vec3 srcPos = inverseTransformPosition(dstPos);
+					const VoxelEntry *source = sampleSnapshotVoxel(srcPos);
+					if (source) {
+						writeVoxel(vol, wrapper, dstPos, source->voxel);
+					}
+				}
+			}
+		}
+	} else {
+		// Forward mapping: Move and Shear produce 1:1 mappings without gaps
+		for (const VoxelEntry &entry : _snapshot) {
+			const glm::ivec3 newPos = transformPosition(entry.pos);
+			writeVoxel(vol, wrapper, newPos, entry.voxel);
+		}
+	}
+
+	// Prune interior voxels: remove any transformed voxel that is fully enclosed
+	// by 6 solid neighbors. These are invisible and waste sparse storage.
+	auto isInterior = [&](const glm::ivec3 &pos) {
+		for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
+			const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
+			if (!volRegion.containsPoint(nb) || voxel::isAir(vol->voxel(nb).getMaterial())) {
+				return false;
+			}
+		}
+		return true;
+	};
+
+	for (const HistoryEntry &entry : _history) {
+		const glm::ivec3 &pos = entry.pos;
+		const voxel::Voxel &current = vol->voxel(pos);
+		if (!voxel::isAir(current.getMaterial()) && isInterior(pos)) {
+			vol->setVoxel(pos, air);
+			wrapper.addToDirtyRegion(pos);
+		}
+	}
+}
+
+void TransformBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+							  const voxel::Region &) {
+	voxel::RawVolume *vol = wrapper.volume();
+	const voxel::Region &volRegion = vol->region();
+
+	// Capture snapshot on first use
+	if (!_hasSnapshot) {
+		captureSnapshot(vol, volRegion);
+		if (!_hasSnapshot) {
+			return;
+		}
+	}
+
+	// Restore previously transformed state before re-applying
+	restoreHistory(vol, wrapper);
+
+	// Apply the current transform from the original snapshot
+	applyTransform(wrapper, ctx);
+}
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -1,0 +1,204 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "app/I18N.h"
+#include "Brush.h"
+#include "core/GLM.h"
+#include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicMap.h"
+#include "core/collection/DynamicSet.h"
+#include "voxel/Voxel.h"
+
+#include <glm/vec3.hpp>
+
+namespace voxedit {
+
+/**
+ * @brief Transform mode for the TransformBrush
+ */
+enum class TransformMode : uint8_t {
+	Move,
+	Shear,
+	Scale,
+	Rotate,
+
+	Max
+};
+
+static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"), NC_("Transform Modes", "Shear"),
+												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
+static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
+
+/**
+ * @brief Sampling type for scale interpolation
+ */
+enum class ScaleSampling : uint8_t {
+	Nearest,
+	Linear,
+	Cubic,
+
+	Max
+};
+
+static constexpr const char *ScaleSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
+												   NC_("Scale Sampling", "Cubic")};
+static_assert(lengthof(ScaleSamplingStr) == (int)ScaleSampling::Max, "ScaleSamplingStr size mismatch");
+
+/**
+ * @brief Transforms selected voxels: move, shear, scale, rotate
+ *
+ * When the brush becomes active it captures the original selected voxels.
+ * Consecutive parameter changes always re-transform from the original snapshot
+ * so transforms are absolute, not incremental.
+ * On finalize (reset/brush switch) the final state is committed to the undo stack.
+ *
+ * @ingroup Brushes
+ */
+class TransformBrush : public Brush {
+private:
+	using Super = Brush;
+
+	struct VoxelEntry {
+		glm::ivec3 pos;
+		voxel::Voxel voxel;
+	};
+
+	struct HistoryEntry {
+		glm::ivec3 pos;
+		voxel::Voxel original;
+	};
+
+	TransformMode _transformMode = TransformMode::Move;
+	ScaleSampling _scaleSampling = ScaleSampling::Nearest;
+	bool _active = false;
+	bool _hasSnapshot = false;
+
+	// Original selected voxels captured at brush activation
+	core::DynamicArray<VoxelEntry> _snapshot;
+	// Selection bounding box at capture time
+	voxel::Region _snapshotRegion;
+	// Center of selection (used as pivot for scale/rotate)
+	glm::vec3 _snapshotCenter{0.0f};
+
+	// For each position overwritten, stores the original voxel for rollback
+	core::DynamicArray<HistoryEntry> _history;
+	// Fast O(1) lookup for history positions to avoid linear scans
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> _historyPositions;
+
+	// Spatial lookup: snapshot position -> index into _snapshot for O(1) access
+	core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>> _snapshotLookup;
+
+	// Transform parameters
+	glm::ivec3 _moveOffset{0};
+	glm::ivec3 _shearOffset{0};
+	glm::vec3 _scale{1.0f, 1.0f, 1.0f};
+	glm::vec3 _rotationDegrees{0.0f, 0.0f, 0.0f};
+
+	void captureSnapshot(voxel::RawVolume *volume, const voxel::Region &volRegion);
+	void applyTransform(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
+	void restoreHistory(voxel::RawVolume *volume, ModifierVolumeWrapper &wrapper);
+	glm::ivec3 transformPosition(const glm::ivec3 &pos) const;
+	glm::vec3 inverseTransformPosition(const glm::ivec3 &pos) const;
+	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
+	void writeVoxel(voxel::RawVolume *vol, ModifierVolumeWrapper &wrapper,
+					const glm::ivec3 &pos, const voxel::Voxel &voxel);
+	const VoxelEntry *findNearestSnapshotVoxel(const glm::vec3 &srcPos) const;
+	const VoxelEntry *findLinearSnapshotVoxel(const glm::vec3 &srcPos) const;
+	const VoxelEntry *findCubicSnapshotVoxel(const glm::vec3 &srcPos) const;
+	const VoxelEntry *sampleSnapshotVoxel(const glm::vec3 &srcPos) const;
+
+protected:
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region) override;
+
+public:
+	static constexpr int MaxMoveOffset = 128;
+	static constexpr int MaxShearOffset = 128;
+	TransformBrush() : Super(BrushType::Transform, ModifierType::Override, ModifierType::Override) {
+	}
+	virtual ~TransformBrush() = default;
+
+	void reset() override;
+	bool beginBrush(const BrushContext &ctx) override;
+	void endBrush(BrushContext &ctx) override;
+	bool active() const override;
+	voxel::Region calcRegion(const BrushContext &ctx) const override;
+
+	TransformMode transformMode() const {
+		return _transformMode;
+	}
+
+	void setTransformMode(TransformMode mode) {
+		if (_transformMode != mode) {
+			commitCurrentTransform();
+			_transformMode = mode;
+		}
+	}
+
+	/**
+	 * @brief Commit the current transform: clear history (keeping the volume as-is)
+	 * and re-capture the snapshot from the current volume state on next execute.
+	 * Called when switching transform modes so the new mode starts from the
+	 * result of the previous one rather than jumping back to the original.
+	 */
+	void commitCurrentTransform() {
+		_history.clear();
+		_historyPositions.clear();
+		_snapshot.clear();
+		_snapshotLookup.clear();
+		_hasSnapshot = false;
+		_moveOffset = glm::ivec3(0);
+		_shearOffset = glm::ivec3(0);
+		_scale = glm::vec3(1.0f);
+		_rotationDegrees = glm::vec3(0.0f);
+	}
+
+	ScaleSampling scaleSampling() const {
+		return _scaleSampling;
+	}
+
+	void setScaleSampling(ScaleSampling sampling) {
+		_scaleSampling = sampling;
+	}
+
+	const glm::ivec3 &moveOffset() const {
+		return _moveOffset;
+	}
+
+	void setMoveOffset(const glm::ivec3 &offset) {
+		_moveOffset = glm::clamp(offset, glm::ivec3(-MaxMoveOffset), glm::ivec3(MaxMoveOffset));
+	}
+
+	const glm::ivec3 &shearOffset() const {
+		return _shearOffset;
+	}
+
+	void setShearOffset(const glm::ivec3 &offset) {
+		_shearOffset = glm::clamp(offset, glm::ivec3(-MaxShearOffset), glm::ivec3(MaxShearOffset));
+	}
+
+	const glm::vec3 &scale() const {
+		return _scale;
+	}
+
+	void setScale(const glm::vec3 &scale) {
+		_scale = glm::max(scale, glm::vec3(0.01f));
+	}
+
+	const glm::vec3 &rotationDegrees() const {
+		return _rotationDegrees;
+	}
+
+	void setRotationDegrees(const glm::vec3 &degrees) {
+		_rotationDegrees = degrees;
+	}
+
+	bool hasSnapshot() const {
+		return _hasSnapshot;
+	}
+};
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
@@ -1,0 +1,204 @@
+/**
+ * @file
+ */
+
+#include "../modifier/brush/TransformBrush.h"
+#include "app/tests/AbstractTest.h"
+#include "scenegraph/SceneGraph.h"
+#include "scenegraph/SceneGraphNode.h"
+#include "voxedit-util/modifier/ModifierType.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Voxel.h"
+
+namespace voxedit {
+
+class TransformBrushTest : public app::AbstractTest {
+protected:
+	static voxel::Voxel selectedVoxel(uint8_t color = 1) {
+		voxel::Voxel voxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+		voxel.setFlags(voxel::FlagOutline);
+		return voxel;
+	}
+
+	void executeTransform(TransformBrush &brush, scenegraph::SceneGraphNode &node, BrushContext &ctx) {
+		ctx.modifierType = ModifierType::Override;
+		scenegraph::SceneGraph sceneGraph;
+		ModifierVolumeWrapper wrapper(node, ModifierType::Override);
+		brush.preExecute(ctx, wrapper.volume());
+		brush.execute(sceneGraph, wrapper, ctx);
+		brush.endBrush(ctx);
+	}
+};
+
+TEST_F(TransformBrushTest, testMovePositiveX) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+	brush.setMoveOffset(glm::ivec3(2, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original position should be empty after move";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 0).getMaterial()))
+		<< "Voxel should be at new position (2,0,0)";
+	EXPECT_TRUE(volume.voxel(2, 0, 0).getFlags() & voxel::FlagOutline)
+		<< "Moved voxel should retain selection flag";
+
+	brush.shutdown();
+}
+
+TEST_F(TransformBrushTest, testMoveReversible) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// Move to +3
+	brush.setMoveOffset(glm::ivec3(3, 0, 0));
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()));
+
+	// Move back to 0 (same snapshot, different offset)
+	brush.setMoveOffset(glm::ivec3(0, 0, 0));
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Voxel should be back at original position";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Previous moved position should be empty";
+
+	brush.shutdown();
+}
+
+TEST_F(TransformBrushTest, testScaleUp) {
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+	// Create a 3x3x1 selected slab at y=0, z=0
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			volume.setVoxel(x, y, 0, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Scale);
+	brush.setScale(glm::vec3(2.0f, 2.0f, 1.0f));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+
+	// Scaled up 2x: center should still have a voxel, and edges should be further out
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Center should still be filled";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 0).getMaterial()))
+		<< "Scaled edge should be filled (no gaps)";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Intermediate position should be filled (no gaps)";
+
+	brush.shutdown();
+}
+
+TEST_F(TransformBrushTest, testRotate90) {
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+	// Horizontal line along X at y=0, z=0
+	for (int x = -2; x <= 2; ++x) {
+		volume.setVoxel(x, 0, 0, selectedVoxel());
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Rotate);
+	brush.setRotationDegrees(glm::vec3(0.0f, 0.0f, 90.0f));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+
+	// After 90-degree Z rotation, line along X should become line along Y
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 2, 0).getMaterial()))
+		<< "Rotated voxel should be at (0,2,0)";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, -2, 0).getMaterial()))
+		<< "Rotated voxel should be at (0,-2,0)";
+	// Original X positions should be empty (except center which maps to center)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 0, 0).getMaterial()))
+		<< "Original position (2,0,0) should be empty after rotation";
+
+	brush.shutdown();
+}
+
+TEST_F(TransformBrushTest, testDoubleBeginFails) {
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = voxel::Region(0, 5);
+
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_FALSE(brush.beginBrush(ctx)) << "Second beginBrush without endBrush should fail";
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+TEST_F(TransformBrushTest, testCommitOnModeSwitch) {
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+	brush.setMoveOffset(glm::ivec3(3, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// Execute move
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()));
+
+	// Switch to scale: should commit the move (not jump back)
+	brush.setTransformMode(TransformMode::Scale);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Moved voxel should stay at (3,0,0) after mode switch";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original position should remain empty after mode switch";
+
+	brush.shutdown();
+}
+
+} // namespace voxedit


### PR DESCRIPTION
● Summary                                                                                                                                                                               
   
  - Add a new Transform brush for manipulating selected voxels with four sub-modes: Move, Shear, Scale, and Rotate  
  - Captures a snapshot of selected voxels on first use; consecutive parameter changes always re-transform from the original snapshot (absolute, not incremental)  
  - Switching between sub-modes commits the current result and recaptures, allowing transforms to be chained 
  - Scale and Rotate use inverse mapping (iterating destination positions and sampling back into the source) to avoid gaps 
  - Prunes interior voxels (fully enclosed by 6 solid neighbors) after each transform to minimize sparse storage waste 

  UI

  - Transform mode combo dropdown (Move / Shear / Scale / Rotate)
  - Move & Shear: integer sliders with -/+ buttons per axis (-128..128)
  - Scale: float sliders per axis (0.01..4.0) with sampling type dropdown (Nearest/Linear/Cubic)
  - Rotate: float sliders per axis (-360..360 degrees)
  - Shows "No selection active" message when no voxels are selected

  Test plan

  - Unit tests added: move, reversible move, scale up, rotate 90, double-begin guard, commit on mode switch 
  - Manual test: select voxels, move along each axis, verify original position is cleared 
  - Manual test: shear creates staircase effect across layers 
  - Manual test: scale up fills gaps (no holes), scale down shrinks 
  - Manual test: rotate at arbitrary angles (e.g. 45, 90, 180)
  - Manual test: switch modes mid-transform — result is preserved, not reverted 
  - Manual test: deselect/reselect brush clears state cleanly 
  