### PR TITLE
VOXEDIT: brush lifecycle, gizmo fix, preview-only workflow and pruning

### DIFF
--- a/src/modules/ui/IMGUIEx.cpp
+++ b/src/modules/ui/IMGUIEx.cpp
@@ -191,7 +191,8 @@ static bool SliderIntMinMax(const char *id, int *val, int lo, int hi) {
 	}
 	ImGui::EndDisabled();
 	ImGui::SameLine();
-	ImGui::SetNextItemWidth(-1);
+	const float buttonWidth = ImGui::CalcTextSize("+").x + ImGui::GetStyle().FramePadding.x * 2.0f + ImGui::GetStyle().ItemSpacing.x;
+	ImGui::SetNextItemWidth(-(buttonWidth));
 	if (ImGui::SliderInt("", val, lo, hi)) {
 		changed = true;
 	}

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -776,33 +776,24 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 	if (depth == 0 && (!node || !node->hasSelection())) {
 		ImGui::TextColored(warningTextColor, "%s", _("No selection active - use the Select brush first"));
 	}
-	// Carving (negative depth) applies directly to the real volume because the preview
-	// system can only render solid voxels - carved (air) positions are invisible as ghosts.
-	// Positive extrusion uses preview-only (ghost overlay of new voxels).
-	// depth==0 also applies to restore the real volume when transitioning back from carving
-	// (the history mechanism undoes the carve, restoring the original selected voxels).
-	auto applyIfCarving = [&]() {
-		if (brush.depth() <= 0) {
-			executeExtrudeBrush();
-		}
-	};
-
+	// All depth/offset changes are preview-only. The preview system creates a fresh
+	// volume copy each frame and generate() writes to it. Commit happens on brush switch.
 	ImGui::TextUnformatted(_("Depth"));
 	if (ImGui::Button("-##extrude_depth")) {
 		brush.setDepth(depth - 1);
-		applyIfCarving();
 	}
 	ImGui::SameLine();
 	if (ImGui::SliderInt("##extrude_depth_slider", &depth, -maxDepth, maxDepth)) {
 		brush.setDepth(depth);
 	}
-	if (ImGui::IsItemDeactivatedAfterEdit()) {
-		applyIfCarving();
-	}
 	ImGui::SameLine();
 	if (ImGui::Button("+##extrude_depth")) {
 		brush.setDepth(depth + 1);
-		applyIfCarving();
+	}
+
+	bool fillWalls = brush.fillWalls();
+	if (ImGui::Checkbox(_("Fill walls"), &fillWalls)) {
+		brush.setFillWalls(fillWalls);
 	}
 
 	// Lateral offset sliders - only shown when depth is non-zero.
@@ -817,38 +808,28 @@ void BrushPanel::updateExtrudeBrushPanel(command::CommandExecutionListener &list
 		ImGui::Text(_("Offset %s"), AxisLabels[perp1]);
 		if (ImGui::Button("-##extrude_offsetU")) {
 			brush.setOffsetU(offsetU - 1);
-			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::SliderInt("##extrude_offsetU_slider", &offsetU, -maxDepth, maxDepth)) {
 			brush.setOffsetU(offsetU);
 		}
-		if (ImGui::IsItemDeactivatedAfterEdit()) {
-			applyIfCarving();
-		}
 		ImGui::SameLine();
 		if (ImGui::Button("+##extrude_offsetU")) {
 			brush.setOffsetU(offsetU + 1);
-			applyIfCarving();
 		}
 
 		int offsetV = brush.offsetV();
 		ImGui::Text(_("Offset %s"), AxisLabels[perp2]);
 		if (ImGui::Button("-##extrude_offsetV")) {
 			brush.setOffsetV(offsetV - 1);
-			applyIfCarving();
 		}
 		ImGui::SameLine();
 		if (ImGui::SliderInt("##extrude_offsetV_slider", &offsetV, -maxDepth, maxDepth)) {
 			brush.setOffsetV(offsetV);
 		}
-		if (ImGui::IsItemDeactivatedAfterEdit()) {
-			applyIfCarving();
-		}
 		ImGui::SameLine();
 		if (ImGui::Button("+##extrude_offsetV")) {
 			brush.setOffsetV(offsetV + 1);
-			applyIfCarving();
 		}
 	}
 }
@@ -890,6 +871,9 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 			const TransformMode mode = (TransformMode)i;
 			const bool selected = mode == currentTransformMode;
 			if (ImGui::Selectable(_(TransformModeStr[i]), selected)) {
+				if (brush.hasSnapshot()) {
+					executeTransformBrush();
+				}
 				brush.setTransformMode(mode);
 			}
 			if (selected) {

--- a/src/tools/voxedit/modules/voxedit-ui/Viewport.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/Viewport.cpp
@@ -927,17 +927,20 @@ bool Viewport::runBrushGizmo(const video::Camera &camera) {
 	Modifier &modifier = _sceneMgr->modifier();
 	Brush *brush = modifier.currentBrush();
 	if (brush == nullptr) {
+		modifier.setBrushGizmoActive(false);
 		return false;
 	}
 
 	const BrushContext &ctx = modifier.brushContext();
 	if (!brush->wantBrushGizmo(ctx)) {
+		modifier.setBrushGizmoActive(false);
 		return false;
 	}
 
 	BrushGizmoState state;
 	brush->brushGizmoState(ctx, state);
 	if (state.operations == BrushGizmo_None) {
+		modifier.setBrushGizmoActive(false);
 		return false;
 	}
 
@@ -966,6 +969,7 @@ bool Viewport::runBrushGizmo(const video::Camera &camera) {
 	}
 
 	if (imguizmoOp == 0) {
+		modifier.setBrushGizmoActive(false);
 		return false;
 	}
 
@@ -984,6 +988,11 @@ bool Viewport::runBrushGizmo(const video::Camera &camera) {
 
 	const bool manipulated = ImGuizmo::Manipulate(vMatPtr, pMatPtr, (ImGuizmo::OPERATION)imguizmoOp, mode, mPtr,
 												  dMatPtr, snapPtr, boundsPtr, boundsSnap);
+
+	// Track whether the brush gizmo is being interacted with so the action
+	// button (ModifierButton) does not commit intermediate transforms
+	modifier.setBrushGizmoActive(ImGuizmo::IsUsing());
+
 	if (!manipulated) {
 		return false;
 	}
@@ -1056,6 +1065,8 @@ bool Viewport::renderGizmo(video::Camera &camera, float headerSize, const ImVec2
 		ImGuizmo::Enable(true);
 		brushGizmoModified = runBrushGizmo(camera);
 		ImGuizmo::PopID();
+	} else {
+		_sceneMgr->modifier().setBrushGizmoActive(false);
 	}
 
 	ImGuizmo::Enable(isSceneMode() || _modelGizmo->boolVal());

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -470,16 +470,36 @@ bool Modifier::modifierTypeRequiresExistingVoxel() const {
 }
 
 BrushType Modifier::setBrushType(BrushType type) {
+	if (_brushType == type) {
+		return _brushType;
+	}
+
+	// Auto-commit pending changes from the current brush before switching.
+	// Must happen before changing _brushType so currentBrush() returns the old brush.
+	Brush *oldBrush = currentBrush();
+	if (oldBrush && oldBrush->onDeactivated()) {
+		if (beginBrushFromPanel()) {
+			_sceneMgr->nodeForeachGroup([&](int nodeId) {
+				if (scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId)) {
+					if (!node->visible()) {
+						return;
+					}
+					auto callback = [&](const voxel::Region &region, ModifierType modType, SceneModifiedFlags flags) {
+						_sceneMgr->modified(nodeId, region, flags);
+					};
+					execute(_sceneMgr->sceneGraph(), *node, callback);
+				}
+			});
+			endBrush();
+		}
+		oldBrush->reset();
+	}
+
 	_brushType = type;
-	if (_brushType != BrushType::None) {
-		// ensure the modifier type is compatible with the brush
-		setModifierType(currentBrush()->modifierType(_brushContext.modifierType));
-	}
-	if (_brushType == BrushType::Extrude) {
-		_extrudeBrush.reset();
-	}
-	if (_brushType == BrushType::Transform) {
-		_transformBrush.reset();
+	Brush *newBrush = currentBrush();
+	if (newBrush) {
+		setModifierType(newBrush->modifierType(_brushContext.modifierType));
+		newBrush->onActivated();
 	}
 	return _brushType;
 }

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
@@ -78,6 +78,9 @@ protected:
 	// this can be useful when the user is interaction with the ui elements
 	// and we don't want to modify the volume
 	bool _locked = false;
+	// set to true while the brush gizmo is being interacted with
+	// prevents the action button from committing intermediate transforms
+	bool _brushGizmoActive = false;
 
 	/**
 	 * timer value which indicates the next execution time in case you keep the
@@ -146,6 +149,13 @@ public:
 	void unlock();
 	inline bool isLocked() const {
 		return _locked;
+	}
+
+	inline void setBrushGizmoActive(bool active) {
+		_brushGizmoActive = active;
+	}
+	inline bool isBrushGizmoActive() const {
+		return _brushGizmoActive;
 	}
 
 	math::Axis lockedAxis() const;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ModifierButton.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ModifierButton.cpp
@@ -25,6 +25,9 @@ bool ModifierButton::handleDown(int32_t key, double pressedMillis) {
 		return initialDown;
 	}
 	if (initialDown) {
+		if (modifier.isBrushGizmoActive()) {
+			return initialDown;
+		}
 		if (_newType != ModifierType::None) {
 			_oldType = modifier.modifierType();
 			modifier.setModifierType(_newType);
@@ -43,6 +46,10 @@ bool ModifierButton::handleUp(int32_t key, double releasedMillis) {
 	}
 	if (allUp) {
 		Modifier &modifier = _sceneMgr->modifier();
+		if (modifier.isBrushGizmoActive()) {
+			modifier.endBrush();
+			return allUp;
+		}
 		_furtherAction = modifier.needsAdditionalAction();
 		if (_furtherAction) {
 			modifier.executeAdditionalAction();

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
@@ -266,6 +266,21 @@ public:
 	}
 
 	/**
+	 * @brief Called when this brush becomes the active brush.
+	 */
+	virtual void onActivated() {
+	}
+
+	/**
+	 * @brief Called when this brush is about to be replaced by another brush.
+	 * @return true if the brush has pending changes that should be committed
+	 * to the real volume before deactivation (via the normal execute path).
+	 */
+	virtual bool onDeactivated() {
+		return false;
+	}
+
+	/**
 	 * @brief Reset the brush to initial state
 	 *
 	 * Clears all brush state including mirroring, clamping, and internal modes.

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -15,6 +15,16 @@
 
 namespace voxedit {
 
+using PositionSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+
+void ExtrudeBrush::onActivated() {
+	reset();
+}
+
+bool ExtrudeBrush::onDeactivated() {
+	return _depth != 0 && _hasCachedSelection;
+}
+
 void ExtrudeBrush::reset() {
 	Super::reset();
 	_depth = 0;
@@ -23,7 +33,14 @@ void ExtrudeBrush::reset() {
 	_face = voxel::FaceNames::Max;
 	_active = false;
 	_history.clear();
+	_cachedSelectedPositions.clear();
+	_cachedWallCandidates.clear();
+	_cachedSelectedBBox = voxel::Region::InvalidRegion;
+	_hasCachedSelection = false;
+	_capturedVolumeLower = glm::ivec3(0);
 	_cachedSelBBoxValid = false;
+	_fillWalls = true;
+	_lastVolume = nullptr;
 }
 
 bool ExtrudeBrush::beginBrush(const BrushContext &ctx) {
@@ -40,6 +57,38 @@ bool ExtrudeBrush::beginBrush(const BrushContext &ctx) {
 }
 
 void ExtrudeBrush::endBrush(BrushContext &) {
+	// Prune interior voxels after final commit — voxels fully enclosed by 6 solid
+	// neighbors are invisible and waste sparse storage.
+	if (_lastVolume && _depth > 0) {
+		const voxel::Region &volRegion = _lastVolume->region();
+		const voxel::Voxel air;
+		auto isInterior = [&](const glm::ivec3 &pos) {
+			for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
+				const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
+				if (!volRegion.containsPoint(nb) || voxel::isAir(_lastVolume->voxel(nb).getMaterial())) {
+					return false;
+				}
+			}
+			return true;
+		};
+
+		core::DynamicArray<glm::ivec3> toPrune;
+		toPrune.reserve(_history.size() + _cachedSelectedPositions.size());
+		for (const HistoryEntry &entry : _history) {
+			if (!voxel::isAir(_lastVolume->voxel(entry.pos).getMaterial()) && isInterior(entry.pos)) {
+				toPrune.push_back(entry.pos);
+			}
+		}
+		for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
+			if (!voxel::isAir(_lastVolume->voxel(selPos).getMaterial()) && isInterior(selPos)) {
+				toPrune.push_back(selPos);
+			}
+		}
+		for (const glm::ivec3 &pos : toPrune) {
+			_lastVolume->setVoxel(pos, air);
+		}
+	}
+	_lastVolume = nullptr;
 	_active = false;
 	// _face is intentionally kept: the user sets it by clicking a voxel face in the viewport,
 	// then adjusts depth via the panel without needing to hover the viewport again.
@@ -51,27 +100,26 @@ void ExtrudeBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *v
 	if (!volume) {
 		return;
 	}
-	// Scan for selected (FlagOutline) voxels and cache their bounding box.
-	// This is used by calcRegion() to return a tight region for preview.
+
 	const voxel::Region &volRegion = volume->region();
-	glm::ivec3 selLo(volRegion.getUpperCorner());
-	glm::ivec3 selHi(volRegion.getLowerCorner());
-	const glm::ivec3 &vlo = volRegion.getLowerCorner();
-	const glm::ivec3 &vhi = volRegion.getUpperCorner();
-	// TODO: voxelutil visitor pattern for non-parallel iterations for solid voxels
-	for (int z = vlo.z; z <= vhi.z; ++z) {
-		for (int y = vlo.y; y <= vhi.y; ++y) {
-			for (int x = vlo.x; x <= vhi.x; ++x) {
-				const voxel::Voxel vx = volume->voxel(x, y, z);
-				if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline)) {
-					selLo = glm::min(selLo, glm::ivec3(x, y, z));
-					selHi = glm::max(selHi, glm::ivec3(x, y, z));
-				}
-			}
+
+	// Detect volume region shift and adjust cached data
+	if (_hasCachedSelection) {
+		const glm::ivec3 delta = volRegion.getLowerCorner() - _capturedVolumeLower;
+		if (delta != glm::ivec3(0)) {
+			adjustCacheForRegionShift(delta);
 		}
 	}
-	if (selLo.x <= selHi.x) {
-		_cachedSelBBox = voxel::Region(selLo, selHi);
+
+	// Build the full selection cache (positions + wall candidates) once when
+	// the face is set and no cache exists yet. Subsequent frames reuse it.
+	if (!_hasCachedSelection && _face != voxel::FaceNames::Max) {
+		cacheSelection(volume, volRegion);
+	}
+
+	// Use cached bbox for calcRegion() if available
+	if (_hasCachedSelection) {
+		_cachedSelBBox = _cachedSelectedBBox;
 		_cachedSelBBoxValid = true;
 	}
 }
@@ -157,21 +205,112 @@ void ExtrudeBrush::setOffsetV(int offset) {
 	markDirty();
 }
 
+void ExtrudeBrush::cacheSelection(const voxel::RawVolume *vol, const voxel::Region &volRegion) {
+	_cachedSelectedPositions.clear();
+	_cachedWallCandidates.clear();
+	_hasCachedSelection = false;
+
+	if (_face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	// Collect selected (FlagOutline) voxel positions
+	glm::ivec3 selLo(volRegion.getUpperCorner());
+	glm::ivec3 selHi(volRegion.getLowerCorner());
+	PositionSet selectedSet;
+
+	const glm::ivec3 &vlo = volRegion.getLowerCorner();
+	const glm::ivec3 &vhi = volRegion.getUpperCorner();
+	for (int z = vlo.z; z <= vhi.z; ++z) {
+		for (int y = vlo.y; y <= vhi.y; ++y) {
+			for (int x = vlo.x; x <= vhi.x; ++x) {
+				const voxel::Voxel vx = vol->voxel(x, y, z);
+				if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline)) {
+					const glm::ivec3 pos(x, y, z);
+					_cachedSelectedPositions.push_back(pos);
+					selectedSet.insert(pos);
+					selLo = glm::min(selLo, pos);
+					selHi = glm::max(selHi, pos);
+				}
+			}
+		}
+	}
+
+	if (_cachedSelectedPositions.empty()) {
+		return;
+	}
+
+	_cachedSelectedBBox = voxel::Region(selLo, selHi);
+
+	// Compute wall candidates: for each selected voxel, check 4 perpendicular neighbors.
+	// A wall candidate is a (selectedPos, perpOffset) pair where the perpendicular neighbor
+	// is solid and not selected — indicating an edge that needs sealing during extrusion.
+	const math::Axis axis = voxel::faceToAxis(_face);
+	const int axisIdx = math::getIndexForAxis(axis);
+	static constexpr int NumAxes = 3;
+	const int perp1 = (axisIdx + 1) % NumAxes;
+	const int perp2 = (axisIdx + 2) % NumAxes;
+
+	static constexpr int NumPerpOffsets = 4;
+	glm::ivec3 perpOffsets[NumPerpOffsets] = {};
+	perpOffsets[0][perp1] = 1;
+	perpOffsets[1][perp1] = -1;
+	perpOffsets[2][perp2] = 1;
+	perpOffsets[3][perp2] = -1;
+
+	for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
+		for (int pi = 0; pi < NumPerpOffsets; ++pi) {
+			const glm::ivec3 neighborPos = selPos + perpOffsets[pi];
+			if (!volRegion.containsPoint(neighborPos)) {
+				continue;
+			}
+			const voxel::Voxel &nv = vol->voxel(neighborPos);
+			if (voxel::isAir(nv.getMaterial())) {
+				continue;
+			}
+			if (selectedSet.has(neighborPos)) {
+				continue;
+			}
+			_cachedWallCandidates.push_back({selPos, perpOffsets[pi]});
+		}
+	}
+
+	_capturedVolumeLower = volRegion.getLowerCorner();
+	_hasCachedSelection = true;
+}
+
+void ExtrudeBrush::adjustCacheForRegionShift(const glm::ivec3 &delta) {
+	for (glm::ivec3 &pos : _cachedSelectedPositions) {
+		pos += delta;
+	}
+	_cachedSelectedBBox.shift(delta.x, delta.y, delta.z);
+
+	for (WallCandidate &wc : _cachedWallCandidates) {
+		wc.basePos += delta;
+	}
+
+	for (HistoryEntry &entry : _history) {
+		entry.pos += delta;
+	}
+
+	_capturedVolumeLower += delta;
+}
+
 void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
 							const voxel::Region &) {
 	voxel::RawVolume *vol = wrapper.volume();
 	const voxel::Region &volRegion = vol->region();
+	_lastVolume = vol;
 
-	// Restore all positions from a previous extrude in this session before re-applying.
-	// This makes depth changes fully reversible without touching the undo stack.
+	// Step 1: Restore all positions modified by the previous generate() call.
+	// This makes depth/offset changes fully reversible without touching the undo stack.
 	for (const HistoryEntry &entry : _history) {
-		if (vol->setVoxel(entry.pos, entry.original)) {
-			wrapper.addToDirtyRegion(entry.pos);
-		}
+		vol->setVoxel(entry.pos, entry.original);
+		wrapper.addToDirtyRegion(entry.pos);
 	}
 	_history.clear();
 
-	if (_depth == 0 || _face == voxel::FaceNames::Max) {
+	if (_depth == 0 || _face == voxel::FaceNames::Max || !_hasCachedSelection) {
 		return;
 	}
 
@@ -179,8 +318,6 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	const int axisIdx = math::getIndexForAxis(axis);
 	const int faceSign = voxel::isNegativeFace(_face) ? -1 : 1;
 
-	// Positive depth -> extrude outward (along face normal, place voxels)
-	// Negative depth -> carve inward (opposite to face normal, erase voxels)
 	const bool carving = _depth < 0;
 	const int steps = glm::abs(_depth);
 	const int dirSign = carving ? -faceSign : faceSign;
@@ -188,13 +325,10 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 	glm::ivec3 dir(0);
 	dir[axisIdx] = dirSign;
 
-	// Perpendicular axes used for lateral offset (sweep) and side-wall filling.
 	static constexpr int NumAxes = 3;
 	const int perp1 = (axisIdx + 1) % NumAxes;
 	const int perp2 = (axisIdx + 2) % NumAxes;
 
-	// Compute lateral shift at a given extrusion step via linear interpolation.
-	// shift = offset * step / depth (truncated toward zero).
 	const float stepU = static_cast<float>(_offsetU) / steps;
 	const float stepV = static_cast<float>(_offsetV) / steps;
 	auto lateralShift = [&](int step) -> glm::ivec3 {
@@ -208,211 +342,55 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 		return shift;
 	};
 
-	// Save original voxel at pos (only once per session) then write the new voxel.
+	// Step 2: Save original voxel before writing — uses a set for O(1) dedup.
+	// Saves both air and solid voxels so restore is always complete.
+	PositionSet savedPositions;
 	auto writeVoxel = [&](const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
 		if (!volRegion.containsPoint(pos)) {
 			return;
 		}
-		// Linear search - history is small enough that this is fine.
-		bool alreadySaved = false;
-		for (const HistoryEntry &entry : _history) {
-			if (entry.pos == pos) {
-				alreadySaved = true;
-				break;
-			}
-		}
-		if (!alreadySaved) {
+		if (!savedPositions.has(pos)) {
 			_history.push_back({pos, vol->voxel(pos)});
+			savedPositions.insert(pos);
 		}
-		if (vol->setVoxel(pos, newVoxel)) {
-			wrapper.addToDirtyRegion(pos);
-		}
+		vol->setVoxel(pos, newVoxel);
+		wrapper.addToDirtyRegion(pos);
 	};
 
 	const voxel::Voxel air{};
 
-	// Collect selected (FlagOutline) voxel positions to avoid scanning the full volume
-	// (which can be 256^3+) in the extrusion and fill-sides loops.
-	core::DynamicArray<glm::ivec3> selectedPositions;
-	glm::ivec3 selLo(volRegion.getUpperCorner());
-	glm::ivec3 selHi(volRegion.getLowerCorner());
-	{
-		const glm::ivec3 &vlo = volRegion.getLowerCorner();
-		const glm::ivec3 &vhi = volRegion.getUpperCorner();
-		for (int z = vlo.z; z <= vhi.z; ++z) {
-			for (int y = vlo.y; y <= vhi.y; ++y) {
-				for (int x = vlo.x; x <= vhi.x; ++x) {
-					const voxel::Voxel vx = vol->voxel(x, y, z);
-					if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline)) {
-						const glm::ivec3 pos(x, y, z);
-						selectedPositions.push_back(pos);
-						selLo = glm::min(selLo, pos);
-						selHi = glm::max(selHi, pos);
-					}
-				}
-			}
-		}
-	}
-	if (selectedPositions.empty()) {
-		return; // no selected voxels
-	}
-	const glm::ivec3 &lo = selLo;
-	const glm::ivec3 &hi = selHi;
-
-	// Carve or extrude each selected voxel along dir.
-	for (const glm::ivec3 &selPos : selectedPositions) {
-		// Carving starts at the selected voxel itself (step=0) so the surface layer
-		// becomes air. Extrusion starts at step=1 to place new voxels outward.
-		const int stepFirst = carving ? 0 : 1;
-		const int stepLast = carving ? steps - 1 : steps;
-		for (int step = stepFirst; step <= stepLast; ++step) {
-			const glm::ivec3 shift = lateralShift(step);
-			const glm::ivec3 newPos = selPos + dir * step + shift;
-			if (!volRegion.containsPoint(newPos)) {
-				break;
-			}
-			writeVoxel(newPos, carving ? air : ctx.cursorVoxel);
-		}
-	}
-
-	// Expanded bounding box covering extruded voxels after lateral offset + side wall margin.
-	// The fill-sides and pruning loops need to find selected voxels which may have been
-	// shifted outside the original selection bbox (lo..hi) by the lateral offset.
-	const glm::ivec3 tipShift = lateralShift(steps);
-	const glm::ivec3 extLo = glm::max(glm::min(lo, lo + dir * steps + tipShift) - glm::ivec3(1),
-									   volRegion.getLowerCorner());
-	const glm::ivec3 extHi = glm::min(glm::max(hi, hi + dir * steps + tipShift) + glm::ivec3(1),
-									   volRegion.getUpperCorner());
-
-	// Fill perpendicular side walls - only meaningful when extruding straight outward
-	// (no lateral offset). With lateral offsets the extrusion is a sweep/shear and
-	// wall placement doesn't make geometric sense.
-	// Side walls are only placed when the neighbor already has pre-existing solid
-	// material extending in the extrusion direction (e.g. an existing wall/structure).
-	// This avoids creating unwanted rim voxels when extruding on a flat surface.
-	const bool hasLateralOffset = _offsetU != 0 || _offsetV != 0;
-	if (!carving && !hasLateralOffset) {
-		static constexpr int NumPerpOffsets = 4; // 2 perpendicular axes * 2 directions each
-
-		glm::ivec3 perpOffsets[NumPerpOffsets] = {};
-		perpOffsets[0][perp1] = 1;
-		perpOffsets[1][perp1] = -1;
-		perpOffsets[2][perp2] = 1;
-		perpOffsets[3][perp2] = -1;
-
-		for (const glm::ivec3 &selPos : selectedPositions) {
-			for (int pi = 0; pi < NumPerpOffsets; ++pi) {
-				const glm::ivec3 neighborPos = selPos + perpOffsets[pi];
-				if (!volRegion.containsPoint(neighborPos)) {
-					continue;
-				}
-				const voxel::Voxel &nv = vol->voxel(neighborPos);
-				if (voxel::isAir(nv.getMaterial())) {
-					continue; // air neighbor - no edge to seal
-				}
-				// Skip if the neighbor is also a selected voxel (no open edge between them).
-				bool neighborSelected = false;
-				for (const glm::ivec3 &other : selectedPositions) {
-					if (other == neighborPos) {
-						neighborSelected = true;
-						break;
-					}
-				}
-				if (neighborSelected) {
-					continue;
-				}
-				// Only fill when the neighbor has pre-existing geometry extending in the
-				// extrusion direction. On a flat surface the neighbor has nothing above
-				// its base level, so no wall is needed. Check the original (pre-extrusion)
-				// voxel state via history to avoid false positives from extrusion overlap.
-				const glm::ivec3 aboveNeighbor = neighborPos + dir;
-				if (!volRegion.containsPoint(aboveNeighbor)) {
-					continue;
-				}
-				voxel::Voxel aboveOriginal = vol->voxel(aboveNeighbor);
-				for (const HistoryEntry &entry : _history) {
-					if (entry.pos == aboveNeighbor) {
-						aboveOriginal = entry.original;
-						break;
-					}
-				}
-				if (voxel::isAir(aboveOriginal.getMaterial())) {
-					continue;
-				}
-				for (int step = 1; step <= steps; ++step) {
-					const glm::ivec3 shift = lateralShift(step);
-					const glm::ivec3 sidePos = selPos + perpOffsets[pi] + dir * step + shift;
-					if (!volRegion.containsPoint(sidePos)) {
-						break;
-					}
+	// Step 3: Apply extrusion or carving
+	if (carving) {
+		// Loop 1: Place walls at each depth step before carving
+		if (_fillWalls) {
+			for (int step = 0; step < steps; ++step) {
+				const glm::ivec3 shift = lateralShift(step);
+				for (const WallCandidate &wc : _cachedWallCandidates) {
+					const glm::ivec3 sidePos = wc.basePos + wc.perpOffset + dir * step + shift;
 					writeVoxel(sidePos, ctx.cursorVoxel);
 				}
 			}
 		}
-	}
-
-	// For outward extrusion: remove any voxel that is now fully interior
-	// (all 6 axis-aligned neighbors solid and within bounds) - invisible voxels waste sparse storage.
-	// Running after fill-sides gives accurate neighbor state before pruning.
-	// Important: collect ALL positions to prune first (read-only pass), then remove them.
-	// Pruning one-by-one would mutate the volume mid-iteration, making adjacent voxels
-	// appear non-interior and creating a checkerboard artifact.
-	if (!carving) {
-		auto isInterior = [&](const glm::ivec3 &pos) {
-			for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
-				const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
-				if (!volRegion.containsPoint(nb) || voxel::isAir(vol->voxel(nb).getMaterial())) {
-					return false;
-				}
+		// Loop 2: Carve out cached selected positions at each depth step
+		for (int step = 0; step < steps; ++step) {
+			const glm::ivec3 shift = lateralShift(step);
+			for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
+				writeVoxel(selPos + dir * step + shift, air);
 			}
-			return true;
-		};
-
-		// Collect all interior positions before modifying the volume.
-		core::DynamicArray<glm::ivec3> toPrune;
-		toPrune.reserve(_history.size());
-
-		// Check newly placed voxels (already in history).
-		for (const HistoryEntry &entry : _history) {
-			const glm::ivec3 &pos = entry.pos;
-			if (!voxel::isAir(vol->voxel(pos).getMaterial()) && isInterior(pos)) {
-				toPrune.push_back(pos);
+		}
+	} else {
+		// Positive depth: place selected voxels at each step from 1 to depth
+		for (int step = 1; step <= steps; ++step) {
+			const glm::ivec3 shift = lateralShift(step);
+			for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
+				writeVoxel(selPos + dir * step + shift, ctx.cursorVoxel);
 			}
 		}
 
-		// Check selected voxels that outward extrusion has now fully surrounded.
-		// Save them to history first so a depth change can restore them.
-		for (int z = extLo.z; z <= extHi.z; ++z) {
-			for (int y = extLo.y; y <= extHi.y; ++y) {
-				for (int x = extLo.x; x <= extHi.x; ++x) {
-					const voxel::Voxel &sv = vol->voxel(x, y, z);
-					if (voxel::isAir(sv.getMaterial()) || !(sv.getFlags() & voxel::FlagOutline)) {
-						continue;
-					}
-					const glm::ivec3 pos(x, y, z);
-					if (!isInterior(pos)) {
-						continue;
-					}
-					bool alreadySaved = false;
-					for (const HistoryEntry &entry : _history) {
-						if (entry.pos == pos) {
-							alreadySaved = true;
-							break;
-						}
-					}
-					if (!alreadySaved) {
-						_history.push_back({pos, sv});
-					}
-					toPrune.push_back(pos);
-				}
-			}
+		// Remove original selected voxels — extrude moves the face outward
+		for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
+			writeVoxel(selPos, air);
 		}
-
-		// Now prune all collected positions at once.
-		for (const glm::ivec3 &pos : toPrune) {
-			vol->setVoxel(pos, air);
-		}
-		wrapper.addToDirtyRegion(toPrune);
 	}
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "Brush.h"
+#include "core/GLM.h"
 #include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicSet.h"
 #include "voxel/Face.h"
 #include "voxel/Region.h"
 #include "voxel/Voxel.h"
@@ -30,19 +32,41 @@ private:
 	int _depth = 0;
 	int _offsetU = 0; // lateral offset along first perpendicular axis
 	int _offsetV = 0; // lateral offset along second perpendicular axis
+	bool _fillWalls = true;
 	struct HistoryEntry {
 		glm::ivec3 pos;
 		voxel::Voxel original;
 	};
 	// For each position overwritten by the current extrude session, stores the original voxel.
 	// Cleared in reset() when the brush is deselected.
-	// TODO: use a SparseVolume here?
 	core::DynamicArray<HistoryEntry> _history;
+
+	// Cached selected voxel positions, captured once on first generate() call.
+	// Re-used for all subsequent depth/offset changes to prevent selection bleeding.
+	core::DynamicArray<glm::ivec3> _cachedSelectedPositions;
+	voxel::Region _cachedSelectedBBox;
+	bool _hasCachedSelection = false;
+
+	// Wall candidate: a selected voxel with a solid non-selected perpendicular neighbor.
+	// The wall extends from basePos + perpOffset along the extrusion direction.
+	// This variable exists to debug complex 3D extrusion where walls kept overwriting each other and causing holes. The candidates are cached to be able to analyze the final wall configuration in endBrush() and adjust the wall filling logic if necessary.
+	struct WallCandidate {
+		glm::ivec3 basePos;
+		glm::ivec3 perpOffset;
+	};
+	core::DynamicArray<WallCandidate> _cachedWallCandidates;
 
 	// Cached bounding box of selected (FlagOutline) voxels, computed in preExecute().
 	// Used by calcRegion() to return a tight preview region instead of the full volume.
 	voxel::Region _cachedSelBBox;
 	bool _cachedSelBBoxValid = false;
+	voxel::RawVolume *_lastVolume = nullptr;
+
+	// Volume region lower corner when cache was captured (to detect region shifts)
+	glm::ivec3 _capturedVolumeLower{0};
+
+	void cacheSelection(const voxel::RawVolume *vol, const voxel::Region &volRegion);
+	void adjustCacheForRegionShift(const glm::ivec3 &delta);
 
 protected:
 	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
@@ -54,6 +78,8 @@ public:
 	virtual ~ExtrudeBrush() = default;
 
 	void reset() override;
+	void onActivated() override;
+	bool onDeactivated() override;
 	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;
@@ -77,6 +103,21 @@ public:
 
 	voxel::FaceNames face() const {
 		return _face;
+	}
+
+	bool hasCachedSelection() const {
+		return _hasCachedSelection;
+	}
+
+	void setFillWalls(bool fill) {
+		if (_fillWalls == fill) {
+			return;
+		}
+		_fillWalls = fill;
+		markDirty();
+	}
+	bool fillWalls() const {
+		return _fillWalls;
 	}
 
 	bool wantBrushGizmo(const BrushContext &ctx) const override;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
@@ -24,6 +24,14 @@ namespace voxedit {
 
 using PositionSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
 
+void TransformBrush::onActivated() {
+	reset();
+}
+
+bool TransformBrush::onDeactivated() {
+	return _hasSnapshot;
+}
+
 void TransformBrush::reset() {
 	Super::reset();
 	_active = false;
@@ -36,12 +44,14 @@ void TransformBrush::reset() {
 	_cachedRegion = voxel::Region::InvalidRegion;
 	_cachedRegionValid = false;
 	_snapshotCenter = glm::vec3(0.0f);
+	_capturedVolumeLower = glm::ivec3(0);
 	_moveOffset = glm::ivec3(0);
 	_shearOffset = glm::ivec3(0);
 	_scale = glm::vec3(1.0f);
 	_rotationDegrees = glm::vec3(0.0f);
 	_transformMode = TransformMode::Move;
 	_scaleSampling = ScaleSampling::Nearest;
+	_lastVolume = nullptr;
 }
 
 bool TransformBrush::beginBrush(const BrushContext &ctx) {
@@ -53,6 +63,36 @@ bool TransformBrush::beginBrush(const BrushContext &ctx) {
 }
 
 void TransformBrush::endBrush(BrushContext &) {
+	// Prune interior voxels on final commit. Only for Scale/Rotate which can
+	// create new interior voxels. Move/Shear are 1:1 mappings that preserve topology.
+	const bool useInverseMapping = (_transformMode == TransformMode::Scale ||
+									_transformMode == TransformMode::Rotate);
+	if (_lastVolume && useInverseMapping) {
+		const voxel::Region &volRegion = _lastVolume->region();
+		const voxel::Voxel air;
+		auto isInterior = [&](const glm::ivec3 &pos) {
+			for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
+				const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
+				if (!volRegion.containsPoint(nb) || voxel::isAir(_lastVolume->voxel(nb).getMaterial())) {
+					return false;
+				}
+			}
+			return true;
+		};
+
+		core::DynamicArray<glm::ivec3> toPrune;
+		toPrune.reserve(_history.size());
+		for (const HistoryEntry &entry : _history) {
+			const glm::ivec3 &pos = entry.pos;
+			if (!voxel::isAir(_lastVolume->voxel(pos).getMaterial()) && isInterior(pos)) {
+				toPrune.push_back(pos);
+			}
+		}
+		for (const glm::ivec3 &pos : toPrune) {
+			_lastVolume->setVoxel(pos, air);
+		}
+	}
+	_lastVolume = nullptr;
 	_active = false;
 }
 
@@ -63,6 +103,12 @@ bool TransformBrush::active() const {
 void TransformBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) {
 	if (!_hasSnapshot && volume != nullptr) {
 		captureSnapshot(volume, ctx.targetVolumeRegion);
+	} else if (_hasSnapshot) {
+		// Detect volume region shift (e.g. node was moved) and adjust cached data
+		const glm::ivec3 delta = ctx.targetVolumeRegion.getLowerCorner() - _capturedVolumeLower;
+		if (delta != glm::ivec3(0)) {
+			adjustSnapshotForRegionShift(delta);
+		}
 	}
 	_cachedRegion = computeTransformedRegion();
 	_cachedRegionValid = _cachedRegion.isValid();
@@ -110,7 +156,31 @@ void TransformBrush::captureSnapshot(const voxel::RawVolume *volume, const voxel
 
 	_snapshotRegion = voxel::Region(selLo, selHi);
 	_snapshotCenter = glm::vec3(selLo + selHi) * 0.5f;
+	_capturedVolumeLower = volRegion.getLowerCorner();
 	_hasSnapshot = true;
+}
+
+void TransformBrush::adjustSnapshotForRegionShift(const glm::ivec3 &delta) {
+	for (VoxelEntry &entry : _snapshot) {
+		entry.pos += delta;
+	}
+
+	_snapshotRegion.shift(delta.x, delta.y, delta.z);
+	_snapshotCenter += glm::vec3(delta);
+	_capturedVolumeLower += delta;
+
+	// Rebuild spatial lookup with shifted positions
+	_snapshotLookup.clear();
+	for (int i = 0; i < (int)_snapshot.size(); ++i) {
+		_snapshotLookup.put(_snapshot[i].pos, i);
+	}
+
+	// Shift history positions in-place
+	_historyPositions.clear();
+	for (HistoryEntry &entry : _history) {
+		entry.pos += delta;
+		_historyPositions.insert(entry.pos);
+	}
 }
 
 voxel::Region TransformBrush::computeTransformedRegion() const {
@@ -479,33 +549,6 @@ void TransformBrush::applyTransform(ModifierVolumeWrapper &wrapper, const BrushC
 		}
 	}
 
-	// Prune interior voxels: remove any transformed voxel that is fully enclosed
-	// by 6 solid neighbors. These are invisible and waste sparse storage.
-	// Collect all positions first (read-only), then prune - mutating during
-	// iteration would cause adjacent voxels to appear non-interior (checkerboard).
-	auto isInterior = [&](const glm::ivec3 &pos) {
-		for (int ni = 0; ni < lengthof(voxel::arrayPathfinderFaces); ++ni) {
-			const glm::ivec3 nb = pos + voxel::arrayPathfinderFaces[ni];
-			if (!volRegion.containsPoint(nb) || voxel::isAir(vol->voxel(nb).getMaterial())) {
-				return false;
-			}
-		}
-		return true;
-	};
-
-	core::DynamicArray<glm::ivec3> toPrune;
-	toPrune.reserve(_history.size());
-	for (const HistoryEntry &entry : _history) {
-		const glm::ivec3 &pos = entry.pos;
-		const voxel::Voxel &current = vol->voxel(pos);
-		if (!voxel::isAir(current.getMaterial()) && isInterior(pos)) {
-			toPrune.push_back(pos);
-		}
-	}
-	for (const glm::ivec3 &pos : toPrune) {
-		vol->setVoxel(pos, air);
-	}
-	wrapper.addToDirtyRegion(toPrune);
 }
 
 void TransformBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
@@ -515,6 +558,7 @@ void TransformBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &w
 	}
 
 	voxel::RawVolume *vol = wrapper.volume();
+	_lastVolume = vol;
 
 	// Restore previously transformed state before re-applying
 	for (const HistoryEntry &entry : _history) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -76,6 +76,7 @@ private:
 	ScaleSampling _scaleSampling = ScaleSampling::Nearest;
 	bool _active = false;
 	bool _hasSnapshot = false;
+	voxel::RawVolume *_lastVolume = nullptr;
 
 	// Original selected voxels captured at brush activation
 	// TODO: could also be a SparseVolume maybe?
@@ -85,6 +86,8 @@ private:
 	voxel::Region _snapshotRegion;
 	// Center of selection (used as pivot for scale/rotate)
 	glm::vec3 _snapshotCenter{0.0f};
+	// Volume region lower corner at snapshot capture time (to detect region shifts)
+	glm::ivec3 _capturedVolumeLower{0};
 
 	// Per-generate bookkeeping: tracks positions written during a single generate()
 	// call so interior pruning can find all modified positions.
@@ -108,6 +111,7 @@ private:
 	glm::vec3 _rotationDegrees{0.0f, 0.0f, 0.0f};
 
 	void captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion);
+	void adjustSnapshotForRegionShift(const glm::ivec3 &delta);
 	void applyTransform(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
 	voxel::Region computeTransformedRegion() const;
 	glm::ivec3 transformPosition(const glm::ivec3 &pos) const;
@@ -132,6 +136,8 @@ public:
 	virtual ~TransformBrush() = default;
 
 	void reset() override;
+	void onActivated() override;
+	bool onDeactivated() override;
 	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;

--- a/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
@@ -203,39 +203,37 @@ TEST_F(ExtrudeBrushTest, testExtrudePushThenPull) {
 	executeExtrude(brush, node, ctx);
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial())) << "Selected voxel at (0,0,0) should be carved";
 
-	// Push outward (+1) from same selection: history restores (0,0,0), places at x=+1
+	// Push outward (+1) from same selection: history restores (0,0,0), then
+	// positive extrude places at x=+1 and removes the original at x=0
 	brush.setDepth(1);
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
-		<< "Restored selected voxel at (0,0,0) after direction reversal";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original at (0,0,0) removed by positive extrude";
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
 		<< "Outward voxel at (1,0,0) expected";
 
 	brush.shutdown();
 }
 
-// Fill sides: extrude next to an existing wall fills the gap between extrusion and wall
-TEST_F(ExtrudeBrushTest, testExtrudeFillSidesWithWall) {
+// Fill walls during carving: walls seal the sides of the carved channel
+TEST_F(ExtrudeBrushTest, testCarveFillWalls) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
-	// Selected voxel at (0,0,0) recessed inside a box. Wall neighbor at (1,0,0) extends
-	// upward to (1,0,3). Extruding by 2 should fill the gap at (1,0,1) and (1,0,2).
-	volume.setVoxel(0, 0, 0, selectedVoxel());
 	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
-	// Wall column next to the selection, extending upward
-	for (int z = 0; z <= 3; ++z) {
-		volume.setVoxel(2, 0, z, solid);
-	}
-	// Neighbor at (1,0,0) with solid above it at (1,0,1) triggers fill-sides
+	// Selected voxel at (0,0,0) with solid neighbor at (1,0,0) that is not selected.
+	// Carving inward (-Z) should fill wall at (1,0,-1) next to carved area.
+	volume.setVoxel(0, 0, 0, selectedVoxel());
 	volume.setVoxel(1, 0, 0, solid);
-	volume.setVoxel(1, 0, 1, solid);
+	// Solid behind the selection to carve into
+	volume.setVoxel(0, 0, -1, solid);
 
 	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
 	node.setVolume(&volume, false);
 
 	ExtrudeBrush brush;
 	ASSERT_TRUE(brush.init());
-	brush.setDepth(2); // outward for PositiveZ -> z+1, z+2
+	brush.setDepth(-1); // carve inward for PositiveZ -> z=0 erased
+	brush.setFillWalls(true);
 
 	BrushContext ctx;
 	ctx.targetVolumeRegion = volume.region();
@@ -245,12 +243,14 @@ TEST_F(ExtrudeBrushTest, testExtrudeFillSidesWithWall) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Extruded voxels at z=1 and z=2
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial())) << "Extruded voxel at (0,0,1) expected";
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 2).getMaterial())) << "Tip voxel at (0,0,2) expected";
-	// Side wall fills gap: (1,0,2) was air, should now be filled by fill-sides
-	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 2).getMaterial()))
-		<< "Side wall at (1,0,2) should fill gap next to existing wall";
+	// Carved voxel at z=0
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Selected voxel at (0,0,0) should be carved";
+	// Wall candidate: (0,0,0) with perpOffset (1,0,0). Wall placed at (1,0,0) + dir*step=(0,0,-1)*0
+	// = (1,0,0). But that's already solid. With depth=-1 step=0: sidePos = (0,0,0)+(1,0,0)+(0,0,-1)*0 = (1,0,0)
+	// Already solid, so check that it remains solid
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Wall at (1,0,0) should remain solid";
 
 	brush.shutdown();
 }
@@ -325,8 +325,8 @@ TEST_F(ExtrudeBrushTest, testExtrudeWithOffsetU) {
 	brush.shutdown();
 }
 
-// Extrusion preserves FlagOutline on originals and does not set it on new voxels
-TEST_F(ExtrudeBrushTest, testExtrudePreservesSelection) {
+// Positive extrude removes originals and new voxels do not get FlagOutline
+TEST_F(ExtrudeBrushTest, testExtrudeRemovesOriginalsAndNoFlag) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	volume.setVoxel(0, 0, 0, selectedVoxel());
 
@@ -345,10 +345,9 @@ TEST_F(ExtrudeBrushTest, testExtrudePreservesSelection) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Original voxel should still have FlagOutline
-	const voxel::Voxel origVoxel = volume.voxel(0, 0, 0);
-	EXPECT_TRUE(origVoxel.getFlags() & voxel::FlagOutline)
-		<< "Original voxel at (0,0,0) should keep FlagOutline after extrusion";
+	// Original voxel removed by positive extrude
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original voxel at (0,0,0) should be removed by positive extrude";
 	// New extruded voxels should NOT have FlagOutline
 	const voxel::Voxel midVoxel = volume.voxel(1, 0, 0);
 	EXPECT_TRUE(voxel::isBlocked(midVoxel.getMaterial()));
@@ -445,6 +444,178 @@ TEST_F(ExtrudeBrushTest, testEndBrushResetsState) {
 	// beginBrush should work again after endBrush
 	EXPECT_TRUE(brush.beginBrush(ctx));
 	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+// onDeactivated returns true when there are pending changes to commit
+TEST_F(ExtrudeBrushTest, testOnDeactivatedReturnsTrueWithPendingChanges) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Before any execution, cache is not built yet
+	EXPECT_FALSE(brush.onDeactivated()) << "No cached selection yet — nothing to commit";
+
+	// Execute to build cache
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// After execution with depth != 0 and cached selection, onDeactivated should return true
+	EXPECT_TRUE(brush.hasCachedSelection());
+	EXPECT_TRUE(brush.onDeactivated()) << "Should have pending changes to commit";
+
+	brush.shutdown();
+}
+
+// onDeactivated returns false when depth is zero
+TEST_F(ExtrudeBrushTest, testOnDeactivatedReturnsFalseAtDepthZero) {
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(0);
+
+	EXPECT_FALSE(brush.onDeactivated()) << "Depth 0 means no changes to commit";
+
+	brush.shutdown();
+}
+
+// onActivated resets the brush state
+TEST_F(ExtrudeBrushTest, testOnActivatedResetsState) {
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(5);
+	brush.setOffsetU(3);
+
+	brush.onActivated();
+	EXPECT_EQ(brush.depth(), 0) << "Depth should be reset by onActivated";
+	EXPECT_EQ(brush.face(), voxel::FaceNames::Max) << "Face should be reset by onActivated";
+
+	brush.shutdown();
+}
+
+// fillWalls=false disables wall filling during carving
+TEST_F(ExtrudeBrushTest, testFillWallsDisabled) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// Selected voxel at origin with a solid neighbor at (+1,0,0) that extends in Z
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	volume.setVoxel(1, 0, 0, solid);
+	// Solid above neighbor to trigger wall-fill condition
+	volume.setVoxel(1, 0, -1, solid);
+	// Solid behind selection to carve
+	volume.setVoxel(0, 0, -1, solid);
+	volume.setVoxel(0, 0, -2, solid);
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(-2);
+	brush.setFillWalls(false);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// With fillWalls=false, the side position (1,0,-1) should remain as original solid (not overwritten)
+	// The carved positions should be air
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Selected voxel should be carved";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, -1).getMaterial()))
+		<< "Second depth step should be carved";
+
+	brush.shutdown();
+}
+
+// Positive extrude removes original selected voxels
+TEST_F(ExtrudeBrushTest, testPositiveExtrudeRemovesOriginals) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Original position should be air — extrude moves the face outward
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original selected voxel should be removed after positive extrude";
+	// Extruded voxels at x=1 and x=2
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Extruded voxel at (1,0,0)";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 0).getMaterial()))
+		<< "Extruded voxel at (2,0,0)";
+
+	brush.shutdown();
+}
+
+// Interior pruning happens on endBrush for positive extrude
+TEST_F(ExtrudeBrushTest, testInteriorPruningOnCommit) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	// Create a 3x3x1 slab at z=0, all selected.
+	// Positive extrude removes originals (z=0 -> air), places at z=1,2,3.
+	// With depth=3 and 3x3 slab, the center voxel at (0,0,2) has:
+	//   x±1, y±1 = solid (extruded neighbors), z+1=(0,0,3), z-1=(0,0,1) = solid
+	// So (0,0,2) is fully interior and should be pruned.
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			volume.setVoxel(x, y, 0, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	ExtrudeBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setDepth(3);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveZ;
+	ctx.cursorVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeExtrude(brush, node, ctx);
+
+	// Center of middle layer (0,0,2) is fully enclosed: pruned
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 2).getMaterial()))
+		<< "Interior voxel at (0,0,2) should be pruned";
+	// Tip layer surface voxels should remain
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 3).getMaterial()))
+		<< "Tip voxel at (0,0,3) should remain";
+	// Edge voxels of middle layer should remain (exposed on x or y face)
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 2).getMaterial()))
+		<< "Edge voxel at (1,0,2) should remain";
+	// Originals removed
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original at (0,0,0) should be removed";
+
 	brush.shutdown();
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/TransformBrushTest.cpp
@@ -214,4 +214,164 @@ TEST_F(TransformBrushTest, testCommitOnModeSwitch) {
 	brush.shutdown();
 }
 
+// onDeactivated returns true when snapshot exists
+TEST_F(TransformBrushTest, testOnDeactivatedWithSnapshot) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+	brush.setMoveOffset(glm::ivec3(1, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// Before execute, no snapshot
+	EXPECT_FALSE(brush.onDeactivated()) << "No snapshot yet";
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// After execute, snapshot exists
+	EXPECT_TRUE(brush.hasSnapshot());
+	EXPECT_TRUE(brush.onDeactivated()) << "Should commit pending transform";
+
+	brush.shutdown();
+}
+
+// onDeactivated returns false when no snapshot
+TEST_F(TransformBrushTest, testOnDeactivatedWithoutSnapshot) {
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+
+	EXPECT_FALSE(brush.onDeactivated()) << "No snapshot — nothing to commit";
+
+	brush.shutdown();
+}
+
+// onActivated resets the brush
+TEST_F(TransformBrushTest, testOnActivatedResetsState) {
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+	volume.setVoxel(0, 0, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+	brush.setMoveOffset(glm::ivec3(3, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
+	EXPECT_TRUE(brush.hasSnapshot());
+
+	brush.onActivated();
+	EXPECT_FALSE(brush.hasSnapshot()) << "Snapshot should be cleared by onActivated";
+	EXPECT_EQ(brush.moveOffset(), glm::ivec3(0)) << "Move offset should be reset";
+
+	brush.shutdown();
+}
+
+// Move preserves all surface voxels (no pruning for forward mapping)
+TEST_F(TransformBrushTest, testMovePreservesSurfaceVoxels) {
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+	// Create a 3x3x3 cube of selected voxels
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				volume.setVoxel(x, y, z, selectedVoxel());
+			}
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Move);
+	brush.setMoveOffset(glm::ivec3(5, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Count voxels at new position — all 27 should be there (no pruning for move)
+	int count = 0;
+	for (int x = 4; x <= 6; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				if (voxel::isBlocked(volume.voxel(x, y, z).getMaterial())) {
+					++count;
+				}
+			}
+		}
+	}
+	EXPECT_EQ(count, 27) << "All 27 voxels should be preserved after move (no pruning)";
+
+	// Original positions should be empty
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = -1; y <= 1; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				EXPECT_TRUE(voxel::isAir(volume.voxel(x, y, z).getMaterial()))
+					<< "Original position (" << x << "," << y << "," << z << ") should be empty";
+			}
+		}
+	}
+
+	brush.shutdown();
+}
+
+// Shear preserves all voxels (forward mapping, no pruning)
+TEST_F(TransformBrushTest, testShearPreservesAllVoxels) {
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+	// Vertical column along Y so shear X (which shifts by Y-layer) has effect.
+	// Center = (0, 0, 0). shearOffset.x=4 shifts each Y-layer by (relative.y/halfSize.y)*4.
+	// Voxel at y=+2: relative.y=2, halfSize.y=2.5 -> shift.x = (2/2.5)*4 = 3.2 -> 3
+	// Voxel at y=-2: shift.x = (-2/2.5)*4 = -3.2 -> -3
+	for (int y = -2; y <= 2; ++y) {
+		volume.setVoxel(0, y, 0, selectedVoxel());
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	TransformBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setTransformMode(TransformMode::Shear);
+	brush.setShearOffset(glm::ivec3(4, 0, 0));
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeTransform(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Top voxel (y=+2) should have shifted in +X
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 2, 0).getMaterial()))
+		<< "Top voxel should be sheared to x=+3";
+	// Bottom voxel (y=-2) should have shifted in -X
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(-3, -2, 0).getMaterial()))
+		<< "Bottom voxel should be sheared to x=-3";
+	// Center voxel (y=0) should stay at x=0 (relative.y=0)
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Center voxel should remain at origin";
+
+	brush.shutdown();
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- Add generic `onActivated`/`onDeactivated` lifecycle to Brush base class — ExtrudeBrush and TransformBrush auto-commit pending changes on brush switch
- Fix TransformBrush gizmo leaving duplicate voxels by preventing ModifierButton from committing during gizmo interaction
- Switch ExtrudeBrush to preview-only for all depths, add fillWalls checkbox for carving, cache selection/wall candidates across frames
- Move interior pruning from `generate()` to `endBrush()` so it only runs on final commit; skip pruning for Move/Shear (topology-preserving)
- Fix SliderIntMinMax `+` button being hidden, commit TransformBrush state on mode switch
- Positive extrude now removes original selected voxels (face moves outward)

## Test plan
- [ ] Verify TransformBrush gizmo no longer leaves duplicate voxels when switching axes
- [ ] Verify switching from Move to Shear mode commits the current move
- [ ] Verify switching brushes away from Extrude/Transform commits pending changes
- [ ] Verify fillWalls checkbox toggles wall filling during carving
- [ ] Verify positive extrude removes originals and shows correct preview
- [ ] Verify interior pruning works on commit for Scale/Rotate transforms
- [ ] Run ExtrudeBrushTest and TransformBrushTest unit tests