### PR TITLE
VOXEDIT: add preview rendering for Extrude and Transform brushes

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -744,6 +744,7 @@ void BrushPanel::executeExtrudeBrush() {
 		}
 	});
 	modifier.endBrush();
+	modifier.extrudeBrush().markDirty();
 }
 
 void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &listener) {
@@ -775,22 +776,33 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 	if (depth == 0 && (!node || !node->hasSelection())) {
 		ImGui::TextColored(warningTextColor, "%s", _("No selection active - use the Select brush first"));
 	}
+	// Carving (negative depth) applies directly to the real volume because the preview
+	// system can only render solid voxels — carved (air) positions are invisible as ghosts.
+	// Positive extrusion uses preview-only (ghost overlay of new voxels).
+	// depth==0 also applies to restore the real volume when transitioning back from carving
+	// (the history mechanism undoes the carve, restoring the original selected voxels).
+	auto applyIfCarving = [&]() {
+		if (brush.depth() <= 0) {
+			executeExtrudeBrush();
+		}
+	};
+
 	ImGui::TextUnformatted(_("Depth"));
 	if (ImGui::Button("-##extrude_depth")) {
 		brush.setDepth(depth - 1);
-		executeExtrudeBrush();
+		applyIfCarving();
 	}
 	ImGui::SameLine();
 	if (ImGui::SliderInt("##extrude_depth_slider", &depth, -maxDepth, maxDepth)) {
 		brush.setDepth(depth);
 	}
 	if (ImGui::IsItemDeactivatedAfterEdit()) {
-		executeExtrudeBrush();
+		applyIfCarving();
 	}
 	ImGui::SameLine();
 	if (ImGui::Button("+##extrude_depth")) {
 		brush.setDepth(depth + 1);
-		executeExtrudeBrush();
+		applyIfCarving();
 	}
 
 	// Lateral offset sliders - only shown when depth is non-zero.
@@ -805,38 +817,38 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 		ImGui::Text(_("Offset %s"), AxisLabels[perp1]);
 		if (ImGui::Button("-##extrude_offsetU")) {
 			brush.setOffsetU(offsetU - 1);
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::SliderInt("##extrude_offsetU_slider", &offsetU, -maxDepth, maxDepth)) {
 			brush.setOffsetU(offsetU);
 		}
 		if (ImGui::IsItemDeactivatedAfterEdit()) {
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::Button("+##extrude_offsetU")) {
 			brush.setOffsetU(offsetU + 1);
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 
 		int offsetV = brush.offsetV();
 		ImGui::Text(_("Offset %s"), AxisLabels[perp2]);
 		if (ImGui::Button("-##extrude_offsetV")) {
 			brush.setOffsetV(offsetV - 1);
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::SliderInt("##extrude_offsetV_slider", &offsetV, -maxDepth, maxDepth)) {
 			brush.setOffsetV(offsetV);
 		}
 		if (ImGui::IsItemDeactivatedAfterEdit()) {
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::Button("+##extrude_offsetV")) {
 			brush.setOffsetV(offsetV + 1);
-			executeExtrudeBrush();
+			applyIfCarving();
 		}
 	}
 }

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -531,6 +531,9 @@ bool Modifier::previewNeedsExistingVolume() const {
 	if (_brushType == BrushType::Extrude) {
 		return true;
 	}
+	if (_brushType == BrushType::Transform) {
+		return true;
+	}
 	return false;
 }
 
@@ -648,6 +651,11 @@ void Modifier::render(const video::Camera &camera, palette::Palette &activePalet
 	// Handle brush preview with deferred updates
 	if (!isMode(ModifierType::ColorPicker)) {
 		ctx.brushActive = brush && brush->active();
+		// Bootstrap: TransformBrush/ExtrudeBrush need preview before internal state exists
+		if (!ctx.brushActive && brush &&
+			(brush->type() == BrushType::Transform || brush->type() == BrushType::Extrude)) {
+			ctx.brushActive = true;
+		}
 	}
 
 	if (ctx.brushActive) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -75,19 +75,58 @@ void ExtrudeBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *v
 }
 
 bool ExtrudeBrush::active() const {
-	return _active;
+	return _active || _cachedSelBBoxValid;
 }
 
 voxel::Region ExtrudeBrush::calcRegion(const BrushContext &ctx) const {
 	if (!_cachedSelBBoxValid || _face == voxel::FaceNames::Max) {
 		return ctx.targetVolumeRegion;
 	}
-	// Expand the cached selection bbox to include all voxels that may be affected
-	// by the extrusion: depth steps + lateral offsets + side wall margin.
+	// Expand the selection bbox along the extrusion direction to cover the
+	// extruded/carved voxels, plus lateral offsets and a small side-wall margin
+	// on perpendicular axes. Only expand in the direction that is actually affected
+	// to keep the region tight (large regions exceed maxPreviewRegion).
+	const math::Axis axis = voxel::faceToAxis(_face);
+	const int axisIdx = math::getIndexForAxis(axis);
+	const int faceSign = voxel::isNegativeFace(_face) ? -1 : 1;
+	const bool carving = _depth < 0;
+	const int dirSign = carving ? -faceSign : faceSign;
+	const int steps = glm::abs(_depth);
+
+	static constexpr int NumAxes = 3;
+	const int perp1 = (axisIdx + 1) % NumAxes;
+	const int perp2 = (axisIdx + 2) % NumAxes;
+
+	glm::ivec3 lo = _cachedSelBBox.getLowerCorner();
+	glm::ivec3 hi = _cachedSelBBox.getUpperCorner();
+
+	// Extend along extrusion axis by depth steps
+	if (dirSign > 0) {
+		hi[axisIdx] += steps;
+	} else {
+		lo[axisIdx] -= steps;
+	}
+
+	// Lateral offset shifts
+	if (_offsetU > 0) {
+		hi[perp1] += _offsetU;
+	} else if (_offsetU < 0) {
+		lo[perp1] += _offsetU;
+	}
+	if (_offsetV > 0) {
+		hi[perp2] += _offsetV;
+	} else if (_offsetV < 0) {
+		lo[perp2] += _offsetV;
+	}
+
+	// Small margin for side walls on perpendicular axes
 	static constexpr int SideWallMargin = 1;
-	const int expand = glm::abs(_depth) + glm::abs(_offsetU) + glm::abs(_offsetV) + SideWallMargin;
-	voxel::Region region = _cachedSelBBox;
-	region.grow(expand);
+	lo[perp1] -= SideWallMargin;
+	hi[perp1] += SideWallMargin;
+	lo[perp2] -= SideWallMargin;
+	hi[perp2] += SideWallMargin;
+
+	voxel::Region region(lo, hi);
 	region.cropTo(ctx.targetVolumeRegion);
 	return region;
 }
@@ -189,10 +228,6 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	};
 
 	const voxel::Voxel air{};
-	// Tip voxel: same as cursor but with FlagOutline so the outermost extrusion layer
-	// stays selected for chaining extrudes (e.g. building a column then bending it).
-	voxel::Voxel tipVoxel = ctx.cursorVoxel;
-	tipVoxel.setFlags(ctx.cursorVoxel.getFlags() | voxel::FlagOutline);
 
 	// Collect selected (FlagOutline) voxel positions to avoid scanning the full volume
 	// (which can be 256^3+) in the extrusion and fill-sides loops.
@@ -222,16 +257,6 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	const glm::ivec3 &lo = selLo;
 	const glm::ivec3 &hi = selHi;
 
-	// Clear FlagOutline on original selected voxels so only the tip stays selected.
-	// Save them to history so depth changes can restore the original selection state.
-	if (!carving) {
-		for (const glm::ivec3 &pos : selectedPositions) {
-			const voxel::Voxel origVoxel = vol->voxel(pos);
-			writeVoxel(pos, voxel::Voxel(origVoxel.getMaterial(), origVoxel.getColor(), origVoxel.getNormal(),
-										 origVoxel.getFlags() & ~voxel::FlagOutline, origVoxel.getBoneIdx()));
-		}
-	}
-
 	// Carve or extrude each selected voxel along dir.
 	for (const glm::ivec3 &selPos : selectedPositions) {
 		// Carving starts at the selected voxel itself (step=0) so the surface layer
@@ -244,29 +269,12 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 			if (!volRegion.containsPoint(newPos)) {
 				break;
 			}
-			// Only the outermost layer gets FlagOutline.
-			const bool isTip = (step == stepLast) && !carving;
-			writeVoxel(newPos, carving ? air : (isTip ? tipVoxel : ctx.cursorVoxel));
-		}
-		// After carving, mark the voxel behind the deepest carved layer
-		// with FlagOutline so the selection moves inward (mirrors tip selection
-		// for positive extrusion). This keeps visual masking active.
-		if (carving) {
-			const glm::ivec3 shift = lateralShift(steps);
-			const glm::ivec3 behindPos = selPos + dir * steps + shift;
-			if (volRegion.containsPoint(behindPos)) {
-				const voxel::Voxel behind = vol->voxel(behindPos);
-				if (!voxel::isAir(behind.getMaterial())) {
-					voxel::Voxel flagged = behind;
-					flagged.setFlags(behind.getFlags() | voxel::FlagOutline);
-					writeVoxel(behindPos, flagged);
-				}
-			}
+			writeVoxel(newPos, carving ? air : ctx.cursorVoxel);
 		}
 	}
 
-	// Expanded bounding box covering tip voxels after lateral offset + side wall margin.
-	// The fill-sides and pruning loops need to find FlagOutline voxels which may have been
+	// Expanded bounding box covering extruded voxels after lateral offset + side wall margin.
+	// The fill-sides and pruning loops need to find selected voxels which may have been
 	// shifted outside the original selection bbox (lo..hi) by the lateral offset.
 	const glm::ivec3 tipShift = lateralShift(steps);
 	const glm::ivec3 extLo = glm::max(glm::min(lo, lo + dir * steps + tipShift) - glm::ivec3(1),
@@ -344,7 +352,9 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	// For outward extrusion: remove any voxel that is now fully interior
 	// (all 6 axis-aligned neighbors solid and within bounds) - invisible voxels waste sparse storage.
 	// Running after fill-sides gives accurate neighbor state before pruning.
-	// Pruned selected (FlagOutline) voxels are saved to history so depth changes restore them.
+	// Important: collect ALL positions to prune first (read-only pass), then remove them.
+	// Pruning one-by-one would mutate the volume mid-iteration, making adjacent voxels
+	// appear non-interior and creating a checkerboard artifact.
 	if (!carving) {
 		auto isInterior = [&](const glm::ivec3 &pos) {
 			for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
@@ -356,16 +366,19 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 			return true;
 		};
 
-		// Prune newly placed voxels (already in history).
+		// Collect all interior positions before modifying the volume.
+		core::DynamicArray<glm::ivec3> toPrune;
+		toPrune.reserve(_history.size());
+
+		// Check newly placed voxels (already in history).
 		for (const HistoryEntry &entry : _history) {
 			const glm::ivec3 &pos = entry.pos;
 			if (!voxel::isAir(vol->voxel(pos).getMaterial()) && isInterior(pos)) {
-				vol->setVoxel(pos, air);
-				wrapper.addToDirtyRegion(pos);
+				toPrune.push_back(pos);
 			}
 		}
 
-		// Prune tip voxels that outward extrusion has now fully surrounded.
+		// Check selected voxels that outward extrusion has now fully surrounded.
 		// Save them to history first so a depth change can restore them.
 		for (int z = extLo.z; z <= extHi.z; ++z) {
 			for (int y = extLo.y; y <= extHi.y; ++y) {
@@ -388,11 +401,16 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 					if (!alreadySaved) {
 						_history.push_back({pos, sv});
 					}
-					vol->setVoxel(pos, air);
-					wrapper.addToDirtyRegion(pos);
+					toPrune.push_back(pos);
 				}
 			}
 		}
+
+		// Now prune all collected positions at once.
+		for (const glm::ivec3 &pos : toPrune) {
+			vol->setVoxel(pos, air);
+		}
+		wrapper.addToDirtyRegion(toPrune);
 	}
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
@@ -30,6 +30,8 @@ void TransformBrush::reset() {
 	_history.clear();
 	_historyPositions.clear();
 	_snapshotRegion = voxel::Region::InvalidRegion;
+	_cachedRegion = voxel::Region::InvalidRegion;
+	_cachedRegionValid = false;
 	_snapshotCenter = glm::vec3(0.0f);
 	_moveOffset = glm::ivec3(0);
 	_shearOffset = glm::ivec3(0);
@@ -52,14 +54,25 @@ void TransformBrush::endBrush(BrushContext &) {
 }
 
 bool TransformBrush::active() const {
-	return _active;
+	return _active || _hasSnapshot;
+}
+
+void TransformBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) {
+	if (!_hasSnapshot && volume != nullptr) {
+		captureSnapshot(volume, ctx.targetVolumeRegion);
+	}
+	_cachedRegion = computeTransformedRegion();
+	_cachedRegionValid = _cachedRegion.isValid();
 }
 
 voxel::Region TransformBrush::calcRegion(const BrushContext &ctx) const {
+	if (_cachedRegionValid) {
+		return _cachedRegion;
+	}
 	return ctx.targetVolumeRegion;
 }
 
-void TransformBrush::captureSnapshot(voxel::RawVolume *volume, const voxel::Region &volRegion) {
+void TransformBrush::captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion) {
 	_snapshot.clear();
 	_snapshotLookup.clear();
 	glm::ivec3 selLo(volRegion.getUpperCorner());
@@ -97,14 +110,31 @@ void TransformBrush::captureSnapshot(voxel::RawVolume *volume, const voxel::Regi
 	_hasSnapshot = true;
 }
 
-void TransformBrush::restoreHistory(voxel::RawVolume *volume, ModifierVolumeWrapper &wrapper) {
-	for (const HistoryEntry &entry : _history) {
-		if (volume->setVoxel(entry.pos, entry.original)) {
-			wrapper.addToDirtyRegion(entry.pos);
-		}
+voxel::Region TransformBrush::computeTransformedRegion() const {
+	if (!_hasSnapshot || _snapshot.empty()) {
+		return voxel::Region::InvalidRegion;
 	}
-	_history.clear();
-	_historyPositions.clear();
+	const glm::ivec3 &srcLo = _snapshotRegion.getLowerCorner();
+	const glm::ivec3 &srcHi = _snapshotRegion.getUpperCorner();
+	glm::ivec3 dstLo = srcLo;
+	glm::ivec3 dstHi = srcHi;
+
+	static constexpr int NumCorners = 8;
+	for (int corner = 0; corner < NumCorners; ++corner) {
+		const glm::ivec3 cornerPos(
+			(corner & 1) ? srcHi.x : srcLo.x,
+			(corner & 2) ? srcHi.y : srcLo.y,
+			(corner & 4) ? srcHi.z : srcLo.z);
+		const glm::ivec3 transformed = transformPosition(cornerPos);
+		dstLo = glm::min(dstLo, transformed);
+		dstHi = glm::max(dstHi, transformed);
+	}
+
+	// Union of original and transformed regions with a small margin for rounding
+	static constexpr int Margin = 2;
+	const glm::ivec3 unionLo = glm::min(srcLo, dstLo) - Margin;
+	const glm::ivec3 unionHi = glm::max(srcHi, dstHi) + Margin;
+	return voxel::Region(unionLo, unionHi);
 }
 
 glm::ivec3 TransformBrush::transformPosition(const glm::ivec3 &pos) const {
@@ -447,6 +477,8 @@ void TransformBrush::applyTransform(ModifierVolumeWrapper &wrapper, const BrushC
 
 	// Prune interior voxels: remove any transformed voxel that is fully enclosed
 	// by 6 solid neighbors. These are invisible and waste sparse storage.
+	// Collect all positions first (read-only), then prune — mutating during
+	// iteration would cause adjacent voxels to appear non-interior (checkerboard).
 	auto isInterior = [&](const glm::ivec3 &pos) {
 		for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
 			const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
@@ -457,34 +489,41 @@ void TransformBrush::applyTransform(ModifierVolumeWrapper &wrapper, const BrushC
 		return true;
 	};
 
+	core::DynamicArray<glm::ivec3> toPrune;
+	toPrune.reserve(_history.size());
 	for (const HistoryEntry &entry : _history) {
 		const glm::ivec3 &pos = entry.pos;
 		const voxel::Voxel &current = vol->voxel(pos);
 		if (!voxel::isAir(current.getMaterial()) && isInterior(pos)) {
-			vol->setVoxel(pos, air);
-			wrapper.addToDirtyRegion(pos);
+			toPrune.push_back(pos);
 		}
 	}
+	for (const glm::ivec3 &pos : toPrune) {
+		vol->setVoxel(pos, air);
+	}
+	wrapper.addToDirtyRegion(toPrune);
 }
 
 void TransformBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
 							  const voxel::Region &) {
-	voxel::RawVolume *vol = wrapper.volume();
-	const voxel::Region &volRegion = vol->region();
-
-	// Capture snapshot on first use
 	if (!_hasSnapshot) {
-		captureSnapshot(vol, volRegion);
-		if (!_hasSnapshot) {
-			return;
-		}
+		return;
 	}
 
+	voxel::RawVolume *vol = wrapper.volume();
+
 	// Restore previously transformed state before re-applying
-	restoreHistory(vol, wrapper);
+	for (const HistoryEntry &entry : _history) {
+		if (vol->setVoxel(entry.pos, entry.original)) {
+			wrapper.addToDirtyRegion(entry.pos);
+		}
+	}
+	_history.clear();
+	_historyPositions.clear();
 
 	// Apply the current transform from the original snapshot
 	applyTransform(wrapper, ctx);
+	markDirty();
 }
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -50,7 +50,8 @@ static_assert(lengthof(ScaleSamplingStr) == (int)ScaleSampling::Max, "ScaleSampl
 /**
  * @brief Transforms selected voxels: move, shear, scale, rotate
  *
- * When the brush becomes active it captures the original selected voxels.
+ * When the brush becomes active it captures the original selected voxels
+ * in preExecute() from the real volume.
  * Consecutive parameter changes always re-transform from the original snapshot
  * so transforms are absolute, not incremental.
  * On finalize (reset/brush switch) the final state is committed to the undo stack.
@@ -83,13 +84,17 @@ private:
 	// Center of selection (used as pivot for scale/rotate)
 	glm::vec3 _snapshotCenter{0.0f};
 
-	// For each position overwritten, stores the original voxel for rollback
+	// Per-generate bookkeeping: tracks positions written during a single generate()
+	// call so interior pruning can find all modified positions.
 	core::DynamicArray<HistoryEntry> _history;
-	// Fast O(1) lookup for history positions to avoid linear scans
 	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> _historyPositions;
 
 	// Spatial lookup: snapshot position -> index into _snapshot for O(1) access
 	core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>> _snapshotLookup;
+
+	// Cached region for preview (union of snapshot + transformed bounding box)
+	voxel::Region _cachedRegion;
+	bool _cachedRegionValid = false;
 
 	// Transform parameters
 	glm::ivec3 _moveOffset{0};
@@ -97,9 +102,9 @@ private:
 	glm::vec3 _scale{1.0f, 1.0f, 1.0f};
 	glm::vec3 _rotationDegrees{0.0f, 0.0f, 0.0f};
 
-	void captureSnapshot(voxel::RawVolume *volume, const voxel::Region &volRegion);
+	void captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion);
 	void applyTransform(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
-	void restoreHistory(voxel::RawVolume *volume, ModifierVolumeWrapper &wrapper);
+	voxel::Region computeTransformedRegion() const;
 	glm::ivec3 transformPosition(const glm::ivec3 &pos) const;
 	glm::vec3 inverseTransformPosition(const glm::ivec3 &pos) const;
 	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
@@ -122,6 +127,7 @@ public:
 	virtual ~TransformBrush() = default;
 
 	void reset() override;
+	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;
 	bool active() const override;
@@ -150,6 +156,8 @@ public:
 		_snapshot.clear();
 		_snapshotLookup.clear();
 		_hasSnapshot = false;
+		_cachedRegionValid = false;
+		_cachedRegion = voxel::Region::InvalidRegion;
 		_moveOffset = glm::ivec3(0);
 		_shearOffset = glm::ivec3(0);
 		_scale = glm::vec3(1.0f);

--- a/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
@@ -23,9 +23,8 @@ namespace voxedit {
 //   depth=-1 -> voxel at x=-1 erased (inward / carve)
 //
 // FlagOutline handling:
-//   - Original selected voxels have FlagOutline cleared during extrusion.
-//   - Only the outermost (tip) layer gets FlagOutline for chaining extrudes.
-//   - On carve, the voxel behind the deepest carved layer gets FlagOutline.
+//   - Selected voxels (FlagOutline) are left unchanged during extrusion.
+//   - New extruded voxels do not get FlagOutline.
 
 class ExtrudeBrushTest : public app::AbstractTest {
 protected:
@@ -326,8 +325,8 @@ TEST_F(ExtrudeBrushTest, testExtrudeWithOffsetU) {
 	brush.shutdown();
 }
 
-// Tip-only selection: only outermost extruded layer gets FlagOutline
-TEST_F(ExtrudeBrushTest, testExtrudeTipOnlySelection) {
+// Extrusion preserves FlagOutline on originals and does not set it on new voxels
+TEST_F(ExtrudeBrushTest, testExtrudePreservesSelection) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	volume.setVoxel(0, 0, 0, selectedVoxel());
 
@@ -346,26 +345,25 @@ TEST_F(ExtrudeBrushTest, testExtrudeTipOnlySelection) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Original voxel should have FlagOutline cleared
+	// Original voxel should still have FlagOutline
 	const voxel::Voxel origVoxel = volume.voxel(0, 0, 0);
-	EXPECT_FALSE(origVoxel.getFlags() & voxel::FlagOutline)
-		<< "Original voxel at (0,0,0) should not have FlagOutline after extrusion";
-	// Step 1 (intermediate) should NOT have FlagOutline
+	EXPECT_TRUE(origVoxel.getFlags() & voxel::FlagOutline)
+		<< "Original voxel at (0,0,0) should keep FlagOutline after extrusion";
+	// New extruded voxels should NOT have FlagOutline
 	const voxel::Voxel midVoxel = volume.voxel(1, 0, 0);
 	EXPECT_TRUE(voxel::isBlocked(midVoxel.getMaterial()));
 	EXPECT_FALSE(midVoxel.getFlags() & voxel::FlagOutline)
-		<< "Intermediate voxel at (1,0,0) should not have FlagOutline";
-	// Step 2 (tip) should have FlagOutline
-	const voxel::Voxel tipVoxel = volume.voxel(2, 0, 0);
-	EXPECT_TRUE(voxel::isBlocked(tipVoxel.getMaterial()));
-	EXPECT_TRUE(tipVoxel.getFlags() & voxel::FlagOutline)
-		<< "Tip voxel at (2,0,0) should have FlagOutline for chaining";
+		<< "Extruded voxel at (1,0,0) should not have FlagOutline";
+	const voxel::Voxel endVoxel = volume.voxel(2, 0, 0);
+	EXPECT_TRUE(voxel::isBlocked(endVoxel.getMaterial()));
+	EXPECT_FALSE(endVoxel.getFlags() & voxel::FlagOutline)
+		<< "Extruded voxel at (2,0,0) should not have FlagOutline";
 
 	brush.shutdown();
 }
 
-// Carve-behind selection: after carving, the voxel behind the deepest carved layer gets FlagOutline
-TEST_F(ExtrudeBrushTest, testExtrudeCarveBehindSelection) {
+// Carving does not modify FlagOutline on remaining voxels
+TEST_F(ExtrudeBrushTest, testExtrudeCarveNoFlagChange) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
 	// Solid block from x=-3 to x=0, surface at x=0 is selected
@@ -390,11 +388,11 @@ TEST_F(ExtrudeBrushTest, testExtrudeCarveBehindSelection) {
 
 	// Carved voxel at x=0 should be air
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()));
-	// Behind the carved layer at x=-1 should now have FlagOutline
+	// Behind the carved layer at x=-1 should NOT have FlagOutline added
 	const voxel::Voxel behindVoxel = volume.voxel(-1, 0, 0);
 	EXPECT_TRUE(voxel::isBlocked(behindVoxel.getMaterial()));
-	EXPECT_TRUE(behindVoxel.getFlags() & voxel::FlagOutline)
-		<< "Voxel behind carved layer at (-1,0,0) should have FlagOutline for selection continuity";
+	EXPECT_FALSE(behindVoxel.getFlags() & voxel::FlagOutline)
+		<< "Voxel behind carved layer at (-1,0,0) should not have FlagOutline";
 
 	brush.shutdown();
 }

--- a/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
@@ -27,7 +27,6 @@ protected:
 		ModifierVolumeWrapper wrapper(node, ModifierType::Override);
 		brush.preExecute(ctx, wrapper.volume());
 		brush.execute(sceneGraph, wrapper, ctx);
-		brush.endBrush(ctx);
 	}
 };
 
@@ -48,6 +47,7 @@ TEST_F(TransformBrushTest, testMovePositiveX) {
 
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
 		<< "Original position should be empty after move";
@@ -77,12 +77,14 @@ TEST_F(TransformBrushTest, testMoveReversible) {
 	brush.setMoveOffset(glm::ivec3(3, 0, 0));
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()));
 
 	// Move back to 0 (same snapshot, different offset)
 	brush.setMoveOffset(glm::ivec3(0, 0, 0));
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
 		<< "Voxel should be back at original position";
 	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 0, 0).getMaterial()))
@@ -113,6 +115,7 @@ TEST_F(TransformBrushTest, testScaleUp) {
 
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 
 	// Scaled up 2x: center should still have a voxel, and edges should be further out
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
@@ -145,6 +148,7 @@ TEST_F(TransformBrushTest, testRotate90) {
 
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 
 	// After 90-degree Z rotation, line along X should become line along Y
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 2, 0).getMaterial()))
@@ -189,6 +193,7 @@ TEST_F(TransformBrushTest, testCommitOnModeSwitch) {
 	// Execute move
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()));
 
 	// Switch to scale: should commit the move (not jump back)
@@ -197,6 +202,14 @@ TEST_F(TransformBrushTest, testCommitOnModeSwitch) {
 		<< "Moved voxel should stay at (3,0,0) after mode switch";
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
 		<< "Original position should remain empty after mode switch";
+
+	// Now execute scale from the new position (3,0,0)
+	brush.setScale(glm::vec3(1.0f));
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Identity scale should keep voxel at (3,0,0)";
 
 	brush.shutdown();
 }


### PR DESCRIPTION
## Summary
- Add ghost overlay preview for ExtrudeBrush (positive depth) and TransformBrush so users see changes before committing
- Fix checkerboard artifact in interior pruning for both brushes (collect-then-prune instead of mutate-during-iteration)
- Tight `calcRegion()` for ExtrudeBrush expanding only along extrusion direction (fixes preview vanishing on thin models)
- Remove tip-only FlagOutline and carve-behind selection from ExtrudeBrush — originals keep FlagOutline unchanged
- TransformBrush: `preExecute()` with snapshot capture and `computeTransformedRegion()` for tight preview region
- Negative extrusion (carving) applies directly since air voxels can't render as ghost overlay

## Test plan
- [ ] ExtrudeBrush: select voxels, extrude positive depth — ghost preview visible, real volume unchanged until committed
- [ ] ExtrudeBrush: extrude negative depth — carving applies immediately
- [ ] ExtrudeBrush: return to depth=0 from negative — selection restored
- [ ] ExtrudeBrush: lateral offsets with preview
- [ ] TransformBrush: move/shear/scale/rotate — ghost preview visible
- [ ] Verify no checkerboard artifacts when extruding cube corners
- [ ] 12 ExtrudeBrush tests + 6 TransformBrush tests pass