### PR TITLE
VOXEDIT: add Circle and Slope selection modes

### DIFF
--- a/src/modules/voxelutil/VolumeVisitor.h
+++ b/src/modules/voxelutil/VolumeVisitor.h
@@ -1234,4 +1234,215 @@ int visitFlatSurface(const Volume &volume, const glm::ivec3 &position, voxel::Fa
 							VisitFlatSurface(face, position, deviation));
 }
 
+/**
+ * @brief Flood-fill along a surface using a global slope plane to accept/reject voxels.
+ *
+ * The clicked face defines a "height" axis. A slope plane is fitted once from the seed's
+ * neighborhood using 2D linear regression, then frozen. The BFS expands outward and checks
+ * each candidate voxel against the frozen plane: if its actual height deviates from the
+ * plane's predicted height by more than @p maxDeviation, it is rejected.
+ *
+ * This approach is robust at surface edges (no per-voxel gradient needed) and naturally
+ * handles L-shaped staircase kinks (they are small deviations on a well-fitted plane).
+ * Freezing the plane prevents gradual drift around sharp angle changes.
+ *
+ * Uses 26-connectivity so the BFS can traverse diagonal staircase steps.
+ *
+ * @param volume          The volume to query
+ * @param position        Start voxel position (must be solid surface voxel on @p face)
+ * @param face            The clicked face - defines which axis is "height"
+ * @param maxDeviation    Maximum allowed height deviation (in voxels) from the global slope plane
+ * @param sampleDistance  How many voxels to probe around the seed to compute the initial plane
+ * @param visitor         Called with (x, y, z, voxel) for every accepted voxel including start
+ * @return Number of voxels visited
+ */
+template<class Volume, class Visitor = EmptyVisitor>
+int visitSlopeSurface(const Volume &volume, const glm::ivec3 &position, voxel::FaceNames face,
+					  int maxDeviation, int sampleDistance, Visitor &&visitor = Visitor()) {
+	if (face == voxel::FaceNames::Max) {
+		return 0;
+	}
+	typename Volume::Sampler sampler(volume);
+	if (!sampler.setPosition(position)) {
+		return 0;
+	}
+	if (voxel::isAir(sampler.voxel().getMaterial())) {
+		return 0;
+	}
+	const voxel::FaceBits startFaces = voxel::visibleFaces(sampler);
+	if (startFaces == voxel::FaceBits::None) {
+		return 0;
+	}
+
+	const int heightAxis = math::getIndexForAxis(voxel::faceToAxis(face));
+	const int uAxis = (heightAxis + 1) % 3;
+	const int vAxis = (heightAxis + 2) % 3;
+	const bool positiveNormal = voxel::isPositiveFace(face);
+	const voxel::Region &volRegion = volume.region();
+
+	// Find the outermost surface height at a given (u, v) coordinate.
+	// Scans from outside inward to avoid hitting interior shell surfaces.
+	const int searchRange = sampleDistance * 2;
+	auto findSurfaceHeight = [&](int uCoord, int vCoord, int expectedHeight, int &outHeight) -> bool {
+		const int startH = expectedHeight + (positiveNormal ? searchRange : -searchRange);
+		const int endH = expectedHeight + (positiveNormal ? -searchRange : searchRange);
+		const int stepH = positiveNormal ? -1 : 1;
+		for (int scanH = startH; (positiveNormal ? (scanH >= endH) : (scanH <= endH)); scanH += stepH) {
+			glm::ivec3 probe;
+			probe[heightAxis] = scanH;
+			probe[uAxis] = uCoord;
+			probe[vAxis] = vCoord;
+			if (!volRegion.containsPoint(probe)) {
+				continue;
+			}
+			if (voxel::isAir(volume.voxel(probe).getMaterial())) {
+				continue;
+			}
+			glm::ivec3 above = probe;
+			above[heightAxis] += positiveNormal ? 1 : -1;
+			if (!volRegion.containsPoint(above) || voxel::isAir(volume.voxel(above).getMaterial())) {
+				outHeight = scanH;
+				return true;
+			}
+		}
+		return false;
+	};
+
+	// Running 2D linear regression: fits h = a + b*u + c*v to all accepted surface voxels.
+	// Uses relative coordinates (du = u - seedU, dv = v - seedV) for numerical stability.
+	// The plane predicts height at any (u,v): predictedH = seedH + gradU*du + gradV*dv
+	const int seedU = position[uAxis];
+	const int seedV = position[vAxis];
+	const int seedH = position[heightAxis];
+
+	// Accumulators for 2D regression: h = gradU*du + gradV*dv + intercept
+	// Normal equations: [Σdu² Σdu·dv] [gradU]   [Σdu·dh]
+	//                   [Σdu·dv Σdv²] [gradV] = [Σdv·dh]
+	double sumDU = 0.0, sumDV = 0.0, sumDH = 0.0;
+	double sumDU2 = 0.0, sumDV2 = 0.0, sumDUDV = 0.0;
+	double sumDUDH = 0.0, sumDVDH = 0.0;
+	int planeN = 0;
+	float gradU = 0.0f;
+	float gradV = 0.0f;
+
+	auto addToPlane = [&](int uCoord, int vCoord, int height) {
+		const double du = static_cast<double>(uCoord - seedU);
+		const double dv = static_cast<double>(vCoord - seedV);
+		const double dh = static_cast<double>(height - seedH);
+		sumDU += du;
+		sumDV += dv;
+		sumDH += dh;
+		sumDU2 += du * du;
+		sumDV2 += dv * dv;
+		sumDUDV += du * dv;
+		sumDUDH += du * dh;
+		sumDVDH += dv * dh;
+		++planeN;
+	};
+
+	static constexpr int MinPlaneSamples = 3;
+	static constexpr double MinDeterminant = 0.001;
+
+	auto updatePlaneGradients = [&]() {
+		if (planeN < MinPlaneSamples) {
+			return;
+		}
+		// Solve normal equations for 2D regression (with intercept absorbed by centering)
+		const double sampleCount = static_cast<double>(planeN);
+		const double meanDU = sumDU / sampleCount;
+		const double meanDV = sumDV / sampleCount;
+		const double meanDH = sumDH / sampleCount;
+		// Centered second moments
+		const double suu = sumDU2 - sampleCount * meanDU * meanDU;
+		const double svv = sumDV2 - sampleCount * meanDV * meanDV;
+		const double suv = sumDUDV - sampleCount * meanDU * meanDV;
+		const double suh = sumDUDH - sampleCount * meanDU * meanDH;
+		const double svh = sumDVDH - sampleCount * meanDV * meanDH;
+		const double det = suu * svv - suv * suv;
+		if (glm::abs(det) > MinDeterminant) {
+			gradU = static_cast<float>((svv * suh - suv * svh) / det);
+			gradV = static_cast<float>((suu * svh - suv * suh) / det);
+		}
+	};
+
+	auto predictHeight = [&](int uCoord, int vCoord) -> float {
+		return static_cast<float>(seedH) + gradU * static_cast<float>(uCoord - seedU) + gradV * static_cast<float>(vCoord - seedV);
+	};
+
+	// Bootstrap the plane from the seed's neighborhood
+	for (int du = -sampleDistance; du <= sampleDistance; ++du) {
+		for (int dv = -sampleDistance; dv <= sampleDistance; ++dv) {
+			int surfaceHeight = 0;
+			if (du == 0 && dv == 0) {
+				surfaceHeight = seedH;
+			} else if (!findSurfaceHeight(seedU + du, seedV + dv, seedH, surfaceHeight)) {
+				continue;
+			}
+			addToPlane(seedU + du, seedV + dv, surfaceHeight);
+		}
+	}
+	updatePlaneGradients();
+
+	const float maxDev = static_cast<float>(maxDeviation);
+
+	VisitedSet visited;
+	visited.insert(position);
+	visitor(position.x, position.y, position.z, sampler.voxel());
+	int nVisited = 1;
+
+	constexpr size_t InitialQueueReserve = 64u;
+	core::DynamicArray<glm::ivec3> queue;
+	queue.reserve(InitialQueueReserve);
+	queue.push_back(position);
+
+	// 26-connectivity: staircase steps are edge/corner-connected, not face-connected.
+	static constexpr int NeighborCount = 26;
+	static constexpr glm::ivec3 neighbors[NeighborCount] = {
+		// 6 face neighbors
+		{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1},
+		// 12 edge neighbors
+		{1, 1, 0}, {1, -1, 0}, {-1, 1, 0}, {-1, -1, 0},
+		{1, 0, 1}, {1, 0, -1}, {-1, 0, 1}, {-1, 0, -1},
+		{0, 1, 1}, {0, 1, -1}, {0, -1, 1}, {0, -1, -1},
+		// 8 corner neighbors
+		{1, 1, 1}, {1, 1, -1}, {1, -1, 1}, {1, -1, -1},
+		{-1, 1, 1}, {-1, 1, -1}, {-1, -1, 1}, {-1, -1, -1}};
+
+	while (!queue.empty()) {
+		const glm::ivec3 current = queue.back();
+		queue.pop();
+		for (int i = 0; i < NeighborCount; ++i) {
+			const glm::ivec3 neighborPos = current + neighbors[i];
+			if (!visited.insert(neighborPos)) {
+				continue;
+			}
+			if (!volRegion.containsPoint(neighborPos)) {
+				continue;
+			}
+			if (voxel::isAir(volume.voxel(neighborPos).getMaterial())) {
+				continue;
+			}
+			// Must be a surface voxel (has the clicked face exposed)
+			glm::ivec3 above = neighborPos;
+			above[heightAxis] += positiveNormal ? 1 : -1;
+			if (volRegion.containsPoint(above) && !voxel::isAir(volume.voxel(above).getMaterial())) {
+				continue;
+			}
+			// Check if this voxel's height fits the slope plane (frozen after bootstrap)
+			const float predicted = predictHeight(neighborPos[uAxis], neighborPos[vAxis]);
+			const float actual = static_cast<float>(neighborPos[heightAxis]);
+			if (glm::abs(actual - predicted) > maxDev) {
+				continue;
+			}
+			if (!sampler.setPosition(neighborPos)) {
+				continue;
+			}
+			visitor(neighborPos.x, neighborPos.y, neighborPos.z, sampler.voxel());
+			++nVisited;
+			queue.push_back(neighborPos);
+		}
+	}
+	return nVisited;
+}
+
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -265,7 +265,8 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 
 	const char *SelectModeStr[] = {C_("SelectMode", "All"), C_("SelectMode", "Surface"), C_("SelectMode", "Same Color"),
 								   C_("SelectMode", "Fuzzy Color"), C_("SelectMode", "Connected"),
-								   C_("SelectMode", "Flat Surface"), C_("SelectMode", "3D Box")};
+								   C_("SelectMode", "Flat Surface"), C_("SelectMode", "3D Box"),
+								   C_("SelectMode", "Circle"), C_("SelectMode", "Slope")};
 	static_assert(lengthof(SelectModeStr) == (int)SelectMode::Max, "Array size mismatch");
 
 	if (ImGui::Combo(_("Select mode"), &selectModeInt, SelectModeStr, (int)SelectMode::Max)) {
@@ -306,6 +307,132 @@ void BrushPanel::updateSelectBrushPanel(command::CommandExecutionListener &liste
 
 	const int nodeId = _sceneMgr->sceneGraph().activeNode();
 	const scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+
+	if (brush.selectMode() == SelectMode::Slope) {
+		const float btnW = ImGui::GetFrameHeight();
+		const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+		bool changed = false;
+
+		int deviation = brush.slopeDeviation();
+		ImGui::TextUnformatted(_("Max deviation"));
+		ImGui::TooltipTextUnformatted(_("Maximum height deviation (in voxels) from the fitted slope plane for a voxel to be included in the selection"));
+		ImGui::PushID("slopedeviation");
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			deviation = glm::max(deviation - 1, 0);
+			brush.setSlopeDeviation(deviation);
+			changed = true;
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("##slopedeviation", &deviation, 0, SelectBrush::MaxSlopeDeviation)) {
+			brush.setSlopeDeviation(deviation);
+			changed = true;
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			deviation = glm::min(deviation + 1, SelectBrush::MaxSlopeDeviation);
+			brush.setSlopeDeviation(deviation);
+			changed = true;
+		}
+		ImGui::PopID();
+
+		int sampleDist = brush.slopeSampleDistance();
+		ImGui::TextUnformatted(_("Sample distance"));
+		ImGui::TooltipTextUnformatted(_("How far apart (in voxels) to sample when computing the initial slope plane. Larger values give smoother slope detection on staircases"));
+		ImGui::PushID("slopesample");
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			sampleDist = glm::max(sampleDist - 1, SelectBrush::MinSlopeSampleDistance);
+			brush.setSlopeSampleDistance(sampleDist);
+			changed = true;
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("##slopesample", &sampleDist, SelectBrush::MinSlopeSampleDistance, SelectBrush::MaxSlopeSampleDistance)) {
+			brush.setSlopeSampleDistance(sampleDist);
+			changed = true;
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			sampleDist = glm::min(sampleDist + 1, SelectBrush::MaxSlopeSampleDistance);
+			brush.setSlopeSampleDistance(sampleDist);
+			changed = true;
+		}
+		ImGui::PopID();
+
+		if (changed && brush.slopeValid()) {
+			_sceneMgr->selectionSetSlope(nodeId);
+		}
+	}
+
+	if (node && node->hasSelection() && brush.selectMode() == SelectMode::Circle && brush.ellipseValid()) {
+		ImGui::SeparatorText(_("Circle selection"));
+		const voxel::Region &vol = node->region();
+		const glm::ivec3 &vMins = vol.getLowerCorner();
+		const glm::ivec3 &vMaxs = vol.getUpperCorner();
+		glm::ivec3 center = brush.ellipseCenter();
+		int radiusU = brush.ellipseRadiusU();
+		int radiusV = brush.ellipseRadiusV();
+		bool changed = false;
+
+		int uAxis;
+		int vAxis;
+		SelectBrush::ellipseAxes(brush.ellipseFace(), uAxis, vAxis);
+		const char *axisNames[] = {"X", "Y", "Z"};
+
+		auto ellipseSlider = [&changed](const char *id, int *val, int lo, int hi) {
+			ImGui::PushID(id);
+			const float btnW = ImGui::GetFrameHeight();
+			const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+			if (ImGui::Button("-", ImVec2(btnW, 0))) {
+				*val = glm::max(*val - 1, lo);
+				changed = true;
+			}
+			ImGui::SameLine(0, spacing);
+			ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+			changed |= ImGui::SliderInt("", val, lo, hi);
+			ImGui::SameLine(0, spacing);
+			if (ImGui::Button("+", ImVec2(btnW, 0))) {
+				*val = glm::min(*val + 1, hi);
+				changed = true;
+			}
+			ImGui::PopID();
+		};
+
+		ImGui::TextUnformatted(_("Center"));
+		ellipseSlider("##cx", &center[uAxis], vMins[uAxis], vMaxs[uAxis]);
+		ellipseSlider("##cy", &center[vAxis], vMins[vAxis], vMaxs[vAxis]);
+
+		// Max radius is half the volume dimension on each axis
+		const int maxRadiusU = (vMaxs[uAxis] - vMins[uAxis]) / 2;
+		const int maxRadiusV = (vMaxs[vAxis] - vMins[vAxis]) / 2;
+		ImGui::Text(_("Radius %s"), axisNames[uAxis]);
+		ellipseSlider("##ru", &radiusU, 0, maxRadiusU);
+		ImGui::Text(_("Radius %s"), axisNames[vAxis]);
+		ellipseSlider("##rv", &radiusV, 0, maxRadiusV);
+
+		const int faceAxisIdx = math::getIndexForAxis(voxel::faceToAxis(brush.ellipseFace()));
+		const int maxDepth = (vMaxs[faceAxisIdx] - vMins[faceAxisIdx]) / 2;
+		int depth = brush.ellipseDepth();
+		ImGui::Text(_("Depth %s"), axisNames[faceAxisIdx]);
+		ImGui::TooltipTextUnformatted(_("How far from the center the selection extends along the face-normal axis (0 = single layer)"));
+		ellipseSlider("##depth", &depth, 1, maxDepth);
+
+		bool is3D = brush.ellipse3D();
+		if (ImGui::Checkbox(_("3D ellipsoid"), &is3D)) {
+			brush.setEllipse3D(is3D);
+			changed = true;
+		}
+		ImGui::TooltipTextUnformatted(_("Select voxels in a 3D ellipsoid shape behind the clicked surface instead of a 2D ellipse with depth"));
+
+		if (changed) {
+			brush.setEllipseCenter(center);
+			brush.setEllipseRadiusU(radiusU);
+			brush.setEllipseRadiusV(radiusV);
+			brush.setEllipseDepth(depth);
+			_sceneMgr->selectionSetEllipse(nodeId);
+		}
+	}
+
 	if (node && node->hasSelection() && brush.selectMode() == SelectMode::Box3D) {
 		voxel::Region sel = _sceneMgr->selectionCalculateRegion(nodeId);
 		if (sel.isValid()) {

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -1502,6 +1502,127 @@ void SceneManager::selectionSetBounds(int nodeId, const voxel::Region &region) {
 	}
 }
 
+void SceneManager::selectionSetEllipse(int nodeId) {
+	scenegraph::SceneGraphNode *node = sceneGraphModelNode(nodeId);
+	if (node == nullptr) {
+		return;
+	}
+	SelectBrush &brush = _modifierFacade.selectBrush();
+	if (!brush.ellipseValid()) {
+		return;
+	}
+	const glm::ivec3 &center = brush.ellipseCenter();
+	const int radiusU = brush.ellipseRadiusU();
+	const int radiusV = brush.ellipseRadiusV();
+	const int depth = brush.ellipseDepth();
+	const voxel::FaceNames face = brush.ellipseFace();
+	int uAxis;
+	int vAxis;
+	SelectBrush::ellipseAxes(face, uAxis, vAxis);
+	const int faceAxisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool is3D = brush.ellipse3D();
+	const bool positiveNormal = voxel::isPositiveFace(face);
+
+	// Calculate the bounding region of the new ellipse
+	const voxel::Region &vol = node->region();
+	glm::ivec3 mins = center;
+	glm::ivec3 maxs = center;
+	mins[uAxis] -= radiusU;
+	maxs[uAxis] += radiusU;
+	mins[vAxis] -= radiusV;
+	maxs[vAxis] += radiusV;
+	if (positiveNormal) {
+		mins[faceAxisIdx] -= depth;
+	} else {
+		maxs[faceAxisIdx] += depth;
+	}
+	voxel::Region ellipseRegion(mins, maxs);
+	ellipseRegion.cropTo(vol);
+
+	voxel::RawVolume *volume = node->volume();
+
+	// Clear only the positions flagged by the previous ellipse (not all selections)
+	voxel::Region dirtyRegion = ellipseRegion;
+	core::DynamicArray<glm::ivec3> &history = brush.ellipseHistory();
+	for (const glm::ivec3 &pos : history) {
+		const voxel::Voxel &v = volume->voxel(pos);
+		if (!voxel::isAir(v.getMaterial())) {
+			voxel::Voxel modified = v;
+			modified.setFlags(modified.getFlags() & ~voxel::FlagOutline);
+			volume->setVoxel(pos, modified);
+			dirtyRegion.accumulate(pos);
+		}
+	}
+	history.clear();
+
+	// Apply the new ellipse selection and record positions
+	auto selectFunc = [&](int x, int y, int z, const voxel::Voxel &v) {
+		const glm::ivec3 pos(x, y, z);
+		if (SelectBrush::insideSelection(pos, center, radiusU, radiusV, depth, is3D,
+										 uAxis, vAxis, faceAxisIdx, positiveNormal)) {
+			voxel::Voxel modified = v;
+			modified.setFlags(modified.getFlags() | voxel::FlagOutline);
+			volume->setVoxel(x, y, z, modified);
+			history.push_back(pos);
+		}
+	};
+	if (depth > 1) {
+		voxelutil::VisitSolid condition;
+		voxelutil::visitVolume(*volume, ellipseRegion, selectFunc, condition);
+	} else {
+		voxelutil::visitSurfaceVolume(*volume, selectFunc);
+	}
+
+	_selectionCacheNodeId = -1;
+	modified(nodeId, dirtyRegion, SceneModifiedFlags::NoUndo);
+}
+
+void SceneManager::selectionSetSlope(int nodeId) {
+	scenegraph::SceneGraphNode *node = sceneGraphModelNode(nodeId);
+	if (node == nullptr) {
+		return;
+	}
+	SelectBrush &brush = _modifierFacade.selectBrush();
+	if (!brush.slopeValid()) {
+		return;
+	}
+	voxel::RawVolume *volume = node->volume();
+
+	// Clear only the positions flagged by the previous slope selection
+	voxel::Region dirtyRegion = voxel::Region::InvalidRegion;
+	core::DynamicArray<glm::ivec3> &history = brush.slopeHistory();
+	for (const glm::ivec3 &pos : history) {
+		const voxel::Voxel &v = volume->voxel(pos);
+		if (!voxel::isAir(v.getMaterial())) {
+			voxel::Voxel modified = v;
+			modified.setFlags(modified.getFlags() & ~voxel::FlagOutline);
+			volume->setVoxel(pos, modified);
+			dirtyRegion.accumulate(pos);
+		}
+	}
+	history.clear();
+
+	// Re-execute the slope flood fill with current parameters
+	auto selectFunc = [&](int x, int y, int z, const voxel::Voxel &) {
+		const glm::ivec3 pos(x, y, z);
+		const voxel::Voxel &v = volume->voxel(pos);
+		if (!voxel::isAir(v.getMaterial())) {
+			voxel::Voxel modified = v;
+			modified.setFlags(modified.getFlags() | voxel::FlagOutline);
+			volume->setVoxel(pos, modified);
+			history.push_back(pos);
+			dirtyRegion.accumulate(pos);
+		}
+	};
+	voxelutil::visitSlopeSurface(*volume, brush.slopeSeedPos(), brush.slopeFace(),
+								 brush.slopeDeviation(), brush.slopeSampleDistance(), selectFunc);
+
+	_selectionCacheNodeId = -1;
+	if (dirtyRegion.isValid()) {
+		modified(nodeId, dirtyRegion, SceneModifiedFlags::NoUndo);
+	}
+}
+
 void SceneManager::resetLastTrace() {
 	if (!_traceViaMouse) {
 		return;

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -394,6 +394,8 @@ public:
 	void selectionUnselect(int nodeId);
 	void selectionSelectAll(int nodeId);
 	void selectionSetBounds(int nodeId, const voxel::Region &region);
+	void selectionSetEllipse(int nodeId);
+	void selectionSetSlope(int nodeId);
 	bool isSelected(int nodeId, const glm::ivec3 &pos) const;
 	voxel::Region selectionCalculateRegion(int nodeId) const;
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -370,10 +370,7 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	}
 	_brushContext.cursorVoxel = voxel;
 	brush->execute(sceneGraph, wrapper, _brushContext);
-	// Extrude and Transform manage voxel flags (FlagOutline) directly via their own mechanisms.
-	// growSelectionToNewVoxels/autoSelectNewVoxels would incorrectly select all solid voxels in the dirty region.
-	const bool managesOwnSelection = brush->type() == BrushType::Transform || brush->type() == BrushType::Extrude;
-	if (!managesOwnSelection) {
+	if (!brush->managesOwnSelection()) {
 		const bool isPlacementBrush = brush->type() != BrushType::Select && brush->type() != BrushType::Paint
 			&& brush->type() != BrushType::Normal;
 		const bool isPlacementModifier = modifierType == ModifierType::Place;
@@ -621,6 +618,11 @@ void Modifier::updateBrushVolumePreview(palette::Palette &activePalette, voxel::
 	const voxel::Region maxPreviewRegion(0, _maxSuggestedVolumeSizePreview->intVal() - 1);
 	bool simplePreview = isSimplePreview(brush, region);
 	if (!simplePreview && region.voxels() < maxPreviewRegion.voxels()) {
+		const bool isCircleSelect = _brushType == BrushType::Select &&
+			_selectBrush.selectMode() == SelectMode::Circle;
+		if (isCircleSelect) {
+			_selectBrush.setPreviewMode(true);
+		}
 		glm::ivec3 minsMirror = region.getLowerCorner();
 		glm::ivec3 maxsMirror = region.getUpperCorner();
 		if (brush->getMirrorAABB(minsMirror, maxsMirror)) {
@@ -633,6 +635,9 @@ void Modifier::updateBrushVolumePreview(palette::Palette &activePalette, voxel::
 		scenegraph::SceneGraphNode dummyNode(scenegraph::SceneGraphNodeType::Model);
 		dummyNode.setVolume(_previewVolume, false);
 		executeBrush(sceneGraph, dummyNode, modifierType, voxel);
+		if (isCircleSelect) {
+			_selectBrush.setPreviewMode(false);
+		}
 	} else if (simplePreview) {
 		_brushPreview.useSimplePreview = true;
 		_brushPreview.simplePreviewRegion = region;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
@@ -331,6 +331,15 @@ public:
 	SceneModifiedFlags sceneModifiedFlags() const;
 
 	/**
+	 * @return true if this brush directly manages voxel selection flags (FlagOutline).
+	 * When true, growSelectionToNewVoxels/autoSelectNewVoxels are skipped after execution
+	 * to avoid overwriting the brush's own selection logic.
+	 */
+	virtual bool managesOwnSelection() const {
+		return false;
+	}
+
+	/**
 	 * @brief Calculate the region this brush will modify
 	 *
 	 * Each brush defines its own logic for determining the affected region.

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
@@ -86,6 +86,9 @@ public:
 	void endBrush(BrushContext &ctx) override;
 	bool active() const override;
 	voxel::Region calcRegion(const BrushContext &ctx) const override;
+	bool managesOwnSelection() const override {
+		return true;
+	}
 
 	void setDepth(int depth);
 	int depth() const {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "SelectBrush.h"
+#include "math/Axis.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxel/Face.h"
 #include "voxel/Voxel.h"
@@ -12,10 +13,105 @@
 
 namespace voxedit {
 
+void SelectBrush::ellipseAxes(voxel::FaceNames face, int &uAxis, int &vAxis) {
+	const math::Axis axis = voxel::faceToAxis(face);
+	const int faceAxisIdx = math::getIndexForAxis(axis);
+	// The two perpendicular axes in order
+	uAxis = (faceAxisIdx + 1) % 3;
+	vAxis = (faceAxisIdx + 2) % 3;
+}
+
+bool SelectBrush::insideSelection(const glm::ivec3 &pos, const glm::ivec3 &center,
+								  int radiusU, int radiusV, int depth, bool is3D,
+								  int uAxis, int vAxis, int faceAxisIdx, bool positiveNormal) {
+	if (radiusU <= 0 || radiusV <= 0) {
+		return false;
+	}
+	// Signed depth: how far behind the surface the position is
+	// For positive faces, "behind" is the negative direction; for negative faces, positive
+	const int dd = positiveNormal ? (center[faceAxisIdx] - pos[faceAxisIdx])
+								  : (pos[faceAxisIdx] - center[faceAxisIdx]);
+	if (dd < 0) {
+		return false;
+	}
+	if (is3D && depth > 0) {
+		const double du = (double)(pos[uAxis] - center[uAxis]);
+		const double dv = (double)(pos[vAxis] - center[vAxis]);
+		const double ddd = (double)dd;
+		return (du * du) / ((double)radiusU * radiusU) +
+			   (dv * dv) / ((double)radiusV * radiusV) +
+			   (ddd * ddd) / ((double)depth * depth) <= 1.0;
+	}
+	// 2D ellipse + flat depth check (also used as fallback when 3D with depth=0)
+	if (!insideEllipse(pos, center, radiusU, radiusV, uAxis, vAxis)) {
+		return false;
+	}
+	return dd <= depth;
+}
+
+bool SelectBrush::insideEllipse(const glm::ivec3 &pos, const glm::ivec3 &center,
+								int radiusU, int radiusV, int uAxis, int vAxis) {
+	if (radiusU <= 0 || radiusV <= 0) {
+		return false;
+	}
+	const double du = (double)(pos[uAxis] - center[uAxis]);
+	const double dv = (double)(pos[vAxis] - center[vAxis]);
+	return (du * du) / ((double)radiusU * radiusU) + (dv * dv) / ((double)radiusV * radiusV) <= 1.0;
+}
+
+bool SelectBrush::needsAdditionalAction(const BrushContext &ctx) const {
+	// Circle, Connected, SameColor, Surface, FuzzyColor, FlatSurface use their own
+	// selection logic -they don't benefit from the 3-click AABB workflow.
+	// Only All and Box3D use the standard AABB region.
+	if (_selectMode != SelectMode::All && _selectMode != SelectMode::Box3D) {
+		return false;
+	}
+	return Super::needsAdditionalAction(ctx);
+}
+
+bool SelectBrush::beginBrush(const BrushContext &ctx) {
+	if (_selectMode == SelectMode::Circle) {
+		_ellipseValid = false;
+		_ellipseHistory.clear();
+	}
+	return Super::beginBrush(ctx);
+}
+
 voxel::Region SelectBrush::calcRegion(const BrushContext &ctx) const {
-	if (_selectMode == SelectMode::Connected || _selectMode == SelectMode::SameColor ||
-		_selectMode == SelectMode::Surface || _selectMode == SelectMode::FuzzyColor ||
-		_selectMode == SelectMode::FlatSurface) {
+	if (_selectMode == SelectMode::Circle && _aabbMode && _aabbFace != voxel::FaceNames::Max) {
+		const glm::ivec3 center = applyGridResolution(_aabbFirstPos, ctx.gridResolution);
+		const glm::ivec3 current = currentCursorPosition(ctx);
+		int uAxis;
+		int vAxis;
+		ellipseAxes(_aabbFace, uAxis, vAxis);
+		const int du = glm::abs(current[uAxis] - center[uAxis]);
+		const int dv = glm::abs(current[vAxis] - center[vAxis]);
+		const int r = glm::max(du, dv);
+		glm::ivec3 mins = center;
+		glm::ivec3 maxs = center;
+		mins[uAxis] -= r;
+		maxs[uAxis] += r;
+		mins[vAxis] -= r;
+		maxs[vAxis] += r;
+		// Limit face-normal axis by depth -only extend behind the surface
+		const math::Axis faceAxis = voxel::faceToAxis(_aabbFace);
+		const int faceAxisIdx = math::getIndexForAxis(faceAxis);
+		if (voxel::isPositiveFace(_aabbFace)) {
+			// Behind a positive face = negative direction
+			mins[faceAxisIdx] = center[faceAxisIdx] - _ellipseDepth;
+			maxs[faceAxisIdx] = center[faceAxisIdx];
+		} else {
+			// Behind a negative face = positive direction
+			mins[faceAxisIdx] = center[faceAxisIdx];
+			maxs[faceAxisIdx] = center[faceAxisIdx] + _ellipseDepth;
+		}
+		voxel::Region circleRegion(mins, maxs);
+		circleRegion.cropTo(ctx.targetVolumeRegion);
+		return circleRegion;
+	}
+	// Only All and Box3D use the standard AABB region; all other modes
+	// flood-fill or visit the full volume and don't need a user-drawn box.
+	if (_selectMode != SelectMode::All && _selectMode != SelectMode::Box3D) {
 		return ctx.targetVolumeRegion;
 	}
 	return Super::calcRegion(ctx);
@@ -91,6 +187,93 @@ void SelectBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWra
 			return;
 		}
 		voxelutil::visitFlatSurface(wrapper, startPos, ctx.cursorFace, _flatDeviation, func);
+		break;
+	}
+	case SelectMode::Circle: {
+		// Use _aabbFace (the face from the initial click) rather than ctx.cursorFace
+		// which can change during the drag as the cursor moves across faces
+		const voxel::FaceNames face = _aabbFace;
+		if (face == voxel::FaceNames::Max) {
+			return;
+		}
+		const glm::ivec3 center(_aabbFirstPos);
+		int uAxis;
+		int vAxis;
+		ellipseAxes(face, uAxis, vAxis);
+		const int faceAxisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+		// During initial drag, both radii are the same (circle), depth defaults to 1
+		const int du = glm::abs(ctx.cursorPosition[uAxis] - center[uAxis]);
+		const int dv = glm::abs(ctx.cursorPosition[vAxis] - center[vAxis]);
+		const int radius = glm::max(du, dv);
+		const int radiusU = radius;
+		const int radiusV = radius;
+		const int depth = _ellipseDepth;
+		const bool is3D = _ellipse3D;
+		const bool positiveNormal = voxel::isPositiveFace(face);
+		auto inBounds = [&](int x, int y, int z) {
+			const glm::ivec3 pos(x, y, z);
+			return insideSelection(pos, center, radiusU, radiusV, depth, is3D,
+								   uAxis, vAxis, faceAxisIdx, positiveNormal);
+		};
+		if (_previewMode) {
+			// In preview mode, remove voxels outside the selection from the preview copy
+			// so the ghost overlay shows only the selection shape
+			voxel::RawVolume *vol = wrapper.volume();
+			const voxel::Region &r = vol->region();
+			const voxel::Voxel air;
+			for (int z = r.getLowerZ(); z <= r.getUpperZ(); ++z) {
+				for (int y = r.getLowerY(); y <= r.getUpperY(); ++y) {
+					for (int x = r.getLowerX(); x <= r.getUpperX(); ++x) {
+						if (!inBounds(x, y, z)) {
+							vol->setVoxel(x, y, z, air);
+						}
+					}
+				}
+			}
+		} else {
+			_ellipseHistory.clear();
+			auto circleFunc = [&](int x, int y, int z, const voxel::Voxel &v) {
+				if (inBounds(x, y, z)) {
+					func(x, y, z, v);
+					_ellipseHistory.push_back(glm::ivec3(x, y, z));
+				}
+			};
+			if (depth > 1) {
+				// Visit all solid voxels in the ellipse bounding region.
+				// visitSurfaceVolume would skip interior voxels.
+				voxelutil::VisitSolid condition;
+				voxelutil::visitVolume(wrapper, selectionRegion, circleFunc, condition);
+			} else {
+				voxelutil::visitSurfaceVolume(wrapper, circleFunc);
+			}
+			// Cache ellipse parameters for slider adjustment
+			_ellipseCenter = center;
+			_ellipseRadiusU = radiusU;
+			_ellipseRadiusV = radiusV;
+			_ellipseDepth = depth;
+			_ellipse3D = is3D;
+			_ellipseFace = face;
+			_ellipseValid = true;
+		}
+		break;
+	}
+	case SelectMode::Slope: {
+		if (ctx.cursorFace == voxel::FaceNames::Max) {
+			return;
+		}
+		const glm::ivec3 &startPos = ctx.cursorPosition;
+		if (voxel::isAir(wrapper.voxel(startPos).getMaterial())) {
+			return;
+		}
+		_slopeHistory.clear();
+		auto slopeFunc = [&](int x, int y, int z, const voxel::Voxel &v) {
+			func(x, y, z, v);
+			_slopeHistory.push_back(glm::ivec3(x, y, z));
+		};
+		voxelutil::visitSlopeSurface(wrapper, startPos, ctx.cursorFace, _slopeDeviation, _slopeSampleDistance, slopeFunc);
+		_slopeSeedPos = startPos;
+		_slopeFace = ctx.cursorFace;
+		_slopeValid = true;
 		break;
 	}
 	case SelectMode::Box3D: {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
@@ -6,7 +6,9 @@
 
 #include "AABBBrush.h"
 #include "color/ColorUtil.h"
+#include "core/collection/DynamicArray.h"
 #include "voxedit-util/modifier/ModifierType.h"
+#include "voxel/Face.h"
 #include "voxel/Region.h"
 #include <glm/common.hpp>
 #include <glm/vec3.hpp>
@@ -32,6 +34,10 @@ enum class SelectMode : uint8_t {
 	FlatSurface,
 	/** Replace the current selection with all solid voxels in the drawn 3D box region */
 	Box3D,
+	/** Select surface voxels within a circular radius from the clicked center point */
+	Circle,
+	/** Flood-fill select connected surface voxels that fit a global slope plane within a height deviation threshold */
+	Slope,
 
 	Max
 };
@@ -45,6 +51,29 @@ private:
 	SelectMode _selectMode = SelectMode::All;
 	float _colorThreshold = color::ApproximationDistanceModerate;
 	int _flatDeviation = 0;
+	int _slopeDeviation = 10;
+	int _slopeSampleDistance = 3;
+	bool _previewMode = false;
+
+	/** Cached ellipse parameters from the last Circle selection */
+	glm::ivec3 _ellipseCenter{0};
+	int _ellipseRadiusU = 0;
+	int _ellipseRadiusV = 0;
+	int _ellipseDepth = 1;
+	bool _ellipse3D = false;
+	voxel::FaceNames _ellipseFace = voxel::FaceNames::Max;
+	bool _ellipseValid = false;
+
+	/** Positions flagged by the current ellipse -used to undo only our flags on slider changes */
+	core::DynamicArray<glm::ivec3> _ellipseHistory;
+
+	/** Cached slope parameters from the last Slope selection */
+	glm::ivec3 _slopeSeedPos{0};
+	voxel::FaceNames _slopeFace = voxel::FaceNames::Max;
+	bool _slopeValid = false;
+
+	/** Positions flagged by the current slope selection -used to undo on slider changes */
+	core::DynamicArray<glm::ivec3> _slopeHistory;
 
 	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
 				  const voxel::Region &region) override;
@@ -57,8 +86,17 @@ public:
 	virtual ~SelectBrush() = default;
 
 	voxel::Region calcRegion(const BrushContext &ctx) const override;
+	bool managesOwnSelection() const override {
+		return true;
+	}
+	bool needsAdditionalAction(const BrushContext &ctx) const override;
+	bool beginBrush(const BrushContext &ctx) override;
 
 	void setSelectMode(SelectMode mode) {
+		if (_selectMode != mode) {
+			_ellipseValid = false;
+			_slopeValid = false;
+		}
 		_selectMode = mode;
 	}
 
@@ -82,6 +120,121 @@ public:
 
 	int flatDeviation() const {
 		return _flatDeviation;
+	}
+
+	static constexpr int MaxSlopeDeviation = 90;
+
+	void setSlopeDeviation(int angle) {
+		_slopeDeviation = glm::clamp(angle, 0, MaxSlopeDeviation);
+	}
+
+	int slopeDeviation() const {
+		return _slopeDeviation;
+	}
+
+	static constexpr int MinSlopeSampleDistance = 2;
+	static constexpr int MaxSlopeSampleDistance = 16;
+
+	void setSlopeSampleDistance(int dist) {
+		_slopeSampleDistance = glm::clamp(dist, MinSlopeSampleDistance, MaxSlopeSampleDistance);
+	}
+
+	int slopeSampleDistance() const {
+		return _slopeSampleDistance;
+	}
+
+	void setPreviewMode(bool v) {
+		_previewMode = v;
+	}
+
+	/** Get the perpendicular axis indices for a given face */
+	static void ellipseAxes(voxel::FaceNames face, int &uAxis, int &vAxis);
+
+	/** Check if a position is inside an ellipse defined on the face plane */
+	static bool insideEllipse(const glm::ivec3 &pos, const glm::ivec3 &center,
+							  int radiusU, int radiusV, int uAxis, int vAxis);
+
+	/** Full bounds check: 2D ellipse + depth, or 3D ellipsoid (behind surface only) */
+	static bool insideSelection(const glm::ivec3 &pos, const glm::ivec3 &center,
+								int radiusU, int radiusV, int depth, bool is3D,
+								int uAxis, int vAxis, int faceAxisIdx, bool positiveNormal);
+
+	bool ellipseValid() const {
+		return _ellipseValid;
+	}
+
+	const glm::ivec3 &ellipseCenter() const {
+		return _ellipseCenter;
+	}
+
+	void setEllipseCenter(const glm::ivec3 &center) {
+		_ellipseCenter = center;
+	}
+
+	int ellipseRadiusU() const {
+		return _ellipseRadiusU;
+	}
+
+	void setEllipseRadiusU(int r) {
+		_ellipseRadiusU = glm::max(r, 0);
+	}
+
+	int ellipseRadiusV() const {
+		return _ellipseRadiusV;
+	}
+
+	void setEllipseRadiusV(int r) {
+		_ellipseRadiusV = glm::max(r, 0);
+	}
+
+	int ellipseDepth() const {
+		return _ellipseDepth;
+	}
+
+	void setEllipseDepth(int d) {
+		_ellipseDepth = glm::max(d, 1);
+	}
+
+	bool ellipse3D() const {
+		return _ellipse3D;
+	}
+
+	void setEllipse3D(bool v) {
+		_ellipse3D = v;
+	}
+
+	voxel::FaceNames ellipseFace() const {
+		return _ellipseFace;
+	}
+
+	void invalidateEllipse() {
+		_ellipseValid = false;
+		_ellipseHistory.clear();
+	}
+
+	core::DynamicArray<glm::ivec3> &ellipseHistory() {
+		return _ellipseHistory;
+	}
+
+	bool slopeValid() const {
+		return _slopeValid;
+	}
+
+	const glm::ivec3 &slopeSeedPos() const {
+		return _slopeSeedPos;
+	}
+
+	voxel::FaceNames slopeFace() const {
+		return _slopeFace;
+	}
+
+	void invalidateSlope() {
+		_slopeValid = false;
+		_slopeHistory.clear();
+	}
+
+	core::DynamicArray<glm::ivec3> &slopeHistory() {
+		return _slopeHistory;
 	}
 };
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -101,6 +101,9 @@ public:
 	void endBrush(BrushContext &ctx) override;
 	bool active() const override;
 	voxel::Region calcRegion(const BrushContext &ctx) const override;
+	bool managesOwnSelection() const override {
+		return true;
+	}
 
 	TransformMode transformMode() const {
 		return _transformMode;

--- a/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
@@ -403,4 +403,327 @@ TEST_F(SelectBrushTest, testSelectModeFlatSurface_invalidFace) {
 	brush.shutdown();
 }
 
+TEST_F(SelectBrushTest, testSelectModeCircle) {
+	// Create a flat 11x11 floor at y=0
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -5; z <= 5; ++z) {
+		for (int x = -5; x <= 5; ++x) {
+			volume.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Circle);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// Click at center (0,0,0), drag to (3,0,0) -> radius = 3
+	// Set cursorFace before prepare() so _aabbFace locks to PositiveY
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_TRUE(brush.active());
+	ctx.cursorPosition = glm::ivec3(3, 0, 0);
+	brush.step(ctx);
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// Center should be selected
+	EXPECT_TRUE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Center voxel should be selected";
+
+	// Voxels within radius 3 should be selected
+	EXPECT_TRUE((volume.voxel(2, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Voxel within radius should be selected";
+	EXPECT_TRUE((volume.voxel(0, 0, 2).getFlags() & voxel::FlagOutline) != 0)
+		<< "Voxel within radius should be selected";
+	EXPECT_TRUE((volume.voxel(3, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Voxel at exactly the radius should be selected";
+
+	// Voxels outside the radius should NOT be selected
+	EXPECT_FALSE((volume.voxel(5, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Voxel far outside radius should not be selected";
+	EXPECT_FALSE((volume.voxel(0, 0, 5).getFlags() & voxel::FlagOutline) != 0)
+		<< "Voxel far outside radius should not be selected";
+
+	// Diagonal at distance sqrt(3^2+3^2) = ~4.24 > 3 should NOT be selected
+	EXPECT_FALSE((volume.voxel(3, 0, 3).getFlags() & voxel::FlagOutline) != 0)
+		<< "Diagonal voxel outside radius should not be selected";
+
+	// Diagonal at distance sqrt(2^2+2^2) = ~2.83 <= 3 should be selected
+	EXPECT_TRUE((volume.voxel(2, 0, 2).getFlags() & voxel::FlagOutline) != 0)
+		<< "Diagonal voxel within radius should be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeCircle_ellipseParams) {
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -5; z <= 5; ++z) {
+		for (int x = -5; x <= 5; ++x) {
+			volume.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Circle);
+	EXPECT_FALSE(brush.ellipseValid());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	// Set cursorFace before beginBrush so _aabbFace locks to PositiveY
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_TRUE(brush.active());
+	ctx.cursorPosition = glm::ivec3(3, 0, 0);
+	brush.step(ctx);
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// After execution, ellipse params should be cached
+	EXPECT_TRUE(brush.ellipseValid());
+	EXPECT_EQ(brush.ellipseCenter(), glm::ivec3(0, 0, 0));
+	EXPECT_EQ(brush.ellipseRadiusU(), 3);
+	EXPECT_EQ(brush.ellipseRadiusV(), 3);
+	EXPECT_EQ(brush.ellipseFace(), voxel::FaceNames::PositiveY);
+
+	// Changing select mode should invalidate ellipse
+	brush.setSelectMode(SelectMode::All);
+	EXPECT_FALSE(brush.ellipseValid());
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeCircle_invalidFace) {
+	voxel::RawVolume volume({-5, 5});
+	volume.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Circle);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	// Set invalid face before beginBrush so _aabbFace locks to Max
+	ctx.cursorFace = voxel::FaceNames::Max;
+	ctx.cursorPosition = glm::ivec3(-5, -5, -5);
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	ctx.cursorPosition = glm::ivec3(5, 5, 5);
+	brush.step(ctx);
+	executeSelect(brush, node, ctx);
+
+	EXPECT_FALSE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "No voxel should be selected when face is invalid";
+	EXPECT_FALSE(brush.ellipseValid());
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeCircle_onlySurface) {
+	// Create a solid 5x5x5 cube - circle should only select surface voxels
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -2; z <= 2; ++z) {
+		for (int y = -2; y <= 2; ++y) {
+			for (int x = -2; x <= 2; ++x) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Circle);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	// Set cursorFace before beginBrush so _aabbFace locks to PositiveY
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	EXPECT_TRUE(brush.active());
+	ctx.cursorPosition = glm::ivec3(5, 0, 0);
+	brush.step(ctx);
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// Interior voxels should NOT be selected (only surface voxels)
+	EXPECT_FALSE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Interior voxel should not be selected";
+
+	// Surface voxels within radius should be selected
+	EXPECT_TRUE((volume.voxel(2, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Surface voxel within radius should be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeSlope_flatSurface) {
+	// 5x5 flat floor at y=0 -gradient is zero everywhere, so any angle should select all
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -2; z <= 2; ++z) {
+		for (int x = -2; x <= 2; ++x) {
+			volume.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Slope);
+	brush.setSlopeDeviation(10);
+	brush.setSlopeSampleDistance(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// All floor voxels should be selected (gradient is zero everywhere)
+	for (int z = -2; z <= 2; ++z) {
+		for (int x = -2; x <= 2; ++x) {
+			EXPECT_TRUE((volume.voxel(x, 0, z).getFlags() & voxel::FlagOutline) != 0)
+				<< "Floor voxel at (" << x << ",0," << z << ") should be selected";
+		}
+	}
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeSlope_stopsAtWall) {
+	// Floor at y=0 and a vertical wall at x=3. The wall voxels aren't surface
+	// voxels on the +Y face, so slope fill from the floor should not include them.
+	voxel::RawVolume volume({-5, 5});
+	// Floor
+	for (int z = -1; z <= 1; ++z) {
+		for (int x = -3; x <= 3; ++x) {
+			volume.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	// Wall going up from x=3 (blocks +Y face of floor voxels at x=3 for y>=1)
+	for (int y = 1; y <= 4; ++y) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(3, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Slope);
+	brush.setSlopeDeviation(45);
+	brush.setSlopeSampleDistance(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// Floor voxels should be selected
+	EXPECT_TRUE((volume.voxel(-3, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Floor voxel at (-3,0,0) should be selected";
+	EXPECT_TRUE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Floor voxel at (0,0,0) should be selected";
+
+	// Wall voxels should NOT be selected (they face +X, not +Y -not surface voxels for this face)
+	EXPECT_FALSE((volume.voxel(3, 2, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Wall voxel at (3,2,0) should not be selected";
+	EXPECT_FALSE((volume.voxel(3, 4, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Wall voxel at (3,4,0) should not be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeSlope_staircase) {
+	// 45-degree staircase: each step goes +1 in X and +1 in Y.
+	// All steps have the same gradient, so slope fill should select them all.
+	voxel::RawVolume volume({-5, 10});
+	// Build a filled staircase so each step has +Y exposed
+	for (int step = 0; step < 6; ++step) {
+		// Each step column goes from y=0 up to y=step
+		for (int y = 0; y <= step; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				volume.setVoxel(step, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Slope);
+	brush.setSlopeDeviation(10); // Small threshold -staircase gradient should be consistent
+	brush.setSlopeSampleDistance(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(10, 10, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// Each stair top should be selected (consistent 45-degree slope)
+	for (int step = 0; step < 6; ++step) {
+		EXPECT_TRUE((volume.voxel(step, step, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Stair top at (" << step << "," << step << ",0) should be selected";
+	}
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeSlope_disconnectedNotSelected) {
+	// Two separate flat surfaces -slope fill should not jump the gap
+	voxel::RawVolume volume({-5, 5});
+	// Surface 1 at x=[-2..0]
+	for (int x = -2; x <= 0; ++x) {
+		volume.setVoxel(x, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	}
+	// Surface 2 at x=[2..4] -gap at x=1
+	for (int x = 2; x <= 4; ++x) {
+		volume.setVoxel(x, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SelectBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Slope);
+	brush.setSlopeDeviation(90);
+	brush.setSlopeSampleDistance(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	prepare(brush, ctx, glm::ivec3(-5, -5, -5), glm::ivec3(5, 5, 5));
+	ctx.cursorPosition = glm::ivec3(0, 0, 0);
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	executeSelect(brush, node, ctx);
+
+	// Surface 1 should be selected
+	for (int x = -2; x <= 0; ++x) {
+		EXPECT_TRUE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Voxel at (" << x << ",0,0) should be selected";
+	}
+
+	// Surface 2 should NOT be selected (disconnected)
+	for (int x = 2; x <= 4; ++x) {
+		EXPECT_FALSE((volume.voxel(x, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+			<< "Disconnected voxel at (" << x << ",0,0) should not be selected";
+	}
+
+	brush.shutdown();
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- **Circle select mode**: click-drag to define a circular selection on a surface. After the initial selection, sliders allow adjusting center, radii (ellipse), depth, and toggling 3D ellipsoid mode. Changes re-execute live without re-clicking.
- **Slope select mode**: flood-fill selects connected surface voxels that fit a global slope plane. The plane is computed once via 2D linear regression from the seed neighborhood and frozen during BFS expansion. Sliders for max height deviation and sample distance allow live re-execution.
- Refactors `managesOwnSelection()` into a virtual method on the `Brush` base class (replacing type-checking in `Modifier::executeBrush`).

## Test plan
- [ ] Circle select: click-drag on a flat surface, verify circular selection. Adjust radii/depth/3D sliders and confirm live updates
- [ ] Circle select: verify only surface voxels are selected (depth=1), interior voxels excluded
- [ ] Slope select: click on a sloped surface (e.g. 45-degree staircase roof), verify connected slope is selected
- [ ] Slope select: verify selection stops at walls, gaps, and sharp angle changes (e.g. rooftop ridge)
- [ ] Slope select: adjust max deviation and sample distance sliders, confirm live re-execution
- [ ] Verify existing selection modes (All, Surface, SameColor, etc.) still work correctly
- [ ] 4 new Circle unit tests + 4 new Slope unit tests pass