### PR TITLE
VOXEDIT: add sculpt brush with erode, grow and flatten modes

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -29,6 +29,7 @@
 #include "voxel/Face.h"
 #include "voxedit-util/modifier/brush/ExtrudeBrush.h"
 #include "voxedit-util/modifier/brush/TransformBrush.h"
+#include "voxedit-util/modifier/brush/SculptBrush.h"
 #include "voxedit-util/modifier/brush/StampBrush.h"
 #include "voxedit-util/modifier/brush/TextureBrush.h"
 #include "voxel/RawVolume.h"
@@ -46,12 +47,15 @@ static constexpr const char *BrushTypeIcons[] = {
 	ICON_LC_PIPETTE,	ICON_LC_BOXES,	   ICON_LC_GROUP,
 	ICON_LC_STAMP,		ICON_LC_PEN_LINE,  ICON_LC_FOOTPRINTS,
 	ICON_LC_PAINTBRUSH, ICON_LC_TEXT_WRAP, ICON_LC_SQUARE_DASHED_MOUSE_POINTER,
-	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT, ICON_LC_EXPAND, ICON_LC_MOVE_3D};
+	ICON_LC_IMAGE,		ICON_LC_MOVE_UP_RIGHT, ICON_LC_EXPAND, ICON_LC_MOVE_3D, ICON_LC_BLEND};
 static_assert(lengthof(BrushTypeIcons) == (int)BrushType::Max, "BrushTypeIcons size mismatch");
 
 static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"), NC_("Transform Modes", "Shear"),
 												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
 static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
+
+static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten")};
+static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
 												   NC_("Scale Sampling", "Cubic")};
@@ -1076,6 +1080,91 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 	}
 }
 
+void BrushPanel::executeSculptBrush() {
+	Modifier &modifier = _sceneMgr->modifier();
+	if (!modifier.beginBrushFromPanel()) {
+		return;
+	}
+	auto func = [&](int nodeId) {
+		if (scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId)) {
+			if (!node->visible()) {
+				return;
+			}
+			auto callback = [&](const voxel::Region &region, ModifierType type, SceneModifiedFlags flags) {
+				_sceneMgr->modified(nodeId, region, flags);
+			};
+			modifier.execute(_sceneMgr->sceneGraph(), *node, callback);
+		}
+	};
+	_sceneMgr->nodeForeachGroup(func);
+	modifier.endBrush();
+}
+
+void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &listener) {
+	Modifier &modifier = _sceneMgr->modifier();
+	SculptBrush &brush = modifier.sculptBrush();
+
+	const scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(_sceneMgr->sceneGraph().activeNode());
+	if (node == nullptr || (!node->hasSelection() && !brush.hasSnapshot())) {
+		ImGui::TextWrappedUnformatted(_("Select voxels first, then switch to sculpt"));
+		return;
+	}
+
+	const SculptMode currentMode = brush.sculptMode();
+	if (ImGui::BeginCombo(_("Sculpt mode"), _(SculptModeStr[(int)currentMode]), ImGuiComboFlags_None)) {
+		for (int i = 0; i < (int)SculptMode::Max; ++i) {
+			const SculptMode mode = (SculptMode)i;
+			const bool selected = mode == currentMode;
+			if (ImGui::Selectable(_(SculptModeStr[i]), selected)) {
+				brush.setSculptMode(mode);
+			}
+			if (selected) {
+				ImGui::SetItemDefaultFocus();
+			}
+		}
+		ImGui::EndCombo();
+	}
+
+	if (currentMode == SculptMode::Flatten) {
+		const voxel::FaceNames flattenFace = brush.flattenFace();
+		if (flattenFace == voxel::FaceNames::Max) {
+			const glm::vec4 &warningTextColor = style::color(style::StyleColor::ColorWarningText);
+			ImGui::TextColored(warningTextColor, "%s", _("Click a voxel face in the viewport to set the flatten direction"));
+			return;
+		}
+		ImGui::Text(_("Direction: %s"), voxel::faceNameString(flattenFace));
+
+		int iterations = brush.iterations();
+		ImGui::TextUnformatted(_("Iterations"));
+		if (ImGui::Button("-##sculpt_iter")) {
+			brush.setIterations(iterations - 1);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##sculpt_iter_slider", &iterations, 1, SculptBrush::MaxFlattenIterations)) {
+			brush.setIterations(iterations);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##sculpt_iter")) {
+			brush.setIterations(iterations + 1);
+			executeSculptBrush();
+		}
+	} else {
+		float strength = brush.strength();
+		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
+			brush.setStrength(strength);
+			executeSculptBrush();
+		}
+
+		int iterations = brush.iterations();
+		if (ImGui::SliderInt(_("Iterations"), &iterations, 1, SculptBrush::MaxIterations)) {
+			brush.setIterations(iterations);
+			executeSculptBrush();
+		}
+	}
+}
+
 void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 	const Modifier &modifier = _sceneMgr->modifier();
 	const BrushType brushType = modifier.brushType();
@@ -1104,6 +1193,8 @@ void BrushPanel::brushSettings(command::CommandExecutionListener &listener) {
 			updateExtrudeBrushPanel(listener);
 		} else if (brushType == BrushType::Transform) {
 			updateTransformBrushPanel(listener);
+		} else if (brushType == BrushType::Sculpt) {
+			updateSculptBrushPanel(listener);
 		}
 	}
 

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
@@ -63,6 +63,8 @@ private:
 	void executeExtrudeBrush();
 	void updateTransformBrushPanel(command::CommandExecutionListener &listener);
 	void executeTransformBrush();
+	void updateSculptBrushPanel(command::CommandExecutionListener &listener);
+	void executeSculptBrush();
 
 	void addBrushClampingOption(Brush &brush);
 	void aabbBrushOptions(command::CommandExecutionListener &listener, AABBBrush &brush);

--- a/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
+++ b/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRCS
 	modifier/brush/SelectBrush.cpp modifier/brush/SelectBrush.h
 	modifier/brush/ExtrudeBrush.cpp modifier/brush/ExtrudeBrush.h
 	modifier/brush/TransformBrush.cpp modifier/brush/TransformBrush.h
+	modifier/brush/SculptBrush.cpp modifier/brush/SculptBrush.h
 	modifier/brush/TextureBrush.cpp modifier/brush/TextureBrush.h
 
 	modifier/IModifierRenderer.h
@@ -104,6 +105,7 @@ set(TEST_SRCS
 	tests/ClipboardTest.cpp
 	tests/ExtrudeBrushTest.cpp
 	tests/TransformBrushTest.cpp
+	tests/SculptBrushTest.cpp
 	tests/LineBrushTest.cpp
 	tests/ModifierTest.cpp
 	tests/ModifierVolumeWrapperTest.cpp

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -44,6 +44,7 @@ Modifier::Modifier(SceneManager *sceneMgr, const ModifierRendererPtr &modifierRe
 	_brushes.push_back(&_normalBrush);
 	_brushes.push_back(&_extrudeBrush);
 	_brushes.push_back(&_transformBrush);
+	_brushes.push_back(&_sculptBrush);
 	core_assert(_brushes.size() == (int)BrushType::Max - 1);
 }
 
@@ -555,6 +556,9 @@ bool Modifier::previewNeedsExistingVolume() const {
 	if (_brushType == BrushType::Transform) {
 		return true;
 	}
+	if (_brushType == BrushType::Sculpt) {
+		return true;
+	}
 	return false;
 }
 
@@ -682,7 +686,7 @@ void Modifier::render(const video::Camera &camera, palette::Palette &activePalet
 		ctx.brushActive = brush && brush->active();
 		// Bootstrap: TransformBrush/ExtrudeBrush need preview before internal state exists
 		if (!ctx.brushActive && brush &&
-			(brush->type() == BrushType::Transform || brush->type() == BrushType::Extrude)) {
+			(brush->type() == BrushType::Transform || brush->type() == BrushType::Extrude || brush->type() == BrushType::Sculpt)) {
 			ctx.brushActive = true;
 		}
 	}

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
@@ -17,6 +17,7 @@
 #include "brush/ExtrudeBrush.h"
 #include "brush/SelectBrush.h"
 #include "brush/TransformBrush.h"
+#include "brush/SculptBrush.h"
 #include "brush/ShapeBrush.h"
 #include "brush/StampBrush.h"
 #include "brush/TextBrush.h"
@@ -104,6 +105,7 @@ protected:
 	NormalBrush _normalBrush;
 	ExtrudeBrush _extrudeBrush;
 	TransformBrush _transformBrush;
+	SculptBrush _sculptBrush;
 
 	ModifierButton _actionExecuteButton;
 	ModifierButton _deleteExecuteButton;
@@ -240,6 +242,7 @@ public:
 	NormalBrush &normalBrush();
 	ExtrudeBrush &extrudeBrush();
 	TransformBrush &transformBrush();
+	SculptBrush &sculptBrush();
 	const BrushContext &brushContext() const;
 
 	/**
@@ -359,6 +362,10 @@ inline ExtrudeBrush &Modifier::extrudeBrush() {
 
 inline TransformBrush &Modifier::transformBrush() {
 	return _transformBrush;
+}
+
+inline SculptBrush &Modifier::sculptBrush() {
+	return _sculptBrush;
 }
 
 inline int Modifier::gridResolution() const {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushType.h
@@ -13,14 +13,14 @@ namespace voxedit {
  *
  * Each brush type provides a different way to place, modify, or select voxels in the scene.
  */
-enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Extrude, Transform, Max };
+enum class BrushType { None, Shape, Plane, Stamp, Line, Path, Paint, Text, Select, Texture, Normal, Extrude, Transform, Sculpt, Max };
 
 /**
  * @brief String representation of brush types for UI display and command registration
  */
 static constexpr const char *BrushTypeStr[] = {"None",  "Shape", "Plane",   "Stamp",    "Line",   "Path",
 											   "Paint", "Text",  "Select",  "Texture",  "Normal", "Extrude",
-											   "Transform"};
+											   "Transform", "Sculpt"};
 static_assert(lengthof(BrushTypeStr) == (int)BrushType::Max, "BrushTypeStr size mismatch");
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -1,0 +1,448 @@
+/**
+ * @file
+ */
+
+#include "SculptBrush.h"
+#include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicMap.h"
+#include "core/collection/DynamicSet.h"
+#include "core/GLM.h"
+#include "math/Axis.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/Connectivity.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Region.h"
+#include "voxel/SparseVolume.h"
+#include "voxel/Voxel.h"
+#include "voxelutil/VolumeVisitor.h"
+#include <climits>
+
+namespace voxedit {
+
+void SculptBrush::onSceneChange() {
+	Super::onSceneChange();
+	_active = false;
+	_hasSnapshot = false;
+	_snapshot.clear();
+	_history.clear();
+	_snapshotRegion = voxel::Region::InvalidRegion;
+	_cachedRegion = voxel::Region::InvalidRegion;
+	_cachedRegionValid = false;
+}
+
+void SculptBrush::onActivated() {
+	reset();
+}
+
+bool SculptBrush::onDeactivated() {
+	return _hasSnapshot;
+}
+
+void SculptBrush::reset() {
+	Super::reset();
+	_active = false;
+	_hasSnapshot = false;
+	_snapshot.clear();
+	_history.clear();
+	_snapshotRegion = voxel::Region::InvalidRegion;
+	_cachedRegion = voxel::Region::InvalidRegion;
+	_cachedRegionValid = false;
+	_capturedVolumeLower = glm::ivec3(0);
+	_strength = 0.5f;
+	_iterations = 1;
+	_sculptMode = SculptMode::Erode;
+	_flattenFace = voxel::FaceNames::Max;
+}
+
+bool SculptBrush::beginBrush(const BrushContext &ctx) {
+	if (_active) {
+		return false;
+	}
+	if (_sculptMode == SculptMode::Flatten && ctx.cursorFace != voxel::FaceNames::Max) {
+		_flattenFace = ctx.cursorFace;
+	}
+	_active = true;
+	return true;
+}
+
+void SculptBrush::endBrush(BrushContext &) {
+	_active = false;
+}
+
+bool SculptBrush::active() const {
+	return _active || _hasSnapshot;
+}
+
+void SculptBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) {
+	if (!_hasSnapshot && volume != nullptr) {
+		captureSnapshot(volume, ctx.targetVolumeRegion);
+	} else if (_hasSnapshot) {
+		const glm::ivec3 delta = ctx.targetVolumeRegion.getLowerCorner() - _capturedVolumeLower;
+		if (delta != glm::ivec3(0)) {
+			adjustSnapshotForRegionShift(delta);
+		}
+	}
+	if (_hasSnapshot) {
+		// Expand by iterations since smoothing can grow surface by 1 voxel per iteration
+		_cachedRegion = _snapshotRegion;
+		_cachedRegion.grow(_iterations);
+		_cachedRegionValid = true;
+	}
+}
+
+voxel::Region SculptBrush::calcRegion(const BrushContext &ctx) const {
+	if (_cachedRegionValid) {
+		return _cachedRegion;
+	}
+	return ctx.targetVolumeRegion;
+}
+
+void SculptBrush::captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion) {
+	_snapshot.clear();
+	glm::ivec3 selLo(volRegion.getUpperCorner());
+	glm::ivec3 selHi(volRegion.getLowerCorner());
+
+	const glm::ivec3 &regionLo = volRegion.getLowerCorner();
+	const glm::ivec3 &regionHi = volRegion.getUpperCorner();
+	for (int z = regionLo.z; z <= regionHi.z; ++z) {
+		for (int y = regionLo.y; y <= regionHi.y; ++y) {
+			for (int x = regionLo.x; x <= regionHi.x; ++x) {
+				const voxel::Voxel &currentVoxel = volume->voxel(x, y, z);
+				if (voxel::isAir(currentVoxel.getMaterial())) {
+					continue;
+				}
+				if (!(currentVoxel.getFlags() & voxel::FlagOutline)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				_snapshot.setVoxel(pos, currentVoxel);
+				selLo = glm::min(selLo, pos);
+				selHi = glm::max(selHi, pos);
+			}
+		}
+	}
+
+	if (_snapshot.empty()) {
+		_hasSnapshot = false;
+		return;
+	}
+
+	_snapshotRegion = voxel::Region(selLo, selHi);
+	_capturedVolumeLower = volRegion.getLowerCorner();
+	_hasSnapshot = true;
+}
+
+void SculptBrush::adjustSnapshotForRegionShift(const glm::ivec3 &delta) {
+	struct ShiftEntry {
+		glm::ivec3 pos;
+		voxel::Voxel voxel;
+	};
+	core::DynamicArray<ShiftEntry> entries;
+	entries.reserve(_snapshot.size());
+	const glm::ivec3 &lo = _snapshotRegion.getLowerCorner();
+	const glm::ivec3 &hi = _snapshotRegion.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				if (!_snapshot.hasVoxel(x, y, z)) {
+					continue;
+				}
+				entries.push_back({glm::ivec3(x + delta.x, y + delta.y, z + delta.z), _snapshot.voxel(x, y, z)});
+			}
+		}
+	}
+	_snapshot.clear();
+	for (const ShiftEntry &e : entries) {
+		_snapshot.setVoxel(e.pos, e.voxel);
+	}
+
+	_snapshotRegion.shift(delta.x, delta.y, delta.z);
+	_capturedVolumeLower += delta;
+
+	struct EntryCollector {
+		core::DynamicArray<ShiftEntry> *entries;
+		glm::ivec3 delta;
+		bool setVoxel(int x, int y, int z, const voxel::Voxel &voxel) {
+			entries->push_back({glm::ivec3(x + delta.x, y + delta.y, z + delta.z), voxel});
+			return true;
+		}
+	};
+	core::DynamicArray<ShiftEntry> historyEntries;
+	historyEntries.reserve(_history.size());
+	EntryCollector collector{&historyEntries, delta};
+	_history.copyTo(collector);
+	_history.clear();
+	for (const ShiftEntry &e : historyEntries) {
+		_history.setVoxel(e.pos, e.voxel);
+	}
+}
+
+void SculptBrush::saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos) {
+	if (_history.hasVoxel(pos)) {
+		return;
+	}
+	_history.setVoxel(pos, vol->voxel(pos));
+}
+
+void SculptBrush::writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
+	voxel::RawVolume *volume = wrapper.volume();
+	if (!volume->region().containsPoint(pos)) {
+		return;
+	}
+	saveToHistory(volume, pos);
+	if (volume->setVoxel(pos, newVoxel)) {
+		wrapper.addToDirtyRegion(pos);
+	}
+}
+
+void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
+	using PositionSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+
+	// Build the current solid set from the snapshot
+	PositionSet currentSolid;
+	// Map positions to their voxel data for color preservation
+	core::DynamicMap<glm::ivec3, voxel::Voxel, 1031, glm::hash<glm::ivec3>> voxelMap;
+
+	const glm::ivec3 &snapLo = _snapshotRegion.getLowerCorner();
+	const glm::ivec3 &snapHi = _snapshotRegion.getUpperCorner();
+	for (int z = snapLo.z; z <= snapHi.z; ++z) {
+		for (int y = snapLo.y; y <= snapHi.y; ++y) {
+			for (int x = snapLo.x; x <= snapHi.x; ++x) {
+				if (!_snapshot.hasVoxel(x, y, z)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				currentSolid.insert(pos);
+				voxelMap.put(pos, _snapshot.voxel(x, y, z));
+			}
+		}
+	}
+
+	voxel::RawVolume *vol = wrapper.volume();
+	const voxel::Region &volRegion = vol->region();
+
+	// Build anchor set: non-selected solid neighbors that act as immovable constraints.
+	PositionSet anchorSolid;
+	for (auto iter = currentSolid.begin(); iter != currentSolid.end(); ++iter) {
+		const glm::ivec3 &pos = iter->key;
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+			const glm::ivec3 neighbor = pos + offset;
+			if (currentSolid.has(neighbor)) {
+				continue;
+			}
+			if (!volRegion.containsPoint(neighbor)) {
+				continue;
+			}
+			const voxel::Voxel &v = vol->voxel(neighbor);
+			if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
+				anchorSolid.insert(neighbor);
+			}
+		}
+	}
+
+	auto isSolid = [&](const glm::ivec3 &pos) -> bool {
+		return currentSolid.has(pos) || anchorSolid.has(pos);
+	};
+
+	// Count solid 6-face neighbors
+	auto countFaceNeighbors = [&](const glm::ivec3 &pos) -> int {
+		int count = 0;
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+			if (isSolid(pos + offset)) {
+				count++;
+			}
+		}
+		return count;
+	};
+
+	if (_sculptMode == SculptMode::Erode) {
+		// Erode: remove surface voxels based on their solid face-neighbor count.
+		// Voxels with fewer solid neighbors are more exposed (protrusions/corners/edges).
+		// Strength controls the threshold - which connectivity tier gets removed:
+		//   strength=0 -> threshold=0 (nothing removed)
+		//   strength~0.25 -> threshold=2 (isolated protrusions with 0-1 neighbors)
+		//   strength~0.5 -> threshold=3 (also corners with 2 neighbors)
+		//   strength~0.75 -> threshold=4 (also edges with 3 neighbors)
+		//   strength=1.0 -> threshold=5 (also flat faces with 4 neighbors)
+		// Each iteration peels one layer at the current threshold.
+		// Anchors (non-selected solid) count as neighbors, so voxels touching
+		// non-selected geometry are more connected and less likely to be removed.
+		const int removeThreshold = (int)glm::mix(0.0f, 5.0f, _strength);
+
+		core::DynamicArray<glm::ivec3> toRemove;
+		for (int iter = 0; iter < _iterations; ++iter) {
+			toRemove.clear();
+
+			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
+				const glm::ivec3 &pos = it->key;
+				const int neighborCount = countFaceNeighbors(pos);
+				if (neighborCount == 6) {
+					continue;
+				}
+
+				if (neighborCount < removeThreshold) {
+					toRemove.push_back(pos);
+				}
+			}
+
+			if (toRemove.empty()) {
+				break;
+			}
+
+			for (const glm::ivec3 &pos : toRemove) {
+				currentSolid.remove(pos);
+				voxelMap.remove(pos);
+			}
+		}
+	} else if (_sculptMode == SculptMode::Grow) {
+		// Grow: fill air positions adjacent to the surface based on their neighbor count.
+		// Air with more solid neighbors is more "surrounded" (concavity/gap).
+		// Strength controls the minimum neighbor count needed to fill:
+		//   strength=0 -> addThreshold=7 (nothing added, impossible)
+		//   strength~0.25 -> addThreshold=5 (only deeply recessed holes)
+		//   strength~0.5 -> addThreshold=4 (moderate concavities)
+		//   strength=1.0 -> addThreshold=1 (any air touching a solid voxel)
+		// Each iteration grows one layer at the current threshold.
+		const int addThreshold = (int)glm::mix(7.0f, 1.0f, _strength);
+
+		core::DynamicArray<glm::ivec3> toAdd;
+		PositionSet airCandidates;
+		for (int iter = 0; iter < _iterations; ++iter) {
+			toAdd.clear();
+			airCandidates.clear();
+
+			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
+				const glm::ivec3 &pos = it->key;
+				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+					const glm::ivec3 neighbor = pos + offset;
+					if (!isSolid(neighbor) && volRegion.containsPoint(neighbor)) {
+						airCandidates.insert(neighbor);
+					}
+				}
+			}
+
+			for (auto it = airCandidates.begin(); it != airCandidates.end(); ++it) {
+				const glm::ivec3 &pos = it->key;
+				const int myCount = countFaceNeighbors(pos);
+				if (myCount >= addThreshold) {
+					toAdd.push_back(pos);
+				}
+			}
+
+			if (toAdd.empty()) {
+				break;
+			}
+
+			for (const glm::ivec3 &pos : toAdd) {
+				currentSolid.insert(pos);
+				// Pick color from nearest solid face-neighbor
+				voxel::Voxel newVoxel = ctx.cursorVoxel;
+				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+					const glm::ivec3 neighbor = pos + offset;
+					auto found = voxelMap.find(neighbor);
+					if (found != voxelMap.end()) {
+						newVoxel = found->second;
+						break;
+					}
+				}
+				newVoxel.setFlags(voxel::FlagOutline);
+				voxelMap.put(pos, newVoxel);
+			}
+		}
+	} else if (_sculptMode == SculptMode::Flatten && _flattenFace != voxel::FaceNames::Max) {
+		// Flatten: peel layers from the outermost surface along the clicked face normal.
+		// The face encodes both axis and direction. PositiveY means peel from top (remove highest Y layer).
+		const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
+		const bool fromPositive = voxel::isPositiveFace(_flattenFace);
+
+		core::DynamicArray<glm::ivec3> toRemove;
+		for (int iter = 0; iter < _iterations; ++iter) {
+			int extremeVal = fromPositive ? INT_MIN : INT_MAX;
+			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
+				const glm::ivec3 &pos = it->key;
+				if (fromPositive) {
+					extremeVal = glm::max(extremeVal, pos[axisIdx]);
+				} else {
+					extremeVal = glm::min(extremeVal, pos[axisIdx]);
+				}
+			}
+
+			toRemove.clear();
+			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
+				const glm::ivec3 &pos = it->key;
+				if (pos[axisIdx] == extremeVal) {
+					toRemove.push_back(pos);
+				}
+			}
+
+			if (toRemove.empty()) {
+				break;
+			}
+
+			for (const glm::ivec3 &pos : toRemove) {
+				currentSolid.remove(pos);
+				voxelMap.remove(pos);
+			}
+		}
+	}
+
+	// Write the result: remove voxels that were in snapshot but not in result,
+	// add voxels that are in result but not in snapshot
+	const voxel::Voxel air;
+
+	// Remove snapshot voxels that were smoothed away
+	for (int z = snapLo.z; z <= snapHi.z; ++z) {
+		for (int y = snapLo.y; y <= snapHi.y; ++y) {
+			for (int x = snapLo.x; x <= snapHi.x; ++x) {
+				if (!_snapshot.hasVoxel(x, y, z)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				if (!currentSolid.has(pos)) {
+					writeVoxel(wrapper, pos, air);
+				}
+			}
+		}
+	}
+
+	// Write all solid voxels with FlagOutline
+	for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
+		const glm::ivec3 &pos = it->key;
+		auto found = voxelMap.find(pos);
+		if (found != voxelMap.end()) {
+			voxel::Voxel v = found->second;
+			v.setFlags(voxel::FlagOutline);
+			writeVoxel(wrapper, pos, v);
+		}
+	}
+}
+
+void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+						   const voxel::Region &) {
+	if (!_hasSnapshot) {
+		return;
+	}
+
+	voxel::RawVolume *vol = wrapper.volume();
+
+	// Restore previously modified state before re-applying
+	struct HistoryRestorer {
+		voxel::RawVolume *vol;
+		ModifierVolumeWrapper *wrapper;
+		bool setVoxel(int x, int y, int z, const voxel::Voxel &voxel) {
+			if (vol->setVoxel(x, y, z, voxel)) {
+				wrapper->addToDirtyRegion(glm::ivec3(x, y, z));
+			}
+			return true;
+		}
+	};
+	HistoryRestorer restorer{vol, &wrapper};
+	_history.copyTo(restorer);
+	_history.clear();
+
+	applySmooth(wrapper, ctx);
+	markDirty();
+}
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -1,0 +1,128 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "app/I18N.h"
+#include "Brush.h"
+#include "core/GLM.h"
+#include "voxel/Face.h"
+#include "voxel/SparseVolume.h"
+#include "voxel/Voxel.h"
+
+#include <glm/vec3.hpp>
+
+namespace voxedit {
+
+enum class SculptMode : uint8_t {
+	Erode,
+	Grow,
+	Flatten,
+
+	Max
+};
+
+/**
+ * @brief Sculpts selected voxels by smoothing surface irregularities
+ *
+ * Captures selected voxels as a snapshot on activation. Each parameter change
+ * re-applies the sculpt operation from the original snapshot so changes are
+ * absolute and reversible. On finalize the result is committed to the undo stack.
+ *
+ * @ingroup Brushes
+ */
+class SculptBrush : public Brush {
+private:
+	using Super = Brush;
+
+	SculptMode _sculptMode = SculptMode::Erode;
+	float _strength = 0.5f;
+	int _iterations = 1;
+	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
+	bool _active = false;
+	bool _hasSnapshot = false;
+
+	// Original selected voxels captured at brush activation
+	voxel::SparseVolume _snapshot;
+	// Selection bounding box at capture time
+	voxel::Region _snapshotRegion;
+	// Volume region lower corner at snapshot capture time (to detect region shifts)
+	glm::ivec3 _capturedVolumeLower{0};
+
+	// Per-generate bookkeeping: tracks positions written during a single generate()
+	// call so the previous state can be restored before re-applying.
+	voxel::SparseVolume _history;
+
+	// Cached region for preview
+	voxel::Region _cachedRegion;
+	bool _cachedRegionValid = false;
+
+	void captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion);
+	void adjustSnapshotForRegionShift(const glm::ivec3 &delta);
+	void applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
+	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
+	void writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &voxel);
+
+protected:
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region) override;
+
+public:
+	static constexpr int MaxIterations = 10;
+	static constexpr int MaxFlattenIterations = 64;
+	SculptBrush() : Super(BrushType::Sculpt, ModifierType::Override, ModifierType::Override) {
+		_history.setStoreEmptyVoxels(true);
+	}
+	virtual ~SculptBrush() = default;
+
+	void onSceneChange() override;
+	void reset() override;
+	void onActivated() override;
+	bool onDeactivated() override;
+	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
+	bool beginBrush(const BrushContext &ctx) override;
+	void endBrush(BrushContext &ctx) override;
+	bool active() const override;
+	voxel::Region calcRegion(const BrushContext &ctx) const override;
+	bool managesOwnSelection() const override {
+		return true;
+	}
+
+	SculptMode sculptMode() const {
+		return _sculptMode;
+	}
+
+	void setSculptMode(SculptMode mode) {
+		if (mode == SculptMode::Flatten && _sculptMode != SculptMode::Flatten) {
+			_flattenFace = voxel::FaceNames::Max;
+		}
+		_sculptMode = mode;
+	}
+
+	float strength() const {
+		return _strength;
+	}
+
+	void setStrength(float strength) {
+		_strength = glm::clamp(strength, 0.0f, 1.0f);
+	}
+
+	int iterations() const {
+		return _iterations;
+	}
+
+	void setIterations(int iterations) {
+		_iterations = glm::clamp(iterations, 1, MaxFlattenIterations);
+	}
+
+	bool hasSnapshot() const {
+		return _hasSnapshot;
+	}
+
+	voxel::FaceNames flattenFace() const {
+		return _flattenFace;
+	}
+};
+
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
@@ -1,0 +1,324 @@
+/**
+ * @file
+ */
+
+#include "../modifier/brush/SculptBrush.h"
+#include "app/tests/AbstractTest.h"
+#include "scenegraph/SceneGraph.h"
+#include "scenegraph/SceneGraphNode.h"
+#include "voxedit-util/modifier/ModifierType.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Voxel.h"
+
+namespace voxedit {
+
+class SculptBrushTest : public app::AbstractTest {
+protected:
+	static voxel::Voxel selectedVoxel(uint8_t color = 1) {
+		voxel::Voxel voxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+		voxel.setFlags(voxel::FlagOutline);
+		return voxel;
+	}
+
+	void executeSculpt(SculptBrush &brush, scenegraph::SceneGraphNode &node, BrushContext &ctx) {
+		ctx.modifierType = ModifierType::Override;
+		scenegraph::SceneGraph sceneGraph;
+		ModifierVolumeWrapper wrapper(node, ModifierType::Override);
+		brush.preExecute(ctx, wrapper.volume());
+		brush.execute(sceneGraph, wrapper, ctx);
+	}
+};
+
+TEST_F(SculptBrushTest, testErodeRemovesProtrusion) {
+	// A single voxel sticking out of a flat 3x3 surface should be removed
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	// Create a 3x3 flat surface at y=0
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+	// Add a protrusion at (0,1,0)
+	volume.setVoxel(0, 1, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Erode);
+	// strength=0.5 -> removeThreshold=2: removes voxels with 0-1 solid face-neighbors
+	brush.setStrength(0.5f);
+	brush.setIterations(1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// The protrusion has 1 solid face-neighbor (below) -> 1 < 2 -> removed
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Protrusion at (0,1,0) should be eroded";
+
+	// The flat surface should remain (corner=2, edge=3, center=4 neighbors, all >= 2)
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 0, z).getMaterial()))
+				<< "Surface voxel at (" << x << ",0," << z << ") should remain";
+		}
+	}
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testErodePreservesFlatSurface) {
+	// A flat 3x3 surface should survive moderate erosion.
+	// Corner voxels have 2 face-neighbors, edge=3, center=4.
+	// strength=0.4 -> threshold=2, so all voxels have >= 2 neighbors and survive.
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Erode);
+	brush.setStrength(0.4f);
+	brush.setIterations(10);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 0, z).getMaterial()))
+				<< "Flat surface voxel at (" << x << ",0," << z << ") should not be eroded";
+		}
+	}
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testErodeReversible) {
+	// Changing strength should re-apply from snapshot, not accumulate
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	// 3x3 surface with protrusion
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+	volume.setVoxel(0, 1, 0, selectedVoxel());
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Erode);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	// First pass: moderate strength removes protrusion (threshold=2, protrusion has 1 neighbor)
+	brush.setStrength(0.5f);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Protrusion should be removed at high strength";
+
+	// Second pass: zero strength should restore protrusion (re-applied from snapshot)
+	brush.setStrength(0.0f);
+	executeSculpt(brush, node, ctx);
+
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Protrusion should be restored when strength=0 (no-op from snapshot)";
+
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testErodePreservesUnselected) {
+	// Non-selected voxels should not be modified
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	// Selected surface
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+	volume.setVoxel(0, 1, 0, selectedVoxel());
+
+	// Non-selected voxel nearby
+	voxel::Voxel unselected = voxel::createVoxel(voxel::VoxelType::Generic, 3);
+	volume.setVoxel(3, 0, 0, unselected);
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Erode);
+	brush.setStrength(1.0f);
+	brush.setIterations(3);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Non-selected voxel should remain unchanged
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Non-selected voxel should not be removed";
+	EXPECT_EQ(volume.voxel(3, 0, 0).getColor(), 3)
+		<< "Non-selected voxel color should be preserved";
+	EXPECT_FALSE((volume.voxel(3, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "Non-selected voxel should not gain selection flag";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testGrowFillsGap) {
+	// A 3x3 surface with a missing center should be filled at high strength
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			if (x == 0 && z == 0) {
+				continue; // Leave gap at center
+			}
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Grow);
+	// strength=1.0 -> addThreshold=1 (any air touching a solid voxel)
+	brush.setStrength(1.0f);
+	brush.setIterations(1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// The gap at (0,0,0) has 4 solid face-neighbors -> 4 >= 1 -> filled
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Gap at (0,0,0) should be filled by grow";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testFlattenRemovesLayers) {
+	// A 3x3x3 cube selected, flatten from PositiveY should remove top layer per iteration
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = 0; y <= 2; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				volume.setVoxel(x, y, z, selectedVoxel());
+			}
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Flatten);
+	brush.setIterations(1);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Top layer (y=2) should be removed, y=0 and y=1 should remain
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 2, z).getMaterial()))
+				<< "Top layer voxel at (" << x << ",2," << z << ") should be removed";
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 1, z).getMaterial()))
+				<< "Middle layer voxel at (" << x << ",1," << z << ") should remain";
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 0, z).getMaterial()))
+				<< "Bottom layer voxel at (" << x << ",0," << z << ") should remain";
+		}
+	}
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testFlattenReversible) {
+	// Reducing iterations should restore layers from snapshot
+	voxel::RawVolume volume(voxel::Region(-5, 5));
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int y = 0; y <= 2; ++y) {
+			for (int z = -1; z <= 1; ++z) {
+				volume.setVoxel(x, y, z, selectedVoxel());
+			}
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setVolume(&volume, false);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::Flatten);
+	brush.setIterations(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+
+	// 2 iterations should remove y=2 and y=1
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 2, 0).getMaterial()));
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 0).getMaterial()));
+
+	// Reduce to 1 iteration - should restore y=1 from snapshot
+	brush.setIterations(1);
+	executeSculpt(brush, node, ctx);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 2, 0).getMaterial()))
+		<< "Top layer should still be removed";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Middle layer should be restored when iterations reduced";
+
+	brush.endBrush(ctx);
+	brush.shutdown();
+}
+
+} // namespace voxedit


### PR DESCRIPTION
## Summary
- New **Sculpt** brush type with three modes: **Erode** (remove exposed surface voxels), **Grow** (fill concavities), and **Flatten** (peel layers along a clicked face normal)
- Snapshot-based architecture: captures selected voxels at activation, re-applies from snapshot on parameter change so all edits are fully reversible
- Flatten mode requires clicking a voxel face to set direction, with warning text and +/- iteration buttons matching the extrude UI pattern

## Test plan
- [ ] 7 unit tests: erode protrusion removal, erode preserves flat surface, erode reversibility, erode preserves unselected, grow fills gap, flatten removes layers, flatten reversible
- [ ] Manual: select voxels on a surface with protrusions, switch to Sculpt brush, verify Erode smooths protrusions at moderate strength
- [ ] Manual: verify Grow fills gaps/concavities in selection
- [ ] Manual: switch to Flatten, verify warning text appears until a face is clicked, then verify layers are peeled per iteration
- [ ] Manual: verify parameter changes (strength/iterations) are reversible without undo