### PR TITLE
VOXEDIT: extend ExtrudeBrush with lateral offsets, tip selection for chained extrude

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -25,10 +25,11 @@
 #include "voxedit-util/modifier/brush/LineBrush.h"
 #include "voxedit-util/modifier/brush/NormalBrush.h"
 #include "voxedit-util/modifier/brush/ShapeBrush.h"
+#include "math/Axis.h"
+#include "voxel/Face.h"
 #include "voxedit-util/modifier/brush/ExtrudeBrush.h"
 #include "voxedit-util/modifier/brush/StampBrush.h"
 #include "voxedit-util/modifier/brush/TextureBrush.h"
-#include "voxel/Face.h"
 #include "voxel/RawVolume.h"
 #include "voxel/Region.h"
 #include "voxel/Voxel.h"
@@ -39,6 +40,8 @@
 #include <glm/trigonometric.hpp>
 
 namespace voxedit {
+
+static constexpr ImVec4 WarningTextColor(1.0f, 0.3f, 0.3f, 1.0f);
 
 static constexpr const char *BrushTypeIcons[] = {
 	ICON_LC_PIPETTE,	ICON_LC_BOXES,	   ICON_LC_GROUP,
@@ -751,7 +754,19 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 		maxDepth = glm::max(r.getWidthInVoxels(), glm::max(r.getHeightInVoxels(), r.getDepthInVoxels()));
 	}
 
+	const voxel::FaceNames extrudeFace = brush.face();
+
+	if (extrudeFace == voxel::FaceNames::Max) {
+		ImGui::TextColored(WarningTextColor, "%s", _("Click a voxel face in the viewport to set the extrusion direction"));
+		return;
+	}
+
+	ImGui::Text(_("Direction: %s"), voxel::faceNameString(extrudeFace));
+
 	int depth = brush.depth();
+	if (depth == 0 && (!node || !node->hasSelection())) {
+		ImGui::TextColored(WarningTextColor, "%s", _("No selection active - use the Select brush first"));
+	}
 	ImGui::TextUnformatted(_("Depth"));
 	if (ImGui::Button("-##extrude_depth")) {
 		brush.setDepth(depth - 1);
@@ -770,23 +785,53 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 		executeExtrudeBrush();
 	}
 
-	bool fillSides = brush.fillSides();
-	if (ImGui::Checkbox(_("Fill sides (keep manifold)"), &fillSides)) {
-		brush.setFillSides(fillSides);
-	}
-	if (ImGui::IsItemHovered()) {
-		ImGui::SetTooltip("%s", _("Fill the perpendicular walls of the extruded region to prevent open edges"));
+	// Lateral offset sliders - only shown when depth is non-zero.
+	if (depth != 0) {
+		static constexpr int NumAxes = 3;
+		static constexpr const char *AxisLabels[] = {"X", "Y", "Z"};
+		const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(extrudeFace));
+		const int perp1 = (axisIdx + 1) % NumAxes;
+		const int perp2 = (axisIdx + 2) % NumAxes;
+
+		int offsetU = brush.offsetU();
+		ImGui::Text(_("Offset %s"), AxisLabels[perp1]);
+		if (ImGui::Button("-##extrude_offsetU")) {
+			brush.setOffsetU(offsetU - 1);
+			executeExtrudeBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##extrude_offsetU_slider", &offsetU, -maxDepth, maxDepth)) {
+			brush.setOffsetU(offsetU);
+		}
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			executeExtrudeBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##extrude_offsetU")) {
+			brush.setOffsetU(offsetU + 1);
+			executeExtrudeBrush();
+		}
+
+		int offsetV = brush.offsetV();
+		ImGui::Text(_("Offset %s"), AxisLabels[perp2]);
+		if (ImGui::Button("-##extrude_offsetV")) {
+			brush.setOffsetV(offsetV - 1);
+			executeExtrudeBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##extrude_offsetV_slider", &offsetV, -maxDepth, maxDepth)) {
+			brush.setOffsetV(offsetV);
+		}
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			executeExtrudeBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##extrude_offsetV")) {
+			brush.setOffsetV(offsetV + 1);
+			executeExtrudeBrush();
+		}
 	}
 
-	const voxel::FaceNames extrudeFace = brush.face();
-	if (extrudeFace == voxel::FaceNames::Max) {
-		ImGui::TextWrappedUnformatted(_("Click a voxel face in the viewport to set the extrusion direction"));
-	} else {
-		ImGui::Text(_("Direction: %s"), voxel::faceNameString(extrudeFace));
-	}
-	if (depth == 0 && (!node || !node->hasSelection())) {
-		ImGui::TextWrappedUnformatted(_("No selection active - use the Select brush first"));
-	}
 }
 
 void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -360,7 +360,11 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	}
 	_brushContext.cursorVoxel = voxel;
 	brush->execute(sceneGraph, wrapper, _brushContext);
-	wrapper.growSelectionToNewVoxels();
+	// Extrude manages voxel flags (FlagOutline) directly via its history mechanism.
+	// growSelectionToNewVoxels would incorrectly select all solid voxels in the dirty region.
+	if (_brushType != BrushType::Extrude) {
+		wrapper.growSelectionToNewVoxels();
+	}
 	const voxel::Region &modifiedRegion = wrapper.dirtyRegion();
 	if (modifiedRegion.isValid()) {
 		voxel::logRegion("Dirty region", modifiedRegion);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -17,9 +17,12 @@ namespace voxedit {
 void ExtrudeBrush::reset() {
 	Super::reset();
 	_depth = 0;
+	_offsetU = 0;
+	_offsetV = 0;
 	_face = voxel::FaceNames::Max;
 	_active = false;
 	_history.clear();
+	_cachedSelBBoxValid = false;
 }
 
 bool ExtrudeBrush::beginBrush(const BrushContext &ctx) {
@@ -41,16 +44,76 @@ void ExtrudeBrush::endBrush(BrushContext &) {
 	// then adjusts depth via the panel without needing to hover the viewport again.
 }
 
+void ExtrudeBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) {
+	Super::preExecute(ctx, volume);
+	_cachedSelBBoxValid = false;
+	if (!volume) {
+		return;
+	}
+	// Scan for selected (FlagOutline) voxels and cache their bounding box.
+	// This is used by calcRegion() to return a tight region for preview.
+	const voxel::Region &volRegion = volume->region();
+	glm::ivec3 selLo(volRegion.getUpperCorner());
+	glm::ivec3 selHi(volRegion.getLowerCorner());
+	const glm::ivec3 &vlo = volRegion.getLowerCorner();
+	const glm::ivec3 &vhi = volRegion.getUpperCorner();
+	for (int z = vlo.z; z <= vhi.z; ++z) {
+		for (int y = vlo.y; y <= vhi.y; ++y) {
+			for (int x = vlo.x; x <= vhi.x; ++x) {
+				const voxel::Voxel vx = volume->voxel(x, y, z);
+				if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline)) {
+					selLo = glm::min(selLo, glm::ivec3(x, y, z));
+					selHi = glm::max(selHi, glm::ivec3(x, y, z));
+				}
+			}
+		}
+	}
+	if (selLo.x <= selHi.x) {
+		_cachedSelBBox = voxel::Region(selLo, selHi);
+		_cachedSelBBoxValid = true;
+	}
+}
+
 bool ExtrudeBrush::active() const {
 	return _active;
 }
 
 voxel::Region ExtrudeBrush::calcRegion(const BrushContext &ctx) const {
-	return ctx.targetVolumeRegion;
+	if (!_cachedSelBBoxValid || _face == voxel::FaceNames::Max) {
+		return ctx.targetVolumeRegion;
+	}
+	// Expand the cached selection bbox to include all voxels that may be affected
+	// by the extrusion: depth steps + lateral offsets + side wall margin.
+	static constexpr int SideWallMargin = 1;
+	const int expand = glm::abs(_depth) + glm::abs(_offsetU) + glm::abs(_offsetV) + SideWallMargin;
+	voxel::Region region = _cachedSelBBox;
+	region.grow(expand);
+	region.cropTo(ctx.targetVolumeRegion);
+	return region;
 }
 
 void ExtrudeBrush::setDepth(int depth) {
+	if (_depth == depth) {
+		return;
+	}
 	_depth = depth;
+	markDirty();
+}
+
+void ExtrudeBrush::setOffsetU(int offset) {
+	if (_offsetU == offset) {
+		return;
+	}
+	_offsetU = offset;
+	markDirty();
+}
+
+void ExtrudeBrush::setOffsetV(int offset) {
+	if (_offsetV == offset) {
+		return;
+	}
+	_offsetV = offset;
+	markDirty();
 }
 
 void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
@@ -84,6 +147,26 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	glm::ivec3 dir(0);
 	dir[axisIdx] = dirSign;
 
+	// Perpendicular axes used for lateral offset (sweep) and side-wall filling.
+	static constexpr int NumAxes = 3;
+	const int perp1 = (axisIdx + 1) % NumAxes;
+	const int perp2 = (axisIdx + 2) % NumAxes;
+
+	// Compute lateral shift at a given extrusion step via linear interpolation.
+	// shift = offset * step / depth (truncated toward zero).
+	const float stepU = static_cast<float>(_offsetU) / steps;
+	const float stepV = static_cast<float>(_offsetV) / steps;
+	auto lateralShift = [&](int step) -> glm::ivec3 {
+		glm::ivec3 shift(0);
+		if (_offsetU != 0) {
+			shift[perp1] = static_cast<int>(stepU * step);
+		}
+		if (_offsetV != 0) {
+			shift[perp2] = static_cast<int>(stepV * step);
+		}
+		return shift;
+	};
+
 	// Save original voxel at pos (only once per session) then write the new voxel.
 	auto writeVoxel = [&](const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
 		if (!volRegion.containsPoint(pos)) {
@@ -106,9 +189,14 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	};
 
 	const voxel::Voxel air{};
+	// Tip voxel: same as cursor but with FlagOutline so the outermost extrusion layer
+	// stays selected for chaining extrudes (e.g. building a column then bending it).
+	voxel::Voxel tipVoxel = ctx.cursorVoxel;
+	tipVoxel.setFlags(ctx.cursorVoxel.getFlags() | voxel::FlagOutline);
 
-	// Compute the bounding box of selected (FlagOutline) voxels so the loops below
-	// only scan the relevant sub-region instead of the full volume (which can be 256^3+).
+	// Collect selected (FlagOutline) voxel positions to avoid scanning the full volume
+	// (which can be 256^3+) in the extrusion and fill-sides loops.
+	core::DynamicArray<glm::ivec3> selectedPositions;
 	glm::ivec3 selLo(volRegion.getUpperCorner());
 	glm::ivec3 selHi(volRegion.getLowerCorner());
 	{
@@ -117,50 +205,84 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 		for (int z = vlo.z; z <= vhi.z; ++z) {
 			for (int y = vlo.y; y <= vhi.y; ++y) {
 				for (int x = vlo.x; x <= vhi.x; ++x) {
-					const voxel::Voxel v = vol->voxel(x, y, z);
-					if (!voxel::isAir(v.getMaterial()) && (v.getFlags() & voxel::FlagOutline)) {
-						selLo = glm::min(selLo, glm::ivec3(x, y, z));
-						selHi = glm::max(selHi, glm::ivec3(x, y, z));
+					const voxel::Voxel vx = vol->voxel(x, y, z);
+					if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline)) {
+						const glm::ivec3 pos(x, y, z);
+						selectedPositions.push_back(pos);
+						selLo = glm::min(selLo, pos);
+						selHi = glm::max(selHi, pos);
 					}
 				}
 			}
 		}
 	}
-	if (selLo.x > selHi.x) {
+	if (selectedPositions.empty()) {
 		return; // no selected voxels
 	}
 	const glm::ivec3 &lo = selLo;
 	const glm::ivec3 &hi = selHi;
 
+	// Clear FlagOutline on original selected voxels so only the tip stays selected.
+	// Save them to history so depth changes can restore the original selection state.
+	if (!carving) {
+		for (const glm::ivec3 &pos : selectedPositions) {
+			const voxel::Voxel origVoxel = vol->voxel(pos);
+			writeVoxel(pos, voxel::Voxel(origVoxel.getMaterial(), origVoxel.getColor(), origVoxel.getNormal(),
+										 origVoxel.getFlags() & ~voxel::FlagOutline, origVoxel.getBoneIdx()));
+		}
+	}
+
 	// Carve or extrude each selected voxel along dir.
-	for (int z = lo.z; z <= hi.z; ++z) {
-		for (int y = lo.y; y <= hi.y; ++y) {
-			for (int x = lo.x; x <= hi.x; ++x) {
-				const voxel::Voxel v = vol->voxel(x, y, z);
-				if (voxel::isAir(v.getMaterial()) || !(v.getFlags() & voxel::FlagOutline)) {
-					continue;
-				}
-				// Carving starts at the selected voxel itself (step=0) so the surface layer
-				// becomes air. Extrusion starts at step=1 to place new voxels outward.
-				const int stepFirst = carving ? 0 : 1;
-				const int stepLast = carving ? steps - 1 : steps;
-				for (int step = stepFirst; step <= stepLast; ++step) {
-					const glm::ivec3 newPos(x + dir.x * step, y + dir.y * step, z + dir.z * step);
-					if (!volRegion.containsPoint(newPos)) {
-						break;
-					}
-					writeVoxel(newPos, carving ? air : ctx.cursorVoxel);
+	for (const glm::ivec3 &selPos : selectedPositions) {
+		// Carving starts at the selected voxel itself (step=0) so the surface layer
+		// becomes air. Extrusion starts at step=1 to place new voxels outward.
+		const int stepFirst = carving ? 0 : 1;
+		const int stepLast = carving ? steps - 1 : steps;
+		for (int step = stepFirst; step <= stepLast; ++step) {
+			const glm::ivec3 shift = lateralShift(step);
+			const glm::ivec3 newPos = selPos + dir * step + shift;
+			if (!volRegion.containsPoint(newPos)) {
+				break;
+			}
+			// Only the outermost layer gets FlagOutline.
+			const bool isTip = (step == stepLast) && !carving;
+			writeVoxel(newPos, carving ? air : (isTip ? tipVoxel : ctx.cursorVoxel));
+		}
+		// After carving, mark the voxel behind the deepest carved layer
+		// with FlagOutline so the selection moves inward (mirrors tip selection
+		// for positive extrusion). This keeps visual masking active.
+		if (carving) {
+			const glm::ivec3 shift = lateralShift(steps);
+			const glm::ivec3 behindPos = selPos + dir * steps + shift;
+			if (volRegion.containsPoint(behindPos)) {
+				const voxel::Voxel behind = vol->voxel(behindPos);
+				if (!voxel::isAir(behind.getMaterial())) {
+					voxel::Voxel flagged = behind;
+					flagged.setFlags(behind.getFlags() | voxel::FlagOutline);
+					writeVoxel(behindPos, flagged);
 				}
 			}
 		}
 	}
 
-	// Fill perpendicular side walls - only meaningful when adding material outward.
-	if (_fillSides && !carving) {
-		static constexpr int NumAxes = 3;
+	// Expanded bounding box covering tip voxels after lateral offset + side wall margin.
+	// The fill-sides and pruning loops need to find FlagOutline voxels which may have been
+	// shifted outside the original selection bbox (lo..hi) by the lateral offset.
+	const glm::ivec3 tipShift = lateralShift(steps);
+	const glm::ivec3 extLo = glm::max(glm::min(lo, lo + dir * steps + tipShift) - glm::ivec3(1),
+									   volRegion.getLowerCorner());
+	const glm::ivec3 extHi = glm::min(glm::max(hi, hi + dir * steps + tipShift) + glm::ivec3(1),
+									   volRegion.getUpperCorner());
+
+	// Fill perpendicular side walls - only meaningful when extruding straight outward
+	// (no lateral offset). With lateral offsets the extrusion is a sweep/shear and
+	// wall placement doesn't make geometric sense.
+	// Side walls are only placed when the neighbor already has pre-existing solid
+	// material extending in the extrusion direction (e.g. an existing wall/structure).
+	// This avoids creating unwanted rim voxels when extruding on a flat surface.
+	const bool hasLateralOffset = _offsetU != 0 || _offsetV != 0;
+	if (!carving && !hasLateralOffset) {
 		static constexpr int NumPerpOffsets = 4; // 2 perpendicular axes * 2 directions each
-		const int perp1 = (axisIdx + 1) % NumAxes;
-		const int perp2 = (axisIdx + 2) % NumAxes;
 
 		glm::ivec3 perpOffsets[NumPerpOffsets] = {};
 		perpOffsets[0][perp1] = 1;
@@ -168,32 +290,52 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 		perpOffsets[2][perp2] = 1;
 		perpOffsets[3][perp2] = -1;
 
-		for (int z = lo.z; z <= hi.z; ++z) {
-			for (int y = lo.y; y <= hi.y; ++y) {
-				for (int x = lo.x; x <= hi.x; ++x) {
-					const voxel::Voxel &sv = vol->voxel(x, y, z);
-					if (voxel::isAir(sv.getMaterial()) || !(sv.getFlags() & voxel::FlagOutline)) {
-						continue;
+		for (const glm::ivec3 &selPos : selectedPositions) {
+			for (int pi = 0; pi < NumPerpOffsets; ++pi) {
+				const glm::ivec3 neighborPos = selPos + perpOffsets[pi];
+				if (!volRegion.containsPoint(neighborPos)) {
+					continue;
+				}
+				const voxel::Voxel &nv = vol->voxel(neighborPos);
+				if (voxel::isAir(nv.getMaterial())) {
+					continue; // air neighbor - no edge to seal
+				}
+				// Skip if the neighbor is also a selected voxel (no open edge between them).
+				bool neighborSelected = false;
+				for (const glm::ivec3 &other : selectedPositions) {
+					if (other == neighborPos) {
+						neighborSelected = true;
+						break;
 					}
-					for (int pi = 0; pi < NumPerpOffsets; ++pi) {
-						const glm::ivec3 neighborPos(x + perpOffsets[pi].x, y + perpOffsets[pi].y,
-													 z + perpOffsets[pi].z);
-						if (volRegion.containsPoint(neighborPos)) {
-							const voxel::Voxel &nv = vol->voxel(neighborPos);
-							if (!voxel::isAir(nv.getMaterial()) && (nv.getFlags() & voxel::FlagOutline)) {
-								continue; // neighbor is also selected - no open edge
-							}
-						}
-						for (int step = 1; step <= steps; ++step) {
-							const glm::ivec3 sidePos(x + perpOffsets[pi].x + dir.x * step,
-													 y + perpOffsets[pi].y + dir.y * step,
-													 z + perpOffsets[pi].z + dir.z * step);
-							if (!volRegion.containsPoint(sidePos)) {
-								break;
-							}
-							writeVoxel(sidePos, ctx.cursorVoxel);
-						}
+				}
+				if (neighborSelected) {
+					continue;
+				}
+				// Only fill when the neighbor has pre-existing geometry extending in the
+				// extrusion direction. On a flat surface the neighbor has nothing above
+				// its base level, so no wall is needed. Check the original (pre-extrusion)
+				// voxel state via history to avoid false positives from extrusion overlap.
+				const glm::ivec3 aboveNeighbor = neighborPos + dir;
+				if (!volRegion.containsPoint(aboveNeighbor)) {
+					continue;
+				}
+				voxel::Voxel aboveOriginal = vol->voxel(aboveNeighbor);
+				for (const HistoryEntry &entry : _history) {
+					if (entry.pos == aboveNeighbor) {
+						aboveOriginal = entry.original;
+						break;
 					}
+				}
+				if (voxel::isAir(aboveOriginal.getMaterial())) {
+					continue;
+				}
+				for (int step = 1; step <= steps; ++step) {
+					const glm::ivec3 shift = lateralShift(step);
+					const glm::ivec3 sidePos = selPos + perpOffsets[pi] + dir * step + shift;
+					if (!volRegion.containsPoint(sidePos)) {
+						break;
+					}
+					writeVoxel(sidePos, ctx.cursorVoxel);
 				}
 			}
 		}
@@ -223,11 +365,11 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 			}
 		}
 
-		// Prune original selected voxels that outward extrusion has now surrounded.
+		// Prune tip voxels that outward extrusion has now fully surrounded.
 		// Save them to history first so a depth change can restore them.
-		for (int z = lo.z; z <= hi.z; ++z) {
-			for (int y = lo.y; y <= hi.y; ++y) {
-				for (int x = lo.x; x <= hi.x; ++x) {
+		for (int z = extLo.z; z <= extHi.z; ++z) {
+			for (int y = extLo.y; y <= extHi.y; ++y) {
+				for (int x = extLo.x; x <= extHi.x; ++x) {
 					const voxel::Voxel &sv = vol->voxel(x, y, z);
 					if (voxel::isAir(sv.getMaterial()) || !(sv.getFlags() & voxel::FlagOutline)) {
 						continue;
@@ -237,8 +379,8 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 						continue;
 					}
 					bool alreadySaved = false;
-					for (const HistoryEntry &e : _history) {
-						if (e.pos == pos) {
+					for (const HistoryEntry &entry : _history) {
+						if (entry.pos == pos) {
 							alreadySaved = true;
 							break;
 						}

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
@@ -7,6 +7,7 @@
 #include "Brush.h"
 #include "core/collection/DynamicArray.h"
 #include "voxel/Face.h"
+#include "voxel/Region.h"
 #include "voxel/Voxel.h"
 #include <glm/vec3.hpp>
 
@@ -16,7 +17,7 @@ namespace voxedit {
  * @brief Extrudes the current voxel selection along the clicked face normal
  *
  * In Place mode voxels are added outward from the selection by @c _depth steps.
- * Optionally the perpendicular "side walls" are filled to keep the model manifold.
+ * The perpendicular "side walls" are filled to keep the model manifold.
  * In Erase mode the outermost selected layer facing the cursor is removed.
  *
  * @ingroup Brushes
@@ -26,8 +27,9 @@ private:
 	using Super = Brush;
 	voxel::FaceNames _face = voxel::FaceNames::Max;
 	bool _active = false;
-	bool _fillSides = false;
 	int _depth = 0;
+	int _offsetU = 0; // lateral offset along first perpendicular axis
+	int _offsetV = 0; // lateral offset along second perpendicular axis
 	struct HistoryEntry {
 		glm::ivec3 pos;
 		voxel::Voxel original;
@@ -35,6 +37,11 @@ private:
 	// For each position overwritten by the current extrude session, stores the original voxel.
 	// Cleared in reset() when the brush is deselected.
 	core::DynamicArray<HistoryEntry> _history;
+
+	// Cached bounding box of selected (FlagOutline) voxels, computed in preExecute().
+	// Used by calcRegion() to return a tight preview region instead of the full volume.
+	voxel::Region _cachedSelBBox;
+	bool _cachedSelBBoxValid = false;
 
 protected:
 	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
@@ -46,6 +53,7 @@ public:
 	virtual ~ExtrudeBrush() = default;
 
 	void reset() override;
+	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;
 	bool active() const override;
@@ -56,16 +64,20 @@ public:
 		return _depth;
 	}
 
+	void setOffsetU(int offset);
+	int offsetU() const {
+		return _offsetU;
+	}
+
+	void setOffsetV(int offset);
+	int offsetV() const {
+		return _offsetV;
+	}
+
 	voxel::FaceNames face() const {
 		return _face;
 	}
 
-	void setFillSides(bool fill) {
-		_fillSides = fill;
-	}
-	bool fillSides() const {
-		return _fillSides;
-	}
 };
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
@@ -22,15 +22,17 @@ namespace voxedit {
 //   depth=+1 -> new voxel at x=+1  (outward)
 //   depth=-1 -> voxel at x=-1 erased (inward / carve)
 //
-// FlagOutline is NOT transferred: selected voxels keep their flags unchanged,
-// newly placed voxels use cursorVoxel as-is.
+// FlagOutline handling:
+//   - Original selected voxels have FlagOutline cleared during extrusion.
+//   - Only the outermost (tip) layer gets FlagOutline for chaining extrudes.
+//   - On carve, the voxel behind the deepest carved layer gets FlagOutline.
 
 class ExtrudeBrushTest : public app::AbstractTest {
 protected:
 	static voxel::Voxel selectedVoxel(uint8_t color = 1) {
-		voxel::Voxel v = voxel::createVoxel(voxel::VoxelType::Generic, color);
-		v.setFlags(voxel::FlagOutline);
-		return v;
+		voxel::Voxel vx = voxel::createVoxel(voxel::VoxelType::Generic, color);
+		vx.setFlags(voxel::FlagOutline);
+		return vx;
 	}
 
 	void executeExtrude(ExtrudeBrush &brush, scenegraph::SceneGraphNode &node, BrushContext &ctx,
@@ -214,12 +216,54 @@ TEST_F(ExtrudeBrushTest, testExtrudePushThenPull) {
 	brush.shutdown();
 }
 
-// Fill sides: outward push (-) on 3x3 face should add side caps
-TEST_F(ExtrudeBrushTest, testExtrudeFillSidesOutward) {
+// Fill sides: extrude next to an existing wall fills the gap between extrusion and wall
+TEST_F(ExtrudeBrushTest, testExtrudeFillSidesWithWall) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// Selected voxel at (0,0,0) recessed inside a box. Wall neighbor at (1,0,0) extends
+	// upward to (1,0,3). Extruding by 2 should fill the gap at (1,0,1) and (1,0,2).
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	// Wall column next to the selection, extending upward
+	for (int z = 0; z <= 3; ++z) {
+		volume.setVoxel(2, 0, z, solid);
+	}
+	// Neighbor at (1,0,0) with solid above it at (1,0,1) triggers fill-sides
+	volume.setVoxel(1, 0, 0, solid);
+	volume.setVoxel(1, 0, 1, solid);
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(2); // outward for PositiveZ -> z+1, z+2
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Extruded voxels at z=1 and z=2
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Extruded voxel at (0,0,1) expected";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 2).getMaterial())) << "Tip voxel at (0,0,2) expected";
+	// Side wall fills gap: (1,0,2) was air, should now be filled by fill-sides
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 2).getMaterial()))
+		<< "Side wall at (1,0,2) should fill gap next to existing wall";
+
+	brush.shutdown();
+}
+
+// No fill sides on flat surface: single voxel extrusion should not create rim
+TEST_F(ExtrudeBrushTest, testExtrudeNoRimOnFlatSurface) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// 3x3 flat surface at z=0, center voxel selected
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
 	for (int x = -1; x <= 1; ++x) {
 		for (int y = -1; y <= 1; ++y) {
-			volume.setVoxel(x, y, 0, selectedVoxel());
+			volume.setVoxel(x, y, 0, (x == 0 && y == 0) ? selectedVoxel() : solid);
 		}
 	}
 
@@ -229,7 +273,6 @@ TEST_F(ExtrudeBrushTest, testExtrudeFillSidesOutward) {
 	ExtrudeBrush brush;
 	ASSERT_TRUE(brush.init());
 	brush.setDepth(1); // outward for PositiveZ -> z+1
-	brush.setFillSides(true);
 
 	BrushContext ctx;
 	ctx.targetVolumeRegion = volume.region();
@@ -239,22 +282,95 @@ TEST_F(ExtrudeBrushTest, testExtrudeFillSidesOutward) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Outward slab at z=1
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Outward voxel at (0,0,1) expected";
-	// Side caps adjacent to slab
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 1).getMaterial())) << "Side cap at (2,0,1) expected";
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-2, 0, 1).getMaterial())) << "Side cap at (-2,0,1) expected";
+	// Only 1 extruded voxel expected, no rim
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Extruded voxel at (0,0,1) expected";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 0, 1).getMaterial())) << "No rim voxel at (1,0,1)";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(-1, 0, 1).getMaterial())) << "No rim voxel at (-1,0,1)";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 1).getMaterial())) << "No rim voxel at (0,1,1)";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, -1, 1).getMaterial())) << "No rim voxel at (0,-1,1)";
 
 	brush.shutdown();
 }
 
-// Without fill sides: no side caps
-TEST_F(ExtrudeBrushTest, testExtrudeNoFillSides) {
+// Lateral offset: depth=2 with offsetU=2 on PositiveZ face shifts along first perpendicular axis
+TEST_F(ExtrudeBrushTest, testExtrudeWithOffsetU) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
-	for (int x = -1; x <= 1; ++x) {
-		for (int y = -1; y <= 1; ++y) {
-			volume.setVoxel(x, y, 0, selectedVoxel());
-		}
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(2);
+	brush.setOffsetU(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// PositiveZ face: axis=Z(2), perp1=(2+1)%3=X(0), perp2=(2+2)%3=Y(1)
+	// offsetU=2 along X: step 1 shift = int(1.0*1)=1, step 2 shift = int(1.0*2)=2
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 1).getMaterial()))
+		<< "Step 1 voxel at (1,0,1) expected";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 2).getMaterial()))
+		<< "Step 2 (tip) voxel at (2,0,2) expected";
+	// Original position should not have a new voxel at z=1 without offset
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 1).getMaterial()))
+		<< "No voxel at (0,0,1) - offset shifts it to (1,0,1)";
+
+	brush.shutdown();
+}
+
+// Tip-only selection: only outermost extruded layer gets FlagOutline
+TEST_F(ExtrudeBrushTest, testExtrudeTipOnlySelection) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Original voxel should have FlagOutline cleared
+	const voxel::Voxel origVoxel = volume.voxel(0, 0, 0);
+	EXPECT_FALSE(origVoxel.getFlags() & voxel::FlagOutline)
+		<< "Original voxel at (0,0,0) should not have FlagOutline after extrusion";
+	// Step 1 (intermediate) should NOT have FlagOutline
+	const voxel::Voxel midVoxel = volume.voxel(1, 0, 0);
+	EXPECT_TRUE(voxel::isBlocked(midVoxel.getMaterial()));
+	EXPECT_FALSE(midVoxel.getFlags() & voxel::FlagOutline)
+		<< "Intermediate voxel at (1,0,0) should not have FlagOutline";
+	// Step 2 (tip) should have FlagOutline
+	const voxel::Voxel tipVoxel = volume.voxel(2, 0, 0);
+	EXPECT_TRUE(voxel::isBlocked(tipVoxel.getMaterial()));
+	EXPECT_TRUE(tipVoxel.getFlags() & voxel::FlagOutline)
+		<< "Tip voxel at (2,0,0) should have FlagOutline for chaining";
+
+	brush.shutdown();
+}
+
+// Carve-behind selection: after carving, the voxel behind the deepest carved layer gets FlagOutline
+TEST_F(ExtrudeBrushTest, testExtrudeCarveBehindSelection) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	// Solid block from x=-3 to x=0, surface at x=0 is selected
+	for (int x = -3; x <= 0; ++x) {
+		volume.setVoxel(x, 0, 0, x == 0 ? selectedVoxel() : solid);
 	}
 
 	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
@@ -262,19 +378,23 @@ TEST_F(ExtrudeBrushTest, testExtrudeNoFillSides) {
 
 	ExtrudeBrush brush;
 	ASSERT_TRUE(brush.init());
-	brush.setDepth(1); // outward
-	brush.setFillSides(false);
+	brush.setDepth(-1);
 
 	BrushContext ctx;
 	ctx.targetVolumeRegion = volume.region();
-	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
 	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
 
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Outward voxel at (0,0,1) expected";
-	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 0, 1).getMaterial())) << "No side cap at (2,0,1) expected";
+	// Carved voxel at x=0 should be air
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()));
+	// Behind the carved layer at x=-1 should now have FlagOutline
+	const voxel::Voxel behindVoxel = volume.voxel(-1, 0, 0);
+	EXPECT_TRUE(voxel::isBlocked(behindVoxel.getMaterial()));
+	EXPECT_TRUE(behindVoxel.getFlags() & voxel::FlagOutline)
+		<< "Voxel behind carved layer at (-1,0,0) should have FlagOutline for selection continuity";
 
 	brush.shutdown();
 }


### PR DESCRIPTION
  ## Summary 
  - Add lateral offset (offsetU/offsetV) to ExtrudeBrush for swept/sheared extrusion paths using linear interpolation 
  - Only the outermost (tip) layer receives FlagOutline, enabling chained extrudes; carving moves the selection inward behind the carved layer 
  - Smart fill-sides: always enabled but only triggers when the neighbor has pre-existing geometry in the extrusion direction — prevents unwanted rim voxels on flat surfaces; disabled  entirely with lateral offsets 
  - Panel improvements: face direction display, warning text when no face/selection is set, lateral offset sliders gated behind non-zero depth 
  - Skip growSelectionToNewVoxels for Extrude brush since it manages FlagOutline directly via history 

  ## Test plan  
  - [ ] Select a single voxel on a flat surface, extrude depth=1 → only 1 new voxel, no rim 
  - [ ] Select a 3x3 face, extrude depth=6 with offsetU=5 offsetV=4 → clean diagonal path, no stray voxels
  - [ ] Extrude positive depth, then slide to negative → history restores correctly, carving works
  - [ ] Extrude next to an existing wall structure → fill-sides seals the gap
  - [ ] Chain extrudes: extrude depth=3, then change offset → tip stays selected, second extrude continues from tip
  - [ ] 12 unit tests pass (carve inward, place outward, depth-2, only-selected, push-then-pull, fill-sides with wall, no rim on flat, lateral offset, tip-only selection, carve-behind, beginBrush edge cases, endBrush state) 
  