### PR TITLE
VOXEDIT: fix auto-select for extrude and keep original voxels

### DIFF
--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -370,15 +370,13 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	}
 	_brushContext.cursorVoxel = voxel;
 	brush->execute(sceneGraph, wrapper, _brushContext);
-	if (!brush->managesOwnSelection()) {
-		const bool isPlacementBrush = brush->type() != BrushType::Select && brush->type() != BrushType::Paint
-			&& brush->type() != BrushType::Normal;
-		const bool isPlacementModifier = modifierType == ModifierType::Place;
-		if (autoSelect() && isPlacementBrush && isPlacementModifier) {
-			wrapper.autoSelectNewVoxels();
-		} else {
-			wrapper.growSelectionToNewVoxels();
-		}
+	const bool isPlacementBrush = brush->type() != BrushType::Select && brush->type() != BrushType::Paint
+		&& brush->type() != BrushType::Normal;
+	const bool isPlacementModifier = modifierType == ModifierType::Place;
+	if (autoSelect() && isPlacementBrush && isPlacementModifier) {
+		wrapper.autoSelectNewVoxels();
+	} else if (!brush->managesOwnSelection()) {
+		wrapper.growSelectionToNewVoxels();
 	}
 	const voxel::Region &modifiedRegion = wrapper.dirtyRegion();
 	if (modifiedRegion.isValid()) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -393,11 +393,9 @@ void ExtrudeBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wra
 				writeVoxel(wrapper, savedPositions, selPos + dir * step + shift, ctx.cursorVoxel);
 			}
 		}
-
-		// Remove original selected voxels — extrude moves the face outward
-		for (const glm::ivec3 &selPos : _cachedSelectedPositions) {
-			writeVoxel(wrapper, savedPositions, selPos, air);
-		}
+		// Include the original selected positions in the dirty region so that
+		// auto-select will re-select them along with the newly extruded voxels
+		wrapper.addToDirtyRegion(_cachedSelectedPositions);
 	}
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ExtrudeBrushTest.cpp
@@ -204,12 +204,12 @@ TEST_F(ExtrudeBrushTest, testExtrudePushThenPull) {
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial())) << "Selected voxel at (0,0,0) should be carved";
 
 	// Push outward (+1) from same selection: history restores (0,0,0), then
-	// positive extrude places at x=+1 and removes the original at x=0
+	// positive extrude places at x=+1 and keeps the original at x=0
 	brush.setDepth(1);
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
-	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
-		<< "Original at (0,0,0) removed by positive extrude";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original at (0,0,0) kept by positive extrude";
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
 		<< "Outward voxel at (1,0,0) expected";
 
@@ -325,8 +325,8 @@ TEST_F(ExtrudeBrushTest, testExtrudeWithOffsetU) {
 	brush.shutdown();
 }
 
-// Positive extrude removes originals and new voxels do not get FlagOutline
-TEST_F(ExtrudeBrushTest, testExtrudeRemovesOriginalsAndNoFlag) {
+// Positive extrude keeps originals and new voxels do not get FlagOutline
+TEST_F(ExtrudeBrushTest, testExtrudeKeepsOriginalsAndNoFlag) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	volume.setVoxel(0, 0, 0, selectedVoxel());
 
@@ -345,9 +345,9 @@ TEST_F(ExtrudeBrushTest, testExtrudeRemovesOriginalsAndNoFlag) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Original voxel removed by positive extrude
-	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
-		<< "Original voxel at (0,0,0) should be removed by positive extrude";
+	// Original voxel kept by positive extrude
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original voxel at (0,0,0) should be kept by positive extrude";
 	// New extruded voxels should NOT have FlagOutline
 	const voxel::Voxel midVoxel = volume.voxel(1, 0, 0);
 	EXPECT_TRUE(voxel::isBlocked(midVoxel.getMaterial()));
@@ -542,8 +542,8 @@ TEST_F(ExtrudeBrushTest, testFillWallsDisabled) {
 	brush.shutdown();
 }
 
-// Positive extrude removes original selected voxels
-TEST_F(ExtrudeBrushTest, testPositiveExtrudeRemovesOriginals) {
+// Positive extrude keeps original selected voxels
+TEST_F(ExtrudeBrushTest, testPositiveExtrudeKeepsOriginals) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	volume.setVoxel(0, 0, 0, selectedVoxel());
 
@@ -562,9 +562,9 @@ TEST_F(ExtrudeBrushTest, testPositiveExtrudeRemovesOriginals) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Original position should be air — extrude moves the face outward
-	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
-		<< "Original selected voxel should be removed after positive extrude";
+	// Original position should be solid — extrude adds outward without removing
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original selected voxel should be kept after positive extrude";
 	// Extruded voxels at x=1 and x=2
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
 		<< "Extruded voxel at (1,0,0)";
@@ -578,10 +578,10 @@ TEST_F(ExtrudeBrushTest, testPositiveExtrudeRemovesOriginals) {
 TEST_F(ExtrudeBrushTest, testInteriorPruningOnCommit) {
 	voxel::RawVolume volume(voxel::Region(-5, 5));
 	// Create a 3x3x1 slab at z=0, all selected.
-	// Positive extrude removes originals (z=0 -> air), places at z=1,2,3.
-	// With depth=3 and 3x3 slab, the center voxel at (0,0,2) has:
-	//   x±1, y±1 = solid (extruded neighbors), z+1=(0,0,3), z-1=(0,0,1) = solid
-	// So (0,0,2) is fully interior and should be pruned.
+	// Positive extrude keeps originals (z=0 solid), places at z=1,2,3.
+	// With depth=3 and 3x3 slab, the center voxels at (0,0,1) and (0,0,2) have:
+	//   x+-1, y+-1 = solid (neighbors), z+-1 = solid (slab at z=0 and layers above)
+	// So (0,0,1) and (0,0,2) are fully interior and should be pruned.
 	for (int x = -1; x <= 1; ++x) {
 		for (int y = -1; y <= 1; ++y) {
 			volume.setVoxel(x, y, 0, selectedVoxel());
@@ -603,7 +603,9 @@ TEST_F(ExtrudeBrushTest, testInteriorPruningOnCommit) {
 	ASSERT_TRUE(brush.beginBrush(ctx));
 	executeExtrude(brush, node, ctx);
 
-	// Center of middle layer (0,0,2) is fully enclosed: pruned
+	// Center of layers z=1 and z=2 are fully enclosed: pruned
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 1).getMaterial()))
+		<< "Interior voxel at (0,0,1) should be pruned";
 	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 2).getMaterial()))
 		<< "Interior voxel at (0,0,2) should be pruned";
 	// Tip layer surface voxels should remain
@@ -612,9 +614,9 @@ TEST_F(ExtrudeBrushTest, testInteriorPruningOnCommit) {
 	// Edge voxels of middle layer should remain (exposed on x or y face)
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 2).getMaterial()))
 		<< "Edge voxel at (1,0,2) should remain";
-	// Originals removed
-	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()))
-		<< "Original at (0,0,0) should be removed";
+	// Originals kept
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original at (0,0,0) should be kept";
 
 	brush.shutdown();
 }

--- a/src/tools/voxedit/modules/voxedit-util/tests/ModifierTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/ModifierTest.cpp
@@ -706,4 +706,52 @@ TEST_F(ModifierTest, testAutoSelectClearsPreviousSelection) {
 	modifier.shutdown();
 }
 
+TEST_F(ModifierTest, testAutoSelectExtrudeNewVoxels) {
+	SceneManager mgr(_testApp->timeProvider(), _testApp->filesystem(),
+					 core::make_shared<ISceneRenderer>(), core::make_shared<IModifierRenderer>());
+	Modifier modifier(&mgr, core::make_shared<IModifierRenderer>());
+	modifier.construct();
+	ASSERT_TRUE(modifier.init());
+	modifier.setAutoSelect(true);
+
+	voxel::RawVolume volume({-10, 10});
+	// Place a selected voxel at origin
+	voxel::Voxel selected = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	selected.setFlags(voxel::FlagOutline);
+	volume.setVoxel(0, 0, 0, selected);
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	modifier.setBrushType(BrushType::Extrude);
+	modifier.setModifierType(ModifierType::Place);
+	modifier.setCursorVoxel(voxel::createVoxel(voxel::VoxelType::Generic, 2));
+	modifier.setCursorPosition(glm::ivec3(0), voxel::FaceNames::PositiveX);
+	ExtrudeBrush &brush = modifier.extrudeBrush();
+	brush.setDepth(1);
+
+	BrushContext &ctx = modifier.brushContext();
+	ctx.cursorFace = voxel::FaceNames::PositiveX;
+	ASSERT_TRUE(modifier.beginBrush());
+
+	scenegraph::SceneGraph sceneGraph;
+	bool callbackFired = false;
+	modifier.execute(sceneGraph, node,
+					 [&](const voxel::Region &, ModifierType, SceneModifiedFlags) { callbackFired = true; });
+	modifier.endBrush();
+	EXPECT_TRUE(callbackFired) << "Extrude should succeed";
+
+	// Extruded voxel at x=1 should have FlagOutline from auto-select
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()))
+		<< "Extruded voxel at (1,0,0) should exist";
+	EXPECT_TRUE((volume.voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Extruded voxel at (1,0,0) should be auto-selected";
+	// Original voxel should also be auto-selected (autoSelectNewVoxels selects all solid in dirty region)
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original voxel at (0,0,0) should be kept";
+	EXPECT_TRUE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Original voxel at (0,0,0) should be auto-selected";
+	modifier.shutdown();
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- Auto-select now applies to all placement brushes including extrude, regardless of `managesOwnSelection()`. Previously extrude was bypassed because it manages its own selection during preview.
- Positive extrude no longer removes original selected voxels — it adds new voxels outward while keeping the originals in place.
- Updated 4 existing extrude tests and added 1 new auto-select + extrude integration test in ModifierTest.

## Test plan
- [ ] Enable auto-select in Mask menu, select voxels, extrude outward — new voxels should be selected after finalizing
- [ ] Disable auto-select, extrude — new voxels should not be selected
- [ ] Positive extrude should keep original voxels in place (no gap between original and extruded)
- [ ] Carve (negative depth) behavior unchanged
- [ ] Run `tests-voxedit-util` — all extrude and modifier tests pass