### PR TITLE
VOXEDIT: add Circle shape type for hollow cylinders

### DIFF
--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -966,6 +966,18 @@ static int luaVoxel_shape_cone(lua_State* s) {
 	return 0;
 }
 
+static int luaVoxel_shape_circle(lua_State* s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const glm::vec3& centerBottom = clua_tovec<glm::vec3>(s, 2);
+	const math::Axis axis = luaVoxel_getAxis(s, 3);
+	const int radius = (int)luaL_checkinteger(s, 4);
+	const int height = (int)luaL_checkinteger(s, 5);
+	const int thickness = (int)luaL_optinteger(s, 6, 1);
+	const voxel::Voxel voxel = luaVoxel_getVoxel(s, 7);
+	shape::createHollowCylinder(*volume, centerBottom, axis, radius, height, thickness, voxel);
+	return 0;
+}
+
 static int luaVoxel_shape_line(lua_State* s) {
 	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
 	const glm::ivec3& start = clua_tovec<glm::ivec3>(s, 2);
@@ -3528,6 +3540,24 @@ static int luaVoxel_shape_bezier_jsonhelp(lua_State* s) {
 	return 1;
 }
 
+static int luaVoxel_shape_circle_jsonhelp(lua_State* s) {
+	const char *json = R"({
+		"name": "circle",
+		"summary": "Create a hollow cylinder (tube) shape in the volume.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to draw in."},
+			{"name": "centerBottom", "type": "vec3", "description": "The center bottom position."},
+			{"name": "axis", "type": "string", "description": "The axis: 'x', 'y', or 'z' (default 'y')."},
+			{"name": "radius", "type": "integer", "description": "The outer radius of the cylinder."},
+			{"name": "height", "type": "integer", "description": "The height of the cylinder."},
+			{"name": "thickness", "type": "integer", "description": "The wall thickness in voxels (optional, default 1)."},
+			{"name": "color", "type": "integer", "description": "The color index (optional, default 1)."}
+		],
+		"returns": []})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
 // Noise jsonhelp functions
 static int luaVoxel_noise_simplex2_jsonhelp(lua_State* s) {
 	const char *json = R"({
@@ -5698,6 +5728,7 @@ static void prepareState(lua_State* s) {
 		{"cone", luaVoxel_shape_cone, luaVoxel_shape_cone_jsonhelp},
 		{"line", luaVoxel_shape_line, luaVoxel_shape_line_jsonhelp},
 		{"bezier", luaVoxel_shape_bezier, luaVoxel_shape_bezier_jsonhelp},
+		{"circle", luaVoxel_shape_circle, luaVoxel_shape_circle_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, shapeFuncs, luaVoxel_metashape(), "g_shape");

--- a/src/modules/voxelgenerator/ShapeGenerator.h
+++ b/src/modules/voxelgenerator/ShapeGenerator.h
@@ -54,6 +54,67 @@ void createCirclePlane(Volume& volume, const glm::ivec3& center, math::Axis axis
 }
 
 /**
+ * @brief Creates a circle outline (ring) - only the perimeter voxels
+ * @param[in,out] volume The volume (RawVolume) to place the voxels into
+ * @param[in] center The position to place the object at
+ * @param[in] axis The axis perpendicular to the circle plane
+ * @param[in] width The width of the bounding box
+ * @param[in] depth The depth of the bounding box
+ * @param[in] radius The outer radius that defines the circle
+ * @param[in] thickness The wall thickness in voxels
+ * @param[in] voxel The Voxel to build the object with
+ */
+template<class Volume, class VoxelType>
+void createCircleOutline(Volume& volume, const glm::ivec3& center, math::Axis axis, int width, int depth, double radius, int thickness, const VoxelType& voxel) {
+	const double xRadius = width / 2.0;
+	const double zRadius = depth / 2.0;
+	const double innerRadius = core_max(0.0, radius - thickness);
+
+	for (double z = -zRadius; z <= zRadius; ++z) {
+		const double distanceZ = glm::pow(z, 2.0);
+		for (double x = -xRadius; x <= xRadius; ++x) {
+			const double distance = glm::sqrt(glm::pow(x, 2.0) + distanceZ);
+			if (distance > radius || distance < innerRadius) {
+				continue;
+			}
+			if (axis == math::Axis::X) {
+				volume.setVoxel(center.x, center.y + x, center.z + z, voxel);
+			} else if (axis == math::Axis::Y) {
+				volume.setVoxel(center.x + x, center.y, center.z + z, voxel);
+			} else {
+				volume.setVoxel(center.x + x, center.y + z, center.z, voxel);
+			}
+		}
+	}
+}
+
+/**
+ * @brief Creates a hollow cylinder (tube) by stacking circle outlines
+ * @param[in,out] volume The volume (RawVolume) to place the voxels into
+ * @param[in] centerBottom The bottom center position
+ * @param[in] axis The axis along which the cylinder extends
+ * @param[in] radius The outer radius of the cylinder
+ * @param[in] height The height of the cylinder
+ * @param[in] thickness The wall thickness in voxels
+ * @param[in] voxel The Voxel to build the object with
+ */
+template<class Volume, class VoxelType>
+void createHollowCylinder(Volume& volume, const glm::vec3& centerBottom, const math::Axis axis, int radius, int height, int thickness, const VoxelType& voxel) {
+	if (axis == math::Axis::None) {
+		return;
+	}
+
+	const int axisIdx = math::getIndexForAxis(axis);
+	glm::ivec3 circleCenter = centerBottom;
+	glm::ivec3 offset{0};
+	offset[axisIdx] = 1;
+	for (int i = 0; i < height; ++i) {
+		createCircleOutline(volume, circleCenter, axis, radius * 2, radius * 2, radius, thickness, voxel);
+		circleCenter += offset;
+	}
+}
+
+/**
  * @brief Creates a cube with the given position being the center of the cube
  * @param[in,out] volume The volume (RawVolume) to place the voxels into
  * @param[in] center The position to place the object at

--- a/src/modules/voxelgenerator/tests/ShapeGeneratorTest.cpp
+++ b/src/modules/voxelgenerator/tests/ShapeGeneratorTest.cpp
@@ -218,6 +218,45 @@ TEST_F(ShapeGeneratorTest, testCreateCylinder) {
 	verify("cylinder.qb");
 }
 
+TEST_F(ShapeGeneratorTest, testCreateCircleOutline) {
+	voxel::RawVolumeWrapper wrapper(_volume);
+	glm::ivec3 center = _center;
+	center.y = _region.getLowerY();
+	const int radius = 10;
+	const int thickness = 2;
+	shape::createCircleOutline(wrapper, center, math::Axis::Y, radius * 2, radius * 2, radius, thickness, _voxel);
+	const int count = voxelutil::countVoxels(*_volume);
+	EXPECT_GT(count, 0);
+
+	// verify the center is empty (hollow)
+	EXPECT_TRUE(voxel::isAir(_volume->voxel(center.x, center.y, center.z).getMaterial()));
+}
+
+TEST_F(ShapeGeneratorTest, testCreateHollowCylinder) {
+	voxel::RawVolumeWrapper wrapper(_volume);
+	glm::ivec3 centerBottom = _center;
+	centerBottom.y = _region.getLowerY();
+	const int radius = 10;
+	const int thickness = 2;
+	shape::createHollowCylinder(wrapper, centerBottom, math::Axis::Y, radius, _height, thickness, _voxel);
+	const int hollowCount = voxelutil::countVoxels(*_volume);
+
+	// compare with filled cylinder - hollow should have fewer voxels
+	voxel::RawVolume filledVolume(_region);
+	voxel::RawVolumeWrapper filledWrapper(&filledVolume);
+	shape::createCylinder(filledWrapper, centerBottom, math::Axis::Y, radius, _height, _voxel);
+	const int filledCount = voxelutil::countVoxels(filledVolume);
+
+	EXPECT_GT(hollowCount, 0);
+	EXPECT_LT(hollowCount, filledCount);
+
+	// verify the center column is empty
+	for (int y = centerBottom.y; y < centerBottom.y + _height; ++y) {
+		EXPECT_TRUE(voxel::isAir(_volume->voxel(centerBottom.x, y, centerBottom.z).getMaterial()))
+			<< "Center should be empty at y=" << y;
+	}
+}
+
 TEST_F(ShapeGeneratorTest, testCreateCirclePlaneX) {
 	testCreateCirclePlane(math::Axis::X);
 	save("circleplaneX.qb");

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -73,6 +73,13 @@ void BrushPanel::addShapes(command::CommandExecutionListener &listener) {
 		}
 		ImGui::EndCombo();
 	}
+
+	if (currentSelectedShapeType == ShapeType::Circle) {
+		int thickness = modifier.shapeBrush().thickness();
+		if (ImGui::InputInt(_("Thickness"), &thickness)) {
+			modifier.shapeBrush().setThickness(thickness);
+		}
+	}
 }
 
 bool BrushPanel::mirrorAxisRadioButton(const char *title, math::Axis type, command::CommandExecutionListener &listener,

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ShapeType.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ShapeType.h
@@ -15,6 +15,7 @@ enum ShapeType {
 	Cone,
 	Dome,
 	Ellipse,
+	Circle,
 
 	Max,
 	Min = AABB,
@@ -27,7 +28,8 @@ static constexpr const char *ShapeTypeStr[ShapeType::Max]{
 	"Cylinder",
 	"Cone",
 	"Dome",
-	"Ellipse"
+	"Ellipse",
+	"Circle"
 };
 // clang-format on
 static_assert(lengthof(ShapeTypeStr) == (int)ShapeType::Max, "Array size mismatch");

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ShapeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ShapeBrush.cpp
@@ -116,14 +116,29 @@ void ShapeBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrap
 	case ShapeType::Ellipse:
 		voxelgenerator::shape::createEllipse(wrapper, centerBottom, axis, width, height, depth, voxel);
 		break;
+	case ShapeType::Circle: {
+		const int radius = (int)glm::round(size / 2.0);
+		voxelgenerator::shape::createHollowCylinder(wrapper, centerBottom, axis, radius, height, _thickness, voxel);
+		break;
+	}
 	case ShapeType::Max:
 		Log::warn("Invalid shape type selected - can't perform action");
 	}
 }
 
+int ShapeBrush::thickness() const {
+	return _thickness;
+}
+
+void ShapeBrush::setThickness(int thickness) {
+	_thickness = core_max(1, thickness);
+	markDirty();
+}
+
 void ShapeBrush::reset() {
 	Super::reset();
 	_shapeType = ShapeType::AABB;
+	_thickness = 1;
 }
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ShapeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ShapeBrush.h
@@ -21,6 +21,7 @@ namespace voxedit {
  * - **Cone**: Tapered cylinder
  * - **Dome**: Half-ellipse/sphere
  * - **Ellipse**: Stretched sphere
+ * - **Circle**: Hollow cylinder (tube) with configurable wall thickness
  *
  * The shape is oriented based on which face was hit when starting the AABB. The
  * face normal determines the "up" direction for shapes like cones and cylinders.
@@ -52,6 +53,7 @@ protected:
 										int &depth) const;
 
 	ShapeType _shapeType = ShapeType::AABB; ///< Current shape being generated
+	int _thickness = 1; ///< Wall thickness for hollow shapes (e.g., Circle)
 
 	/**
 	 * @brief Generate the selected shape within the given region
@@ -79,6 +81,16 @@ public:
 	 * @return The currently active shape type
 	 */
 	ShapeType shapeType() const;
+
+	/**
+	 * @return The wall thickness for hollow shapes
+	 */
+	int thickness() const;
+
+	/**
+	 * @brief Set the wall thickness for hollow shapes
+	 */
+	void setThickness(int thickness);
 };
 
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- Add a new **Circle** shape type to the shape brush that generates hollow circles (rings) for creating open tubes and pipes
- Configurable **wall thickness** parameter (UI slider shown when Circle shape is selected)
- New `createCircleOutline()` and `createHollowCylinder()` generator functions in ShapeGenerator
- Command `shapecircle` auto-registered for keybinding support
- 2 unit tests verifying hollow geometry and center emptiness

## Test plan
- [ ] Select Shape brush, pick "Circle" from the Shape dropdown
- [ ] Draw a region — verify a hollow cylinder (tube) is generated with empty interior
- [ ] Adjust the Thickness slider — verify wall thickness changes accordingly
- [ ] Test on different faces (X/Y/Z orientation) to confirm correct axis alignment
- [ ] Run `tests-voxelgenerator` — verify `testCreateCircleOutline` and `testCreateHollowCylinder` pass