### PR TITLE
VOXEDIT: add deleteselected command and reuse Connectivity.h arrays

### DIFF
--- a/src/modules/voxelutil/VolumeVisitor.h
+++ b/src/modules/voxelutil/VolumeVisitor.h
@@ -1396,50 +1396,48 @@ int visitSlopeSurface(const Volume &volume, const glm::ivec3 &position, voxel::F
 	queue.push_back(position);
 
 	// 26-connectivity: staircase steps are edge/corner-connected, not face-connected.
-	static constexpr int NeighborCount = 26;
-	static constexpr glm::ivec3 neighbors[NeighborCount] = {
-		// 6 face neighbors
-		{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1},
-		// 12 edge neighbors
-		{1, 1, 0}, {1, -1, 0}, {-1, 1, 0}, {-1, -1, 0},
-		{1, 0, 1}, {1, 0, -1}, {-1, 0, 1}, {-1, 0, -1},
-		{0, 1, 1}, {0, 1, -1}, {0, -1, 1}, {0, -1, -1},
-		// 8 corner neighbors
-		{1, 1, 1}, {1, 1, -1}, {1, -1, 1}, {1, -1, -1},
-		{-1, 1, 1}, {-1, 1, -1}, {-1, -1, 1}, {-1, -1, -1}};
-
+	// Uses face/edge/corner offset arrays from voxel::Connectivity.h
 	while (!queue.empty()) {
 		const glm::ivec3 current = queue.back();
 		queue.pop();
-		for (int i = 0; i < NeighborCount; ++i) {
-			const glm::ivec3 neighborPos = current + neighbors[i];
+		auto visitNeighbor = [&](const glm::ivec3 &offset) {
+			const glm::ivec3 neighborPos = current + offset;
 			if (!visited.insert(neighborPos)) {
-				continue;
+				return;
 			}
 			if (!volRegion.containsPoint(neighborPos)) {
-				continue;
+				return;
 			}
 			if (voxel::isAir(volume.voxel(neighborPos).getMaterial())) {
-				continue;
+				return;
 			}
 			// Must be a surface voxel (has the clicked face exposed)
 			glm::ivec3 above = neighborPos;
 			above[heightAxis] += positiveNormal ? 1 : -1;
 			if (volRegion.containsPoint(above) && !voxel::isAir(volume.voxel(above).getMaterial())) {
-				continue;
+				return;
 			}
 			// Check if this voxel's height fits the slope plane (frozen after bootstrap)
 			const float predicted = predictHeight(neighborPos[uAxis], neighborPos[vAxis]);
 			const float actual = static_cast<float>(neighborPos[heightAxis]);
 			if (glm::abs(actual - predicted) > maxDev) {
-				continue;
+				return;
 			}
 			if (!sampler.setPosition(neighborPos)) {
-				continue;
+				return;
 			}
 			visitor(neighborPos.x, neighborPos.y, neighborPos.z, sampler.voxel());
 			++nVisited;
 			queue.push_back(neighborPos);
+		};
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+			visitNeighbor(offset);
+		}
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderEdges) {
+			visitNeighbor(offset);
+		}
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderCorners) {
+			visitNeighbor(offset);
 		}
 	}
 	return nVisited;

--- a/src/tools/voxedit/modules/voxedit-ui/ToolsPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/ToolsPanel.cpp
@@ -110,6 +110,7 @@ void ToolsPanel::updateEditMode(command::CommandExecutionListener &listener) {
 		toolbar.button(ICON_LC_PAINT_BUCKET, "fillhollow");
 		toolbar.button(ICON_LC_ERASER, "hollow");
 		toolbar.button(ICON_LC_X, "clear");
+		toolbar.button(ICON_LC_TRASH, "deleteselected");
 		toolbar.button(ICON_LC_PAINT_BUCKET, "fill");
 	}
 

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -301,6 +301,33 @@ void SceneManager::nodeGroupClear() {
 	});
 }
 
+void SceneManager::nodeGroupDeleteSelected() {
+	nodeForeachGroup([&](int groupNodeId) {
+		scenegraph::SceneGraphNode *node = sceneGraphModelNode(groupNodeId);
+		if (node == nullptr) {
+			return;
+		}
+		if (!node->hasSelection()) {
+			return;
+		}
+		voxel::RawVolume *v = node->volume();
+		if (v == nullptr) {
+			return;
+		}
+		const voxel::Region selRegion = selectionCalculateRegion(groupNodeId);
+		if (!selRegion.isValid()) {
+			return;
+		}
+		voxel::RawVolumeWrapper wrapper = _modifierFacade.createRawVolumeWrapper(v);
+		voxelutil::visitVolume(*v, selRegion, [&](int x, int y, int z, const voxel::Voxel &voxel) {
+			if ((voxel.getFlags() & voxel::FlagOutline) != 0) {
+				wrapper.setVoxel(x, y, z, voxel::Voxel());
+			}
+		}, voxelutil::VisitSolid(), voxelutil::VisitorOrder::ZYX);
+		modified(groupNodeId, wrapper.dirtyRegion());
+	});
+}
+
 void SceneManager::nodeGroupHollow() {
 	nodeForeachGroup([&](int groupNodeId) {
 		scenegraph::SceneGraphNode *node = sceneGraphModelNode(groupNodeId);
@@ -2662,6 +2689,11 @@ void SceneManager::construct() {
 		.setHandler([&] (const command::CommandArgs& args) {
 			nodeGroupClear();
 		}).setHelp(_("Remove all voxels in the current selection"));
+
+	command::Command::registerCommand("deleteselected")
+		.setHandler([&] (const command::CommandArgs& args) {
+			nodeGroupDeleteSelected();
+		}).setHelp(_("Remove selected voxels"));
 
 	command::Command::registerCommand("setreferenceposition")
 		.addArg({"x", command::ArgType::Int, false, "", "X coordinate"})

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -193,6 +193,7 @@ protected:
 	void nodeGroupHollow();
 	void nodeGroupFill();
 	void nodeGroupClear();
+	void nodeGroupDeleteSelected();
 	void nodeGroupRotate(math::Axis axis);
 	void nodeGroupFlip(math::Axis axis);
 	void nodeGroupResize(const glm::ivec3 &size);

--- a/src/tools/voxedit/modules/voxedit-util/tests/AbstractSceneManagerTest.h
+++ b/src/tools/voxedit/modules/voxedit-util/tests/AbstractSceneManagerTest.h
@@ -58,6 +58,10 @@ public:
 		nodeGroupClear();
 	}
 
+	void testDeleteSelected() {
+		nodeGroupDeleteSelected();
+	}
+
 	void testFlip(math::Axis axis) {
 		nodeGroupFlip(axis);
 	}

--- a/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
@@ -1034,6 +1034,52 @@ TEST_F(SceneManagerTest, testClear) {
 	EXPECT_EQ(0, voxelutil::countVoxels(*v));
 }
 
+TEST_F(SceneManagerTest, testDeleteSelected) {
+	const voxel::Region region{0, 5};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "deleteselected_test", region));
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+
+	// Fill the entire volume
+	for (int x = 0; x <= 5; ++x) {
+		for (int y = 0; y <= 5; ++y) {
+			for (int z = 0; z <= 5; ++z) {
+				v->setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+			}
+		}
+	}
+	const int totalVoxels = voxelutil::countVoxels(*v);
+	ASSERT_EQ(216, totalVoxels);
+
+	// Select only a sub-region
+	const voxel::Region selRegion{0, 2};
+	scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	ASSERT_NE(nullptr, node);
+	node->select(selRegion);
+	ASSERT_TRUE(node->hasSelection());
+
+	sceneMgr()->testDeleteSelected();
+
+	const int voxelsAfter = voxelutil::countVoxels(*v);
+	const int selectedVoxels = selRegion.getWidthInVoxels() * selRegion.getHeightInVoxels() * selRegion.getDepthInVoxels();
+	EXPECT_EQ(totalVoxels - selectedVoxels, voxelsAfter)
+		<< "Only selected voxels should have been removed";
+}
+
+TEST_F(SceneManagerTest, testDeleteSelectedNoSelection) {
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	ASSERT_TRUE(testSetVoxel(testMins(), 1));
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+	const int voxelsBefore = voxelutil::countVoxels(*v);
+	EXPECT_GT(voxelsBefore, 0);
+
+	// No selection - deleteSelected should be a no-op
+	sceneMgr()->testDeleteSelected();
+	EXPECT_EQ(voxelsBefore, voxelutil::countVoxels(*v));
+}
+
 TEST_F(SceneManagerTest, testHollow) {
 	const voxel::Region region{0, 5};
 	ASSERT_TRUE(_sceneMgr->newScene(true, "hollow_test", region));


### PR DESCRIPTION
## Summary
- Add `deleteselected` command that removes only voxels with FlagOutline (selected voxels) to air, bounded by the selection region for performance on large models
- Toolbar button in ToolsPanel Action section (trash icon)
- Replace inline 26-neighbor array in `visitSlopeSurface` with range-based iteration over `arrayPathfinderFaces`/`Edges`/`Corners` from `Connectivity.h` (review feedback from PR #764)
- 2 unit tests: normal delete and no-selection no-op

## Test plan
- [ ] Select some voxels, press the deleteselected toolbar button or run the `deleteselected` command - only selected voxels should be removed
- [ ] Run `deleteselected` with no selection - volume should be unchanged
- [ ] Verify slope select still works correctly after the Connectivity.h refactor
- [ ] Run unit tests: `testDeleteSelected`, `testDeleteSelectedNoSelection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)