### PR TITLE
VOXEDIT: add sculpt smooth additive/erode with preserve top height

### DIFF
--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -51,6 +51,7 @@
 #include "voxelutil/VolumeResizer.h"
 #include "voxelutil/VolumeRotator.h"
 #include "voxelutil/VolumeSplitter.h"
+#include "voxelutil/VolumeSculpt.h"
 #include "voxelutil/VoxelUtil.h"
 
 #define GENERATOR_LUA_SANTITY 1
@@ -184,6 +185,10 @@ static const char *luaVoxel_metaimporter() {
 
 static const char *luaVoxel_metaalgorithm() {
 	return "__meta_algorithm";
+}
+
+static const char *luaVoxel_metasculpt() {
+	return "__meta_sculpt";
 }
 
 static const char *luaVoxel_metalsystem() {
@@ -1955,6 +1960,147 @@ static int luaVoxel_shadow(lua_State *s) {
 	const int lightStep = (int)luaL_optinteger(s, 2, 8);
 	voxelutil::shadow(*volume, volume->node()->palette(), lightStep);
 	return 0;
+}
+
+// Sculpt bindings
+
+static int luaVoxel_sculpt_erode(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const float strength = (float)luaL_optnumber(s, 2, 0.5);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const int changed = voxelutil::sculptErode(*volume->volume(), volume->volume()->region(), strength, iterations);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_erode_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "erode",
+		"summary": "Erode surface voxels based on their solid face-neighbor count. Voxels with fewer neighbors are more exposed and get removed first.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to erode."},
+			{"name": "strength", "type": "number", "description": "Erosion strength in [0, 1] (optional, default 0.5)."},
+			{"name": "iterations", "type": "integer", "description": "Number of erosion passes (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_grow(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const float strength = (float)luaL_optnumber(s, 2, 0.5);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const int color = (int)luaL_optinteger(s, 4, 1);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed =
+		voxelutil::sculptGrow(*volume->volume(), volume->volume()->region(), strength, iterations, fillVoxel);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_grow_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "grow",
+		"summary": "Grow into air positions adjacent to the surface. Air with more solid neighbors fills first.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to grow."},
+			{"name": "strength", "type": "number", "description": "Growth strength in [0, 1] (optional, default 0.5)."},
+			{"name": "iterations", "type": "integer", "description": "Number of growth passes (optional, default 1)."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_flatten(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const int changed = voxelutil::sculptFlatten(*volume->volume(), volume->volume()->region(), face, iterations);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_flatten_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "flatten",
+		"summary": "Flatten by peeling layers from the outermost surface along a face normal direction.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to flatten."},
+			{"name": "face", "type": "string", "description": "Face direction: 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "iterations", "type": "integer", "description": "Number of layers to peel (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothadditive(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int heightThreshold = (int)luaL_optinteger(s, 3, 1);
+	const int iterations = (int)luaL_optinteger(s, 4, 1);
+	const int color = (int)luaL_optinteger(s, 5, 1);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed = voxelutil::sculptSmoothAdditive(*volume->volume(), volume->volume()->region(), face,
+														heightThreshold, iterations, fillVoxel);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothadditive_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "smoothadditive",
+		"summary": "Fill height gaps by scanning layers along a face normal. Air voxels on solid ground get filled when a neighbor column is significantly taller. Each iteration adds at most one voxel per column.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to smooth."},
+			{"name": "face", "type": "string", "description": "Face direction defining 'up': 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "heightThreshold", "type": "integer", "description": "Minimum height difference in voxels for filling (optional, default 1). 1 = aggressive, higher = conservative."},
+			{"name": "iterations", "type": "integer", "description": "Number of smoothing passes (optional, default 1). Each pass adds at most one voxel per column."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smootherode(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const bool preserveTopHeight = lua_toboolean(s, 4) != 0;
+	const int trimPerStep = (int)luaL_optinteger(s, 5, 1);
+	const int changed = voxelutil::sculptSmoothErode(*volume->volume(), volume->volume()->region(), face, iterations, preserveTopHeight, trimPerStep);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smootherode_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "smootherode",
+		"summary": "Remove edge voxels from the top of columns along a face normal. Scans top-to-bottom, removing top-of-column voxels that have fewer than 4 solid planar neighbors. Each iteration removes at most one voxel per column.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to erode."},
+			{"name": "face", "type": "string", "description": "Face direction defining 'up': 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "iterations", "type": "integer", "description": "Number of erosion passes (optional, default 1). Each pass removes at most one voxel per column."},
+			{"name": "preserveTopHeight", "type": "boolean", "description": "If true, use island-based slope trimming to create pyramid shapes instead of uniform erosion (optional, default false)."},
+			{"name": "trimPerStep", "type": "integer", "description": "When preserveTopHeight is true, number of voxels trimmed per unit distance from island center (optional, default 1). Higher values create steeper slopes."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
 }
 
 // VoxelFont bindings
@@ -5749,6 +5895,16 @@ static void prepareState(lua_State* s) {
 	};
 	clua_registerfuncsglobal(s, algorithmFuncs, luaVoxel_metaalgorithm(), "g_algorithm");
 
+	static const clua_Reg sculptFuncs[] = {
+		{"erode", luaVoxel_sculpt_erode, luaVoxel_sculpt_erode_jsonhelp},
+		{"grow", luaVoxel_sculpt_grow, luaVoxel_sculpt_grow_jsonhelp},
+		{"flatten", luaVoxel_sculpt_flatten, luaVoxel_sculpt_flatten_jsonhelp},
+		{"smoothadditive", luaVoxel_sculpt_smoothadditive, luaVoxel_sculpt_smoothadditive_jsonhelp},
+		{"smootherode", luaVoxel_sculpt_smootherode, luaVoxel_sculpt_smootherode_jsonhelp},
+		{nullptr, nullptr, nullptr}
+	};
+	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");
+
 	static const clua_Reg lsystemFuncs[] = {
 		{"generate", luaVoxel_lsystem_generate, luaVoxel_lsystem_generate_jsonhelp},
 		{"templates", luaVoxel_lsystem_templates, luaVoxel_lsystem_templates_jsonhelp},
@@ -6341,6 +6497,8 @@ bool LUAApi::apiJsonToStream(io::WriteStream &stream) const {
 					metaName = luaVoxel_metaimporter();
 				} else if (SDL_strcmp(name, "g_algorithm") == 0) {
 					metaName = luaVoxel_metaalgorithm();
+				} else if (SDL_strcmp(name, "g_sculpt") == 0) {
+					metaName = luaVoxel_metasculpt();
 				} else if (SDL_strcmp(name, "g_font") == 0) {
 					metaName = luaVoxel_metavoxelfontglobal();
 				} else if (SDL_strcmp(name, "g_http") == 0) {

--- a/src/modules/voxelutil/CMakeLists.txt
+++ b/src/modules/voxelutil/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRCS
 	VolumeCropper.h VolumeCropper.cpp
 	VolumeSplitter.h VolumeSplitter.cpp
 	VolumeVisitor.h
+	VolumeSculpt.h VolumeSculpt.cpp
 	VoxelUtil.h VoxelUtil.cpp
 )
 engine_add_module(TARGET ${LIB} SRCS ${SRCS} DEPENDENCIES voxel)
@@ -35,6 +36,7 @@ set(TEST_SRCS
 	tests/VolumeMoverTest.cpp
 	tests/VolumeCropperTest.cpp
 	tests/VolumeVisitorTest.cpp
+	tests/VolumeSculptTest.cpp
 	tests/VoxelUtilTest.cpp
 )
 

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -1,0 +1,751 @@
+/**
+ * @file
+ */
+
+#include "VolumeSculpt.h"
+#include "core/GLM.h"
+#include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicMap.h"
+#include "core/collection/DynamicSet.h"
+#include "math/Axis.h"
+#include "voxel/BitVolume.h"
+#include "voxel/Connectivity.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Region.h"
+#include "voxel/SparseVolume.h"
+#include "voxel/Voxel.h"
+#include <cfloat>
+#include <climits>
+
+namespace voxelutil {
+
+static bool isSolid(const voxel::BitVolume &solid, const voxel::BitVolume &anchors, const glm::ivec3 &pos) {
+	return solid.hasValue(pos.x, pos.y, pos.z) || anchors.hasValue(pos.x, pos.y, pos.z);
+}
+
+static int countFaceNeighbors(const voxel::BitVolume &solid, const voxel::BitVolume &anchors,
+							  const glm::ivec3 &pos) {
+	int count = 0;
+	for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+		if (isSolid(solid, anchors, pos + offset)) {
+			count++;
+		}
+	}
+	return count;
+}
+
+void sculptErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+				 float strength, int iterations) {
+	const int removeThreshold = (int)glm::mix(0.0f, 5.0f, strength);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	core::DynamicArray<glm::ivec3> toRemove;
+	for (int iter = 0; iter < iterations; ++iter) {
+		toRemove.clear();
+
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					const int neighborCount = countFaceNeighbors(solid, anchors, pos);
+					if (neighborCount == 6) {
+						continue;
+					}
+					if (neighborCount < removeThreshold) {
+						toRemove.push_back(pos);
+					}
+				}
+			}
+		}
+
+		if (toRemove.empty()) {
+			break;
+		}
+
+		for (const glm::ivec3 &pos : toRemove) {
+			solid.setVoxel(pos, false);
+			voxelMap.setVoxel(pos, voxel::Voxel());
+		}
+	}
+}
+
+void sculptGrow(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+				float strength, int iterations, const voxel::Voxel &fillVoxel) {
+	const int addThreshold = (int)glm::mix(7.0f, 1.0f, strength);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	using AirSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+
+	core::DynamicArray<glm::ivec3> toAdd;
+	AirSet airCandidates;
+	for (int iter = 0; iter < iterations; ++iter) {
+		toAdd.clear();
+		airCandidates.clear();
+
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+						const glm::ivec3 neighbor = pos + offset;
+						if (!isSolid(solid, anchors, neighbor) && region.containsPoint(neighbor)) {
+							airCandidates.insert(neighbor);
+						}
+					}
+				}
+			}
+		}
+
+		for (auto it = airCandidates.begin(); it != airCandidates.end(); ++it) {
+			const glm::ivec3 &pos = it->key;
+			const int myCount = countFaceNeighbors(solid, anchors, pos);
+			if (myCount >= addThreshold) {
+				toAdd.push_back(pos);
+			}
+		}
+
+		if (toAdd.empty()) {
+			break;
+		}
+
+		for (const glm::ivec3 &pos : toAdd) {
+			solid.setVoxel(pos, true);
+			// Pick color from nearest solid face-neighbor
+			voxel::Voxel newVoxel = fillVoxel;
+			for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+				const glm::ivec3 neighbor = pos + offset;
+				if (voxelMap.hasVoxel(neighbor)) {
+					newVoxel = voxelMap.voxel(neighbor);
+					break;
+				}
+			}
+			voxelMap.setVoxel(pos, newVoxel);
+		}
+	}
+}
+
+void sculptFlatten(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face, int iterations) {
+	if (face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool fromPositive = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	core::DynamicArray<glm::ivec3> toRemove;
+	for (int iter = 0; iter < iterations; ++iter) {
+		int extremeVal = fromPositive ? INT_MIN : INT_MAX;
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					if (fromPositive) {
+						extremeVal = glm::max(extremeVal, pos[axisIdx]);
+					} else {
+						extremeVal = glm::min(extremeVal, pos[axisIdx]);
+					}
+				}
+			}
+		}
+
+		toRemove.clear();
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					if (pos[axisIdx] == extremeVal) {
+						toRemove.push_back(pos);
+					}
+				}
+			}
+		}
+
+		if (toRemove.empty()) {
+			break;
+		}
+
+		for (const glm::ivec3 &pos : toRemove) {
+			solid.setVoxel(pos, false);
+			voxelMap.setVoxel(pos, voxel::Voxel());
+		}
+	}
+}
+
+// Compute column height along an axis from a position set.
+// Returns the number of consecutive solid voxels from bottom towards top at the given 2D column.
+static int columnHeight(const voxel::BitVolume &solid, const voxel::BitVolume &anchors, const glm::ivec3 &basePos,
+						int axisIdx, int bottomVal, int topVal) {
+	int height = 0;
+	glm::ivec3 pos = basePos;
+	for (int v = bottomVal; v <= topVal; ++v) {
+		pos[axisIdx] = v;
+		if (isSolid(solid, anchors, pos)) {
+			height = v - bottomVal + 1;
+		}
+	}
+	return height;
+}
+
+// Get the 4 planar neighbor offsets perpendicular to a given axis
+static void getPlanarOffsets(int axisIdx, glm::ivec3 offsets[4]) {
+	static constexpr glm::ivec3 planarOffsetsForAxis[3][4] = {
+		// axis X: neighbors in Y and Z
+		{glm::ivec3(0, 1, 0), glm::ivec3(0, -1, 0), glm::ivec3(0, 0, 1), glm::ivec3(0, 0, -1)},
+		// axis Y: neighbors in X and Z
+		{glm::ivec3(1, 0, 0), glm::ivec3(-1, 0, 0), glm::ivec3(0, 0, 1), glm::ivec3(0, 0, -1)},
+		// axis Z: neighbors in X and Y
+		{glm::ivec3(1, 0, 0), glm::ivec3(-1, 0, 0), glm::ivec3(0, 1, 0), glm::ivec3(0, -1, 0)}};
+	for (int i = 0; i < 4; ++i) {
+		offsets[i] = planarOffsetsForAxis[axisIdx][i];
+	}
+}
+
+void sculptSmoothAdditive(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+						  voxel::FaceNames face, int heightThreshold, int iterations,
+						  const voxel::Voxel &fillVoxel) {
+	if (face == voxel::FaceNames::Max || heightThreshold < 1) {
+		return;
+	}
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	glm::ivec3 planarOffsets[4];
+	getPlanarOffsets(axisIdx, planarOffsets);
+
+	using ColumnSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+
+	for (int iter = 0; iter < iterations; ++iter) {
+		// Recompute bounds each iteration since solid set grows
+		int minVal = INT_MAX;
+		int maxVal = INT_MIN;
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					const int v = pos[axisIdx];
+					minVal = glm::min(minVal, v);
+					maxVal = glm::max(maxVal, v);
+				}
+			}
+		}
+		if (minVal > maxVal) {
+			return;
+		}
+
+		const int absBottom = glm::min(minVal, maxVal);
+		const int absTop = glm::max(minVal, maxVal);
+		const int bottomVal = positiveUp ? minVal : maxVal;
+		const int topVal = positiveUp ? maxVal : minVal;
+		const int step = positiveUp ? 1 : -1;
+
+		// Collect all positions to add for this iteration (at most one per column).
+		core::DynamicArray<glm::ivec3> toAdd;
+		// Track which 2D columns already have a pending add this iteration
+		ColumnSet addedColumns;
+
+		for (int layer = bottomVal; layer != topVal + step; layer += step) {
+			for (int z = lo.z; z <= hi.z; ++z) {
+				for (int y = lo.y; y <= hi.y; ++y) {
+					for (int x = lo.x; x <= hi.x; ++x) {
+						if (!solid.hasValue(x, y, z)) {
+							continue;
+						}
+						const glm::ivec3 pos(x, y, z);
+						if (pos[axisIdx] != layer) {
+							continue;
+						}
+
+						// Check the air voxel one step above this solid position
+						glm::ivec3 above = pos;
+						above[axisIdx] += step;
+						if (isSolid(solid, anchors, above)) {
+							continue;
+						}
+
+						// Use the 2D column key (zero out the up-axis component)
+						glm::ivec3 colKey = pos;
+						colKey[axisIdx] = 0;
+						if (addedColumns.has(colKey)) {
+							continue;
+						}
+
+						// Compute current column height at this 2D position
+						const int curHeight = columnHeight(solid, anchors, pos, axisIdx, absBottom, absTop);
+
+						// Check 4 planar neighbors
+						for (int i = 0; i < 4; ++i) {
+							const glm::ivec3 neighborBase = pos + planarOffsets[i];
+							const int neighborHeight =
+								columnHeight(solid, anchors, neighborBase, axisIdx, absBottom, absTop);
+							if (neighborHeight - curHeight >= heightThreshold) {
+								toAdd.push_back(above);
+								addedColumns.insert(colKey);
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if (toAdd.empty()) {
+			break;
+		}
+
+		for (const glm::ivec3 &pos : toAdd) {
+			solid.setVoxel(pos, true);
+			// Pick color from nearest solid face-neighbor
+			voxel::Voxel newVoxel = fillVoxel;
+			for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+				const glm::ivec3 neighbor = pos + offset;
+				if (voxelMap.hasVoxel(neighbor)) {
+					newVoxel = voxelMap.voxel(neighbor);
+					break;
+				}
+			}
+			voxelMap.setVoxel(pos, newVoxel);
+		}
+	}
+}
+
+void sculptSmoothErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					   voxel::FaceNames face, int iterations, bool preserveTopHeight, int trimPerStep) {
+	if (face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	glm::ivec3 planarOffsets[4];
+	getPlanarOffsets(axisIdx, planarOffsets);
+
+	const int step = positiveUp ? 1 : -1;
+
+	if (preserveTopHeight) {
+		// Per-island slope trimming. Find connected "top islands" (columns sharing the
+		// same top height). Each island gets its own center. Columns farther from their
+		// island center get trimmed more: trim = min(dist * trimPerStep, iterations).
+		const int axis1 = (axisIdx == 0) ? 1 : 0;
+		const int axis2 = (axisIdx == 2) ? 1 : 2;
+
+		// Step 1: Build column top height map
+		using ColHeightMap = core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>>;
+		ColHeightMap columnTop;
+
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const glm::ivec3 pos(x, y, z);
+					glm::ivec3 colKey = pos;
+					colKey[axisIdx] = 0;
+					const int val = pos[axisIdx];
+
+					auto foundTop = columnTop.find(colKey);
+					if (foundTop == columnTop.end()) {
+						columnTop.put(colKey, val);
+					} else if ((positiveUp && val > foundTop->second) ||
+							   (!positiveUp && val < foundTop->second)) {
+						columnTop.put(colKey, val);
+					}
+				}
+			}
+		}
+
+		// Step 2: Flood-fill islands among columns with the same top height (4-connected in 2D)
+		using IslandIdMap = core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>>;
+		IslandIdMap islandId;
+		struct IslandInfo {
+			float centerA;
+			float centerB;
+			int topHeight;
+		};
+		core::DynamicArray<IslandInfo> islands;
+		core::DynamicArray<glm::ivec3> bfsQueue;
+		bfsQueue.reserve(columnTop.size());
+		int bottomHeight = positiveUp ? INT_MAX : INT_MIN;
+
+		for (auto it = columnTop.begin(); it != columnTop.end(); ++it) {
+			const glm::ivec3 &colKey = it->key;
+			if (islandId.find(colKey) != islandId.end()) {
+				continue;
+			}
+
+			const int myHeight = it->second;
+			const int id = (int)islands.size();
+			float sumA = 0.0f;
+			float sumB = 0.0f;
+			int count = 0;
+
+			bfsQueue.clear();
+			bfsQueue.push_back(colKey);
+			islandId.put(colKey, id);
+
+			size_t front = 0;
+			while (front < bfsQueue.size()) {
+				const glm::ivec3 cur = bfsQueue[front];
+				front++;
+				sumA += (float)cur[axis1];
+				sumB += (float)cur[axis2];
+				count++;
+
+				for (int i = 0; i < 4; ++i) {
+					const glm::ivec3 neighbor = cur + planarOffsets[i];
+					if (islandId.find(neighbor) != islandId.end()) {
+						continue;
+					}
+					auto neighborTop = columnTop.find(neighbor);
+					if (neighborTop == columnTop.end()) {
+						continue;
+					}
+					// Only connect columns with the same top height
+					if (neighborTop->second != myHeight) {
+						continue;
+					}
+					islandId.put(neighbor, id);
+					bfsQueue.push_back(neighbor);
+				}
+			}
+
+			IslandInfo info;
+			info.centerA = sumA / (float)count;
+			info.centerB = sumB / (float)count;
+			info.topHeight = myHeight;
+
+			// If the centroid falls between columns (e.g. 2x2 island), snap to the
+			// nearest member so that at least one column stays at dist=0.
+			if (count > 1) {
+				float bestDist = FLT_MAX;
+				float snapA = info.centerA;
+				float snapB = info.centerB;
+				for (size_t qi = 0; qi < bfsQueue.size(); ++qi) {
+					const float da = glm::abs((float)bfsQueue[qi][axis1] - info.centerA);
+					const float db = glm::abs((float)bfsQueue[qi][axis2] - info.centerB);
+					const float d = glm::max(da, db);
+					if (d < bestDist) {
+						bestDist = d;
+						snapA = (float)bfsQueue[qi][axis1];
+						snapB = (float)bfsQueue[qi][axis2];
+					}
+				}
+				info.centerA = snapA;
+				info.centerB = snapB;
+			}
+
+			islands.push_back(info);
+
+			// Track the bottom island height
+			if (positiveUp) {
+				bottomHeight = glm::min(bottomHeight, myHeight);
+			} else {
+				bottomHeight = glm::max(bottomHeight, myHeight);
+			}
+		}
+
+		// Step 3: For each island column, trim = min(dist * trimPerStep, iterations).
+		// Skip the bottom island. Center columns (dist=0) keep full height.
+		core::DynamicArray<glm::ivec3> toRemove;
+		toRemove.reserve(columnTop.size());
+		for (auto it = islandId.begin(); it != islandId.end(); ++it) {
+			const glm::ivec3 &colKey = it->key;
+			const int id = it->second;
+			const IslandInfo &info = islands[id];
+
+			if (info.topHeight == bottomHeight) {
+				continue;
+			}
+
+			const float da = glm::abs((float)colKey[axis1] - info.centerA);
+			const float db = glm::abs((float)colKey[axis2] - info.centerB);
+			const int dist = (int)glm::floor(glm::max(da, db));
+			if (dist == 0) {
+				continue;
+			}
+
+			const int topCoord = info.topHeight;
+			// Cap trim so columns never sink to the bottom island height
+			const int maxTrim = glm::max(0, (topCoord - bottomHeight) * step - 1);
+			const int trim = glm::min(glm::min(dist * trimPerStep, iterations), maxTrim);
+
+			for (int t = 0; t < trim; ++t) {
+				glm::ivec3 pos = colKey;
+				pos[axisIdx] = topCoord - t * step;
+				if (solid.hasValue(pos.x, pos.y, pos.z)) {
+					toRemove.push_back(pos);
+				}
+			}
+		}
+
+		for (const glm::ivec3 &pos : toRemove) {
+			solid.setVoxel(pos, false);
+			voxelMap.setVoxel(pos, voxel::Voxel());
+		}
+		return;
+	}
+
+	// Normal iteration-based smooth erode
+	using ColumnSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
+	for (int iter = 0; iter < iterations; ++iter) {
+		int minVal = INT_MAX;
+		int maxVal = INT_MIN;
+		for (int z = lo.z; z <= hi.z; ++z) {
+			for (int y = lo.y; y <= hi.y; ++y) {
+				for (int x = lo.x; x <= hi.x; ++x) {
+					if (!solid.hasValue(x, y, z)) {
+						continue;
+					}
+					const int v = glm::ivec3(x, y, z)[axisIdx];
+					minVal = glm::min(minVal, v);
+					maxVal = glm::max(maxVal, v);
+				}
+			}
+		}
+		if (minVal > maxVal) {
+			return;
+		}
+
+		const int topVal = positiveUp ? maxVal : minVal;
+		const int bottomVal = positiveUp ? minVal : maxVal;
+
+		core::DynamicArray<glm::ivec3> toRemove;
+		ColumnSet removedColumns;
+
+		for (int layer = topVal; layer != bottomVal - step; layer -= step) {
+			for (int z = lo.z; z <= hi.z; ++z) {
+				for (int y = lo.y; y <= hi.y; ++y) {
+					for (int x = lo.x; x <= hi.x; ++x) {
+						if (!solid.hasValue(x, y, z)) {
+							continue;
+						}
+						const glm::ivec3 pos(x, y, z);
+						if (pos[axisIdx] != layer) {
+							continue;
+						}
+
+						glm::ivec3 above = pos;
+						above[axisIdx] += step;
+						if (isSolid(solid, anchors, above)) {
+							continue;
+						}
+
+						glm::ivec3 colKey = pos;
+						colKey[axisIdx] = 0;
+						if (removedColumns.has(colKey)) {
+							continue;
+						}
+
+						int planarCount = 0;
+						for (int i = 0; i < 4; ++i) {
+							const glm::ivec3 neighbor = pos + planarOffsets[i];
+							if (isSolid(solid, anchors, neighbor)) {
+								planarCount++;
+							}
+						}
+						if (planarCount < 4) {
+							toRemove.push_back(pos);
+							removedColumns.insert(colKey);
+						}
+					}
+				}
+			}
+		}
+
+		if (toRemove.empty()) {
+			break;
+		}
+
+		for (const glm::ivec3 &pos : toRemove) {
+			solid.setVoxel(pos, false);
+			voxelMap.setVoxel(pos, voxel::Voxel());
+		}
+	}
+}
+
+// Helper to build solid, voxelMap, and anchor sets from a volume region
+static void buildFromVolume(const voxel::RawVolume &volume, const voxel::Region &region,
+							voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::BitVolume &anchors) {
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				const voxel::Voxel &v = volume.voxel(x, y, z);
+				if (!voxel::isBlocked(v.getMaterial())) {
+					continue;
+				}
+				solid.setVoxel(x, y, z, true);
+				voxelMap.setVoxel(x, y, z, v);
+			}
+		}
+	}
+
+	// Anchors: solid voxels adjacent to but outside the region
+	const voxel::Region &volRegion = volume.region();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				if (!solid.hasValue(x, y, z)) {
+					continue;
+				}
+				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+					const glm::ivec3 neighbor = glm::ivec3(x, y, z) + offset;
+					if (region.containsPoint(neighbor)) {
+						continue;
+					}
+					if (!volRegion.containsPoint(neighbor)) {
+						continue;
+					}
+					const voxel::Voxel &v = volume.voxel(neighbor);
+					if (voxel::isBlocked(v.getMaterial())) {
+						anchors.setVoxel(neighbor, true);
+					}
+				}
+			}
+		}
+	}
+}
+
+// Helper to write position set changes back to a volume
+static int writeResultToVolume(voxel::RawVolume &volume, const voxel::Region &region, const voxel::BitVolume &solid,
+							   const voxel::SparseVolume &voxelMap) {
+	int changed = 0;
+	const voxel::Voxel air;
+
+	// Remove voxels that were solid in the region but are no longer
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				const voxel::Voxel &v = volume.voxel(x, y, z);
+				if (!voxel::isBlocked(v.getMaterial())) {
+					continue;
+				}
+				if (!solid.hasValue(x, y, z)) {
+					volume.setVoxel(x, y, z, air);
+					changed++;
+				}
+			}
+		}
+	}
+
+	// Add new voxels
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				if (!solid.hasValue(x, y, z)) {
+					continue;
+				}
+				const voxel::Voxel &current = volume.voxel(x, y, z);
+				if (voxel::isBlocked(current.getMaterial())) {
+					continue;
+				}
+				if (voxelMap.hasVoxel(x, y, z)) {
+					volume.setVoxel(x, y, z, voxelMap.voxel(x, y, z));
+					changed++;
+				}
+			}
+		}
+	}
+
+	return changed;
+}
+
+int sculptErode(voxel::RawVolume &volume, const voxel::Region &region, float strength, int iterations) {
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	// Grow anchor region by 1 to capture adjacent voxels outside the sculpt region
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptErode(solid, voxelMap, anchors, strength, iterations);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptGrow(voxel::RawVolume &volume, const voxel::Region &region, float strength, int iterations,
+			   const voxel::Voxel &fillVoxel) {
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptGrow(solid, voxelMap, anchors, strength, iterations, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptFlatten(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face, int iterations) {
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptFlatten(solid, voxelMap, face, iterations);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSmoothAdditive(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+						 int heightThreshold, int iterations, const voxel::Voxel &fillVoxel) {
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptSmoothAdditive(solid, voxelMap, anchors, face, heightThreshold, iterations, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSmoothErode(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face, int iterations,
+					  bool preserveTopHeight, int trimPerStep) {
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptSmoothErode(solid, voxelMap, anchors, face, iterations, preserveTopHeight, trimPerStep);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+} // namespace voxelutil

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -1,0 +1,148 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "voxel/BitVolume.h"
+#include "voxel/Face.h"
+#include "voxel/SparseVolume.h"
+
+namespace voxel {
+class RawVolume;
+class Region;
+} // namespace voxel
+
+namespace voxelutil {
+
+/**
+ * @brief Erode surface voxels based on their solid face-neighbor count.
+ *
+ * Voxels with fewer solid neighbors are more exposed (protrusions, corners, edges).
+ * Strength controls the threshold: 0 removes nothing, 1.0 removes everything except
+ * fully surrounded voxels. Each iteration peels one layer at the current threshold.
+ * Anchors count as neighbors but are never removed.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. Eroded positions are cleared.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions that participate in neighbor counting.
+ * @param strength Erosion strength in [0, 1].
+ * @param iterations Number of erosion passes.
+ */
+void sculptErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+				 float strength, int iterations);
+
+/**
+ * @brief Grow into air positions adjacent to the surface.
+ *
+ * Air with more solid neighbors is more "surrounded" (concavity/gap).
+ * Strength controls the minimum neighbor count needed to fill: 0 adds nothing,
+ * 1.0 fills any air touching a solid voxel. New voxels pick color from the nearest
+ * solid face-neighbor, falling back to @p fillVoxel.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. New positions are set.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid. New entries are added.
+ * @param[in] anchors Immovable solid positions that participate in neighbor counting.
+ * @param strength Growth strength in [0, 1].
+ * @param iterations Number of growth passes.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ */
+void sculptGrow(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+				float strength, int iterations, const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Flatten by peeling layers from the outermost surface along a face normal.
+ *
+ * Each iteration removes the layer of voxels at the extreme coordinate along the
+ * face axis. PositiveY peels from top (removes highest Y layer), NegativeX peels
+ * from the left (removes lowest X layer), etc.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. Peeled positions are cleared.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param face The face direction that determines which axis and side to peel from.
+ * @param iterations Number of layers to peel.
+ */
+void sculptFlatten(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face, int iterations);
+
+/**
+ * @brief Smooth additive: fill height gaps by scanning layers along a face normal.
+ *
+ * The face defines "up". Scans from bottom to top layer. For each air voxel
+ * sitting on a solid voxel, checks the 4 planar neighbors' column heights.
+ * If any neighbor column is at least @p heightThreshold voxels taller than the
+ * current column, fills the air voxel. Filled voxels become ground for the next
+ * layer within the same iteration. Color is picked from the nearest solid neighbor.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. New positions are set.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions included in height computation.
+ * @param face The face direction that defines "up".
+ * @param heightThreshold Minimum height difference (in voxels) a neighbor column must
+ *        exceed the current column for filling to occur. 1 = aggressive, higher = conservative.
+ * @param iterations Number of passes. Each pass adds at most one voxel per column.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ */
+void sculptSmoothAdditive(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+						  voxel::FaceNames face, int heightThreshold, int iterations, const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Smooth erode: remove edge voxels from the top of columns along a face normal.
+ *
+ * The face defines "up". Scans from top to bottom layer. For each solid voxel
+ * that has no solid voxel above it (top of its column) and is on the edge
+ * (has fewer than 4 solid planar neighbors at the same height), removes it.
+ * Each iteration removes at most one voxel per column.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. Removed positions are cleared.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions included in neighbor checks.
+ * @param face The face direction that defines "up".
+ * @param iterations Number of passes. Each pass removes at most one voxel per column.
+ */
+void sculptSmoothErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					   voxel::FaceNames face, int iterations, bool preserveTopHeight = false,
+					   int trimPerStep = 1);
+
+/**
+ * @brief Erode surface voxels in a volume region.
+ *
+ * Convenience wrapper that builds BitVolume/SparseVolume from all solid voxels in
+ * the region, uses solid voxels adjacent to but outside the region as anchors,
+ * runs the erosion algorithm, and writes the result back to the volume.
+ *
+ * @return The number of voxels removed.
+ */
+int sculptErode(voxel::RawVolume &volume, const voxel::Region &region, float strength, int iterations);
+
+/**
+ * @brief Grow surface voxels in a volume region.
+ *
+ * @return The number of voxels added.
+ */
+int sculptGrow(voxel::RawVolume &volume, const voxel::Region &region, float strength, int iterations,
+			   const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Flatten voxels in a volume region along a face normal.
+ *
+ * @return The number of voxels removed.
+ */
+int sculptFlatten(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face, int iterations);
+
+/**
+ * @brief Smooth additive on a volume region along a face normal.
+ *
+ * @return The number of voxels added.
+ */
+int sculptSmoothAdditive(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+						 int heightThreshold, int iterations, const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Smooth erode on a volume region along a face normal.
+ *
+ * @return The number of voxels removed.
+ */
+int sculptSmoothErode(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face, int iterations,
+					  bool preserveTopHeight = false, int trimPerStep = 1);
+
+} // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -1,0 +1,515 @@
+/**
+ * @file
+ */
+
+#include "voxelutil/VolumeSculpt.h"
+#include "app/tests/AbstractTest.h"
+#include "voxel/BitVolume.h"
+#include "voxel/RawVolume.h"
+#include "voxel/SparseVolume.h"
+#include "voxel/Voxel.h"
+#include "voxelutil/VolumeVisitor.h"
+
+namespace voxelutil {
+
+class VolumeSculptTest : public app::AbstractTest {};
+
+static int countSolid(const voxel::RawVolume &volume) {
+	return visitVolumeParallel(volume, EmptyVisitor(), VisitSolid());
+}
+
+static void fillRegion(voxel::RawVolume &volume, const voxel::Region &region, const voxel::Voxel &voxel) {
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				volume.setVoxel(x, y, z, voxel);
+			}
+		}
+	}
+}
+
+TEST_F(VolumeSculptTest, testErodeRemovesProtrusion) {
+	// 3x3x3 cube with a single protrusion voxel on top
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	fillRegion(volume, voxel::Region(1, 3), solid);
+	// Add a protrusion: single voxel sticking out
+	volume.setVoxel(2, 4, 2, solid);
+
+	const int before = countSolid(volume);
+	const int changed = sculptErode(volume, region, 0.5f, 1);
+	EXPECT_GT(changed, 0);
+	EXPECT_LT(countSolid(volume), before);
+	// The protrusion (1 face-neighbor) should be removed at threshold 2
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 4, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testErodeStrengthZeroNoChange) {
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	const int before = countSolid(volume);
+	sculptErode(volume, region, 0.0f, 1);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testGrowFillsConcavity) {
+	// L-shaped region: two arms of a cube missing a corner
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill a 3x3x3 cube but remove a corner to create a concavity
+	fillRegion(volume, voxel::Region(1, 3), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+
+	const int before = countSolid(volume);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+	sculptGrow(volume, region, 0.7f, 1, fill);
+	// The concavity (3 face-neighbors) should be filled at threshold ~3
+	EXPECT_GE(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testGrowStrengthZeroNoChange) {
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+
+	const int before = countSolid(volume);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+	sculptGrow(volume, region, 0.0f, 1, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testFlattenPositiveY) {
+	// 3x3x3 cube, flatten from top (PositiveY)
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	const int before = countSolid(volume);
+	const int changed = sculptFlatten(volume, region, voxel::FaceNames::PositiveY, 1);
+	EXPECT_GT(changed, 0);
+	EXPECT_LT(countSolid(volume), before);
+	// Top layer (y=3) should be removed
+	for (int z = 1; z <= 3; ++z) {
+		for (int x = 1; x <= 3; ++x) {
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 3, z).getMaterial()));
+		}
+	}
+	// Layer below (y=2) should still exist
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testFlattenNegativeX) {
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	sculptFlatten(volume, region, voxel::FaceNames::NegativeX, 1);
+	// Lowest X layer (x=1) should be removed
+	for (int z = 1; z <= 3; ++z) {
+		for (int y = 1; y <= 3; ++y) {
+			EXPECT_TRUE(voxel::isAir(volume.voxel(1, y, z).getMaterial()));
+		}
+	}
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testFlattenMultipleIterations) {
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	sculptFlatten(volume, region, voxel::FaceNames::PositiveY, 2);
+	// Both y=3 and y=2 layers should be removed
+	for (int z = 1; z <= 3; ++z) {
+		for (int x = 1; x <= 3; ++x) {
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 3, z).getMaterial()));
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 2, z).getMaterial()));
+		}
+	}
+	// y=1 should remain
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 1, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testAnchorsPreventErosion) {
+	// A single voxel in the sculpt region with a solid anchor neighbor outside
+	// should have higher neighbor count and resist erosion
+	voxel::Region fullRegion(0, 4);
+	voxel::RawVolume volume(fullRegion);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Place a line of voxels at y=2, x=1..3, z=2
+	for (int x = 1; x <= 3; ++x) {
+		volume.setVoxel(x, 2, 2, solid);
+	}
+	// Sculpt only the middle voxel region
+	voxel::Region sculptRegion(2, 2, 2, 2, 2, 2);
+	const int before = countSolid(volume);
+	// Strength 0.5 -> threshold 2. Middle voxel has 2 anchor neighbors -> NOT removed
+	sculptErode(volume, sculptRegion, 0.5f, 1);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testSetLevelErode) {
+	// Test the set-level API directly
+	voxel::Region region(0, 0, 0, 2, 1, 2);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::BitVolume anchors(region);
+	const voxel::Voxel v = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 3x3x1 flat plane with a single protrusion
+	for (int x = 0; x < 3; ++x) {
+		for (int z = 0; z < 3; ++z) {
+			solid.setVoxel(x, 0, z, true);
+			voxelMap.setVoxel(x, 0, z, v);
+		}
+	}
+	// Protrusion on top of center
+	const glm::ivec3 protrusion(1, 1, 1);
+	solid.setVoxel(protrusion, true);
+	voxelMap.setVoxel(protrusion, v);
+
+	sculptErode(solid, voxelMap, anchors, 0.5f, 1);
+	// Protrusion has 1 face-neighbor (below) -> removed at threshold 2
+	EXPECT_FALSE(solid.hasValue(protrusion.x, protrusion.y, protrusion.z));
+	EXPECT_FALSE(voxelMap.hasVoxel(protrusion));
+}
+
+TEST_F(VolumeSculptTest, testSmoothAdditiveFillsGap) {
+	// Two columns side by side: one is 3 tall, the other is 1 tall.
+	// SmoothAdditive with PositiveY "up" should fill the short column.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Tall column at (2,0..2,2) - height 3
+	volume.setVoxel(2, 0, 2, solid);
+	volume.setVoxel(2, 1, 2, solid);
+	volume.setVoxel(2, 2, 2, solid);
+	// Short column at (3,0,2) - height 1
+	volume.setVoxel(3, 0, 2, solid);
+
+	const int before = countSolid(volume);
+	// heightThreshold=1: any neighbor 1+ voxel taller triggers fill
+	sculptSmoothAdditive(volume, region, voxel::FaceNames::PositiveY, 1, 1, fill);
+	EXPECT_GT(countSolid(volume), before);
+	// (3,1,2) should be filled - short column grew because neighbor is 2 taller
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 1, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothAdditiveMultipleIterations) {
+	// Short column next to tall column, multiple iterations should fill progressively
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Tall column at (2,0..3,2) - height 4
+	for (int y = 0; y <= 3; ++y) {
+		volume.setVoxel(2, y, 2, solid);
+	}
+	// Short column at (3,0,2) - height 1
+	volume.setVoxel(3, 0, 2, solid);
+
+	// heightThreshold=1, 3 iterations: should fill 1 voxel per column per iteration
+	sculptSmoothAdditive(volume, region, voxel::FaceNames::PositiveY, 1, 3, fill);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 1, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 2, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothAdditiveNoFillWhenSameHeight) {
+	// Two columns of equal height - nothing should be filled
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	volume.setVoxel(2, 0, 2, solid);
+	volume.setVoxel(2, 1, 2, solid);
+	volume.setVoxel(3, 0, 2, solid);
+	volume.setVoxel(3, 1, 2, solid);
+
+	const int before = countSolid(volume);
+	sculptSmoothAdditive(volume, region, voxel::FaceNames::PositiveY, 1, 1, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testSmoothAdditiveHighThresholdNoFill) {
+	// With heightThreshold=10, a height diff of 4 is not enough to trigger fill
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	for (int y = 0; y <= 4; ++y) {
+		volume.setVoxel(2, y, 2, solid);
+	}
+	volume.setVoxel(3, 0, 2, solid);
+
+	const int before = countSolid(volume);
+	// heightThreshold=10, height diff is only 4 < 10
+	sculptSmoothAdditive(volume, region, voxel::FaceNames::PositiveY, 10, 1, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testSmoothAdditiveOneVoxelPerIteration) {
+	// Verify that only one voxel per column is added per iteration
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Tall column height 4, short column height 1
+	for (int y = 0; y <= 3; ++y) {
+		volume.setVoxel(2, y, 2, solid);
+	}
+	volume.setVoxel(3, 0, 2, solid);
+
+	const int before = countSolid(volume);
+	// 1 iteration, threshold=1: should add exactly 1 voxel at (3,1,2)
+	sculptSmoothAdditive(volume, region, voxel::FaceNames::PositiveY, 1, 1, fill);
+	EXPECT_EQ(countSolid(volume), before + 1);
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 1, 2).getMaterial()));
+	// (3,2,2) should still be air after only 1 iteration
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 2, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodeRemovesEdge) {
+	// 3x3x2 block with a single tower voxel on the corner at y=2.
+	// The tower voxel is the only top-of-column with <4 planar neighbors at that height.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 3x3x2 base block
+	for (int x = 0; x < 3; ++x) {
+		for (int z = 0; z < 3; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+			volume.setVoxel(x, 1, z, solid);
+		}
+	}
+	// Single tower voxel on corner
+	volume.setVoxel(0, 2, 0, solid);
+
+	const int before = countSolid(volume);
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 1);
+	// Top layer (y=1) edge/corner voxels removed, plus tower at (0,2,0)
+	EXPECT_LT(countSolid(volume), before);
+	// The tower voxel should definitely be removed (0 planar neighbors at y=2)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 2, 0).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodeKeepsSurrounded) {
+	// A 3x3x2 block - top center voxel at (1,1,1) has 4 planar neighbors and should NOT be removed
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 3; ++x) {
+		for (int z = 0; z < 3; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+			volume.setVoxel(x, 1, z, solid);
+		}
+	}
+
+	const int before = countSolid(volume);
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 1);
+	// Center top (1,1,1) has 4 planar neighbors -> stays. Only edge/corner tops removed.
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 1, 1).getMaterial()));
+	EXPECT_LT(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodeOnePerIteration) {
+	// A 1x3 tower. Top voxel is edge (0 planar neighbors). After 1 iteration, only top removed.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	volume.setVoxel(2, 0, 2, solid);
+	volume.setVoxel(2, 1, 2, solid);
+	volume.setVoxel(2, 2, 2, solid);
+
+	const int before = countSolid(volume);
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 1);
+	// Only top voxel (2,2,2) removed
+	EXPECT_EQ(countSolid(volume), before - 1);
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 2, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 1, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodeMultipleIterations) {
+	// A 1x3 tower. 2 iterations should remove top 2 voxels.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	volume.setVoxel(2, 0, 2, solid);
+	volume.setVoxel(2, 1, 2, solid);
+	volume.setVoxel(2, 2, 2, solid);
+
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 2);
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 2, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 1, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 0, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodePreserveTopHeight3x3Pyramid) {
+	// Base layer at y=0 (5x5) plus a 3x3 tower (y=0..2). Two height groups:
+	// base at height 0, tower at height 2. PreserveTopHeight trims the tower
+	// island edges while keeping the center at full height.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Wide base at y=0
+	for (int x = 0; x <= 4; ++x) {
+		for (int z = 0; z <= 4; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// 3x3 tower (y=1..2) on top of base
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 1, z, solid);
+			volume.setVoxel(x, 2, z, solid);
+		}
+	}
+
+	const int before = countSolid(volume);
+	// iterations=2, trimPerStep=1: edge columns at dist=1 get trimmed by min(1*1, 2) = 1
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 2, true, 1);
+	EXPECT_LT(countSolid(volume), before);
+	// Center column (2,2) should keep full height (y=2 still solid)
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 2).getMaterial()));
+	// Edge column (1,1) at dist=1 should lose top layer (y=2 removed)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 2, 1).getMaterial()));
+	// But edge column still has y=1
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 1, 1).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodePreserveTopHeightBottomIslandProtected) {
+	// Two height groups: a base layer (y=0) and a tower (y=0..2).
+	// The base layer is the bottom island and should never be eroded.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Wide base at y=0
+	for (int x = 0; x <= 4; ++x) {
+		for (int z = 0; z <= 4; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// 3x3 tower on top (y=1..2)
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 1, z, solid);
+			volume.setVoxel(x, 2, z, solid);
+		}
+	}
+
+	// Count base voxels
+	int baseCount = 0;
+	for (int x = 0; x <= 4; ++x) {
+		for (int z = 0; z <= 4; ++z) {
+			if (voxel::isBlocked(volume.voxel(x, 0, z).getMaterial())) {
+				baseCount++;
+			}
+		}
+	}
+
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 3, true, 1);
+
+	// Base layer should be untouched
+	int baseCountAfter = 0;
+	for (int x = 0; x <= 4; ++x) {
+		for (int z = 0; z <= 4; ++z) {
+			if (voxel::isBlocked(volume.voxel(x, 0, z).getMaterial())) {
+				baseCountAfter++;
+			}
+		}
+	}
+	EXPECT_EQ(baseCount, baseCountAfter);
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodePreserveTopHeightTrimPerStep) {
+	// Base layer at y=0 (7x7) plus a 5x5 tower (y=0..4). trimPerStep=2 trims twice as aggressively.
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Wide base at y=0
+	for (int x = 0; x <= 6; ++x) {
+		for (int z = 0; z <= 6; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// 5x5 tower (y=1..4) on top of base
+	for (int x = 1; x <= 5; ++x) {
+		for (int z = 1; z <= 5; ++z) {
+			for (int y = 1; y <= 4; ++y) {
+				volume.setVoxel(x, y, z, solid);
+			}
+		}
+	}
+
+	// With trimPerStep=2, iterations=4: dist=1 columns trim min(1*2, 4) = 2, dist=2 trim min(2*2, 4) = 4
+	// But maxTrim caps at (topCoord - bottomHeight) * step - 1 = (4 - 0) - 1 = 3
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 4, true, 2);
+	// Center (3,3) at dist=0 keeps full height
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 4, 3).getMaterial()));
+	// Dist=1 column (2,3) loses 2 layers: y=4 and y=3 removed
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 4, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 3).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothErodePreserveTopHeightNoSinkBelowBottom) {
+	// Columns should never sink below bottomHeight + 1
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Base at y=0
+	for (int x = 0; x <= 4; ++x) {
+		for (int z = 0; z <= 4; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// Short tower at y=1..2 (only 2 layers above base)
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 1, z, solid);
+			volume.setVoxel(x, 2, z, solid);
+		}
+	}
+
+	// High iterations + trimPerStep to try to over-trim
+	sculptSmoothErode(volume, region, voxel::FaceNames::PositiveY, 10, true, 5);
+
+	// Edge tower columns should still have at least y=1 (bottomHeight=0, so can't sink to 0)
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 1, z).getMaterial()))
+				<< "Column (" << x << "," << z << ") sank below bottom+1";
+		}
+	}
+}
+
+} // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -54,7 +54,7 @@ static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"
 												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
 static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
 
-static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten")};
+static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
@@ -1125,42 +1125,79 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		ImGui::EndCombo();
 	}
 
-	if (currentMode == SculptMode::Flatten) {
+	const bool needsFace = currentMode == SculptMode::Flatten || currentMode == SculptMode::SmoothAdditive || currentMode == SculptMode::SmoothErode;
+	if (needsFace) {
 		const voxel::FaceNames flattenFace = brush.flattenFace();
 		if (flattenFace == voxel::FaceNames::Max) {
 			const glm::vec4 &warningTextColor = style::color(style::StyleColor::ColorWarningText);
-			ImGui::TextColored(warningTextColor, "%s", _("Click a voxel face in the viewport to set the flatten direction"));
+			ImGui::TextColored(warningTextColor, "%s", _("Click a voxel face in the viewport to set the direction"));
 			return;
 		}
 		ImGui::Text(_("Direction: %s"), voxel::faceNameString(flattenFace));
+	}
 
-		int iterations = brush.iterations();
-		ImGui::TextUnformatted(_("Iterations"));
-		if (ImGui::Button("-##sculpt_iter")) {
-			brush.setIterations(iterations - 1);
+	if (currentMode == SculptMode::SmoothAdditive) {
+		int threshold = brush.heightThreshold();
+		if (ImGui::SliderInt(_("Height threshold"), &threshold, 1, SculptBrush::MaxHeightThreshold)) {
+			brush.setHeightThreshold(threshold);
 			executeSculptBrush();
 		}
-		ImGui::SameLine();
-		if (ImGui::SliderInt("##sculpt_iter_slider", &iterations, 1, SculptBrush::MaxFlattenIterations)) {
-			brush.setIterations(iterations);
+	} else if (currentMode == SculptMode::SmoothErode) {
+		bool preserve = brush.preserveTopHeight();
+		if (ImGui::Checkbox(_("Preserve top height"), &preserve)) {
+			brush.setPreserveTopHeight(preserve);
 			executeSculptBrush();
 		}
-		ImGui::SameLine();
-		if (ImGui::Button("+##sculpt_iter")) {
-			brush.setIterations(iterations + 1);
-			executeSculptBrush();
+		if (preserve) {
+			int trimPerStep = brush.trimPerStep();
+			ImGui::TextUnformatted(_("Trim per step"));
+			if (ImGui::Button("-##sculpt_trim")) {
+				brush.setTrimPerStep(trimPerStep - 1);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::SliderInt("##sculpt_trim_slider", &trimPerStep, 1, SculptBrush::MaxTrimPerStep)) {
+				brush.setTrimPerStep(trimPerStep);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("+##sculpt_trim")) {
+				brush.setTrimPerStep(trimPerStep + 1);
+				executeSculptBrush();
+			}
 		}
-	} else {
+	} else if (currentMode != SculptMode::Flatten) {
 		float strength = brush.strength();
 		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
 			brush.setStrength(strength);
 			executeSculptBrush();
 		}
+	}
 
+	{
+		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
-		if (ImGui::SliderInt(_("Iterations"), &iterations, 1, SculptBrush::MaxIterations)) {
-			brush.setIterations(iterations);
-			executeSculptBrush();
+		if (needsFace) {
+			ImGui::TextUnformatted(_("Iterations"));
+			if (ImGui::Button("-##sculpt_iter")) {
+				brush.setIterations(iterations - 1);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::SliderInt("##sculpt_iter_slider", &iterations, 1, maxIter)) {
+				brush.setIterations(iterations);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("+##sculpt_iter")) {
+				brush.setIterations(iterations + 1);
+				executeSculptBrush();
+			}
+		} else {
+			if (ImGui::SliderInt(_("Iterations"), &iterations, 1, maxIter)) {
+				brush.setIterations(iterations);
+				executeSculptBrush();
+			}
 		}
 	}
 }

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -383,8 +383,7 @@ bool Modifier::executeBrush(scenegraph::SceneGraph &sceneGraph, scenegraph::Scen
 	if (modifiedRegion.isValid()) {
 		voxel::logRegion("Dirty region", modifiedRegion);
 		if (callback) {
-			SceneModifiedFlags flags = brush->sceneModifiedFlags();
-			flags |= SceneModifiedFlags::MarkUndo;
+			const SceneModifiedFlags flags = brush->sceneModifiedFlags();
 			callback(modifiedRegion, _brushContext.modifierType, flags);
 		}
 	}

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -23,14 +23,17 @@ void ExtrudeBrush::onSceneChange() {
 
 void ExtrudeBrush::onActivated() {
 	reset();
+	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
 bool ExtrudeBrush::onDeactivated() {
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	return _depth != 0 && _hasCachedSelection;
 }
 
 void ExtrudeBrush::reset() {
 	Super::reset();
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	_depth = 0;
 	_offsetU = 0;
 	_offsetV = 0;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -4,19 +4,15 @@
 
 #include "SculptBrush.h"
 #include "core/collection/DynamicArray.h"
-#include "core/collection/DynamicMap.h"
-#include "core/collection/DynamicSet.h"
 #include "core/GLM.h"
-#include "math/Axis.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxel/BitVolume.h"
 #include "voxel/Connectivity.h"
-#include "voxel/Face.h"
 #include "voxel/RawVolume.h"
 #include "voxel/Region.h"
 #include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
-#include "voxelutil/VolumeVisitor.h"
-#include <climits>
+#include "voxelutil/VolumeSculpt.h"
 
 namespace voxedit {
 
@@ -33,14 +29,19 @@ void SculptBrush::onSceneChange() {
 
 void SculptBrush::onActivated() {
 	reset();
+	// Suppress undo registration during preview - only the final commit should create an undo entry
+	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
 bool SculptBrush::onDeactivated() {
+	// Restore undo registration so the final execute in setBrushType() records the undo entry
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	return _hasSnapshot;
 }
 
 void SculptBrush::reset() {
 	Super::reset();
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	_active = false;
 	_hasSnapshot = false;
 	_snapshot.clear();
@@ -51,6 +52,9 @@ void SculptBrush::reset() {
 	_capturedVolumeLower = glm::ivec3(0);
 	_strength = 0.5f;
 	_iterations = 1;
+	_heightThreshold = 1;
+	_preserveTopHeight = false;
+	_trimPerStep = 1;
 	_sculptMode = SculptMode::Erode;
 	_flattenFace = voxel::FaceNames::Max;
 }
@@ -59,7 +63,8 @@ bool SculptBrush::beginBrush(const BrushContext &ctx) {
 	if (_active) {
 		return false;
 	}
-	if (_sculptMode == SculptMode::Flatten && ctx.cursorFace != voxel::FaceNames::Max) {
+	const bool needsFace = _sculptMode == SculptMode::Flatten || _sculptMode == SculptMode::SmoothAdditive || _sculptMode == SculptMode::SmoothErode;
+	if (needsFace && ctx.cursorFace != voxel::FaceNames::Max) {
 		_flattenFace = ctx.cursorFace;
 	}
 	_active = true;
@@ -196,13 +201,9 @@ void SculptBrush::writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &p
 	}
 }
 
-void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
-	using PositionSet = core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>>;
-
-	// Build the current solid set from the snapshot
-	PositionSet currentSolid;
-	// Map positions to their voxel data for color preservation
-	core::DynamicMap<glm::ivec3, voxel::Voxel, 1031, glm::hash<glm::ivec3>> voxelMap;
+void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
+	voxel::BitVolume currentSolid(_snapshotRegion);
+	voxel::SparseVolume voxelMap;
 
 	const glm::ivec3 &snapLo = _snapshotRegion.getLowerCorner();
 	const glm::ivec3 &snapHi = _snapshotRegion.getUpperCorner();
@@ -212,9 +213,8 @@ void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext
 				if (!_snapshot.hasVoxel(x, y, z)) {
 					continue;
 				}
-				const glm::ivec3 pos(x, y, z);
-				currentSolid.insert(pos);
-				voxelMap.put(pos, _snapshot.voxel(x, y, z));
+				currentSolid.setVoxel(x, y, z, true);
+				voxelMap.setVoxel(x, y, z, _snapshot.voxel(x, y, z));
 			}
 		}
 	}
@@ -223,175 +223,56 @@ void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext
 	const voxel::Region &volRegion = vol->region();
 
 	// Build anchor set: non-selected solid neighbors that act as immovable constraints.
-	PositionSet anchorSolid;
-	for (auto iter = currentSolid.begin(); iter != currentSolid.end(); ++iter) {
-		const glm::ivec3 &pos = iter->key;
-		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-			const glm::ivec3 neighbor = pos + offset;
-			if (currentSolid.has(neighbor)) {
-				continue;
-			}
-			if (!volRegion.containsPoint(neighbor)) {
-				continue;
-			}
-			const voxel::Voxel &v = vol->voxel(neighbor);
-			if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
-				anchorSolid.insert(neighbor);
+	voxel::Region anchorRegion = _snapshotRegion;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volRegion);
+	voxel::BitVolume anchorSolid(anchorRegion);
+	for (int z = snapLo.z; z <= snapHi.z; ++z) {
+		for (int y = snapLo.y; y <= snapHi.y; ++y) {
+			for (int x = snapLo.x; x <= snapHi.x; ++x) {
+				if (!currentSolid.hasValue(x, y, z)) {
+					continue;
+				}
+				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+					const glm::ivec3 neighbor = glm::ivec3(x, y, z) + offset;
+					if (currentSolid.hasValue(neighbor.x, neighbor.y, neighbor.z)) {
+						continue;
+					}
+					if (!volRegion.containsPoint(neighbor)) {
+						continue;
+					}
+					const voxel::Voxel &v = vol->voxel(neighbor);
+					if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
+						anchorSolid.setVoxel(neighbor, true);
+					}
+				}
 			}
 		}
 	}
 
-	auto isSolid = [&](const glm::ivec3 &pos) -> bool {
-		return currentSolid.has(pos) || anchorSolid.has(pos);
-	};
-
-	// Count solid 6-face neighbors
-	auto countFaceNeighbors = [&](const glm::ivec3 &pos) -> int {
-		int count = 0;
-		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-			if (isSolid(pos + offset)) {
-				count++;
-			}
-		}
-		return count;
-	};
-
 	if (_sculptMode == SculptMode::Erode) {
-		// Erode: remove surface voxels based on their solid face-neighbor count.
-		// Voxels with fewer solid neighbors are more exposed (protrusions/corners/edges).
-		// Strength controls the threshold - which connectivity tier gets removed:
-		//   strength=0 -> threshold=0 (nothing removed)
-		//   strength~0.25 -> threshold=2 (isolated protrusions with 0-1 neighbors)
-		//   strength~0.5 -> threshold=3 (also corners with 2 neighbors)
-		//   strength~0.75 -> threshold=4 (also edges with 3 neighbors)
-		//   strength=1.0 -> threshold=5 (also flat faces with 4 neighbors)
-		// Each iteration peels one layer at the current threshold.
-		// Anchors (non-selected solid) count as neighbors, so voxels touching
-		// non-selected geometry are more connected and less likely to be removed.
-		const int removeThreshold = (int)glm::mix(0.0f, 5.0f, _strength);
-
-		core::DynamicArray<glm::ivec3> toRemove;
-		for (int iter = 0; iter < _iterations; ++iter) {
-			toRemove.clear();
-
-			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
-				const glm::ivec3 &pos = it->key;
-				const int neighborCount = countFaceNeighbors(pos);
-				if (neighborCount == 6) {
-					continue;
-				}
-
-				if (neighborCount < removeThreshold) {
-					toRemove.push_back(pos);
-				}
-			}
-
-			if (toRemove.empty()) {
-				break;
-			}
-
-			for (const glm::ivec3 &pos : toRemove) {
-				currentSolid.remove(pos);
-				voxelMap.remove(pos);
-			}
-		}
+		voxelutil::sculptErode(currentSolid, voxelMap, anchorSolid, _strength, _iterations);
 	} else if (_sculptMode == SculptMode::Grow) {
-		// Grow: fill air positions adjacent to the surface based on their neighbor count.
-		// Air with more solid neighbors is more "surrounded" (concavity/gap).
-		// Strength controls the minimum neighbor count needed to fill:
-		//   strength=0 -> addThreshold=7 (nothing added, impossible)
-		//   strength~0.25 -> addThreshold=5 (only deeply recessed holes)
-		//   strength~0.5 -> addThreshold=4 (moderate concavities)
-		//   strength=1.0 -> addThreshold=1 (any air touching a solid voxel)
-		// Each iteration grows one layer at the current threshold.
-		const int addThreshold = (int)glm::mix(7.0f, 1.0f, _strength);
-
-		core::DynamicArray<glm::ivec3> toAdd;
-		PositionSet airCandidates;
-		for (int iter = 0; iter < _iterations; ++iter) {
-			toAdd.clear();
-			airCandidates.clear();
-
-			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
-				const glm::ivec3 &pos = it->key;
-				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-					const glm::ivec3 neighbor = pos + offset;
-					if (!isSolid(neighbor) && volRegion.containsPoint(neighbor)) {
-						airCandidates.insert(neighbor);
-					}
-				}
-			}
-
-			for (auto it = airCandidates.begin(); it != airCandidates.end(); ++it) {
-				const glm::ivec3 &pos = it->key;
-				const int myCount = countFaceNeighbors(pos);
-				if (myCount >= addThreshold) {
-					toAdd.push_back(pos);
-				}
-			}
-
-			if (toAdd.empty()) {
-				break;
-			}
-
-			for (const glm::ivec3 &pos : toAdd) {
-				currentSolid.insert(pos);
-				// Pick color from nearest solid face-neighbor
-				voxel::Voxel newVoxel = ctx.cursorVoxel;
-				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-					const glm::ivec3 neighbor = pos + offset;
-					auto found = voxelMap.find(neighbor);
-					if (found != voxelMap.end()) {
-						newVoxel = found->second;
-						break;
-					}
-				}
-				newVoxel.setFlags(voxel::FlagOutline);
-				voxelMap.put(pos, newVoxel);
-			}
-		}
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		voxelutil::sculptGrow(currentSolid, voxelMap, anchorSolid, _strength, _iterations, fillVoxel);
 	} else if (_sculptMode == SculptMode::Flatten && _flattenFace != voxel::FaceNames::Max) {
-		// Flatten: peel layers from the outermost surface along the clicked face normal.
-		// The face encodes both axis and direction. PositiveY means peel from top (remove highest Y layer).
-		const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
-		const bool fromPositive = voxel::isPositiveFace(_flattenFace);
-
-		core::DynamicArray<glm::ivec3> toRemove;
-		for (int iter = 0; iter < _iterations; ++iter) {
-			int extremeVal = fromPositive ? INT_MIN : INT_MAX;
-			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
-				const glm::ivec3 &pos = it->key;
-				if (fromPositive) {
-					extremeVal = glm::max(extremeVal, pos[axisIdx]);
-				} else {
-					extremeVal = glm::min(extremeVal, pos[axisIdx]);
-				}
-			}
-
-			toRemove.clear();
-			for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
-				const glm::ivec3 &pos = it->key;
-				if (pos[axisIdx] == extremeVal) {
-					toRemove.push_back(pos);
-				}
-			}
-
-			if (toRemove.empty()) {
-				break;
-			}
-
-			for (const glm::ivec3 &pos : toRemove) {
-				currentSolid.remove(pos);
-				voxelMap.remove(pos);
-			}
-		}
+		voxelutil::sculptFlatten(currentSolid, voxelMap, _flattenFace, _iterations);
+	} else if (_sculptMode == SculptMode::SmoothAdditive && _flattenFace != voxel::FaceNames::Max) {
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		voxelutil::sculptSmoothAdditive(currentSolid, voxelMap, anchorSolid, _flattenFace, _heightThreshold,
+										_iterations, fillVoxel);
+	} else if (_sculptMode == SculptMode::SmoothErode && _flattenFace != voxel::FaceNames::Max) {
+		voxelutil::sculptSmoothErode(currentSolid, voxelMap, anchorSolid, _flattenFace, _iterations, _preserveTopHeight,
+								_trimPerStep);
 	}
 
 	// Write the result: remove voxels that were in snapshot but not in result,
 	// add voxels that are in result but not in snapshot
 	const voxel::Voxel air;
 
-	// Remove snapshot voxels that were smoothed away
+	// Remove snapshot voxels that were sculpted away
 	for (int z = snapLo.z; z <= snapHi.z; ++z) {
 		for (int y = snapLo.y; y <= snapHi.y; ++y) {
 			for (int x = snapLo.x; x <= snapHi.x; ++x) {
@@ -399,7 +280,7 @@ void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext
 					continue;
 				}
 				const glm::ivec3 pos(x, y, z);
-				if (!currentSolid.has(pos)) {
+				if (!currentSolid.hasValue(x, y, z)) {
 					writeVoxel(wrapper, pos, air);
 				}
 			}
@@ -407,13 +288,19 @@ void SculptBrush::applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext
 	}
 
 	// Write all solid voxels with FlagOutline
-	for (auto it = currentSolid.begin(); it != currentSolid.end(); ++it) {
-		const glm::ivec3 &pos = it->key;
-		auto found = voxelMap.find(pos);
-		if (found != voxelMap.end()) {
-			voxel::Voxel v = found->second;
-			v.setFlags(voxel::FlagOutline);
-			writeVoxel(wrapper, pos, v);
+	for (int z = snapLo.z; z <= snapHi.z; ++z) {
+		for (int y = snapLo.y; y <= snapHi.y; ++y) {
+			for (int x = snapLo.x; x <= snapHi.x; ++x) {
+				if (!currentSolid.hasValue(x, y, z)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				if (voxelMap.hasVoxel(x, y, z)) {
+					voxel::Voxel v = voxelMap.voxel(x, y, z);
+					v.setFlags(voxel::FlagOutline);
+					writeVoxel(wrapper, pos, v);
+				}
+			}
 		}
 	}
 }
@@ -441,7 +328,7 @@ void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrap
 	_history.copyTo(restorer);
 	_history.clear();
 
-	applySmooth(wrapper, ctx);
+	applySculpt(wrapper, ctx);
 	markDirty();
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -19,6 +19,8 @@ enum class SculptMode : uint8_t {
 	Erode,
 	Grow,
 	Flatten,
+	SmoothAdditive,
+	SmoothErode,
 
 	Max
 };
@@ -39,6 +41,9 @@ private:
 	SculptMode _sculptMode = SculptMode::Erode;
 	float _strength = 0.5f;
 	int _iterations = 1;
+	int _heightThreshold = 1;
+	bool _preserveTopHeight = false;
+	int _trimPerStep = 1;
 	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
 	bool _active = false;
 	bool _hasSnapshot = false;
@@ -60,7 +65,7 @@ private:
 
 	void captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion);
 	void adjustSnapshotForRegionShift(const glm::ivec3 &delta);
-	void applySmooth(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
+	void applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
 	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
 	void writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &voxel);
 
@@ -94,7 +99,9 @@ public:
 	}
 
 	void setSculptMode(SculptMode mode) {
-		if (mode == SculptMode::Flatten && _sculptMode != SculptMode::Flatten) {
+		const bool needsFace = mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode;
+		const bool hadFace = _sculptMode == SculptMode::Flatten || _sculptMode == SculptMode::SmoothAdditive || _sculptMode == SculptMode::SmoothErode;
+		if (needsFace && !hadFace) {
 			_flattenFace = voxel::FaceNames::Max;
 		}
 		_sculptMode = mode;
@@ -122,6 +129,34 @@ public:
 
 	voxel::FaceNames flattenFace() const {
 		return _flattenFace;
+	}
+
+	static constexpr int MaxHeightThreshold = 10;
+
+	int heightThreshold() const {
+		return _heightThreshold;
+	}
+
+	void setHeightThreshold(int threshold) {
+		_heightThreshold = glm::clamp(threshold, 1, MaxHeightThreshold);
+	}
+
+	bool preserveTopHeight() const {
+		return _preserveTopHeight;
+	}
+
+	void setPreserveTopHeight(bool preserve) {
+		_preserveTopHeight = preserve;
+	}
+
+	static constexpr int MaxTrimPerStep = 16;
+
+	int trimPerStep() const {
+		return _trimPerStep;
+	}
+
+	void setTrimPerStep(int value) {
+		_trimPerStep = glm::clamp(value, 1, MaxTrimPerStep);
 	}
 };
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
@@ -39,14 +39,17 @@ void TransformBrush::onSceneChange() {
 
 void TransformBrush::onActivated() {
 	reset();
+	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
 bool TransformBrush::onDeactivated() {
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	return _hasSnapshot;
 }
 
 void TransformBrush::reset() {
 	Super::reset();
+	_sceneModifiedFlags = SceneModifiedFlags::All;
 	_active = false;
 	_hasSnapshot = false;
 	_snapshot.clear();


### PR DESCRIPTION
## Summary
- Add **SmoothAdditive** mode to sculpt brush: fills height gaps by scanning layers along a face normal, one voxel per column per iteration
- Add **SmoothErode** mode: removes edge voxels from column tops (fewer than 4 planar neighbors), one per iteration
- **PreserveTopHeight** option for SmoothErode: island-based distance trimming creates pyramid/slope shapes instead of uniform erosion. Configurable **trim-per-step** slider (1-16) controls slope steepness
- Lua API bindings for all sculpt operations (`g_sculpt.erode`, `grow`, `flatten`, `smoothadditive`, `smootherode`)
- NoUndo preview pattern applied consistently to Extrude and Transform brushes
- 25 unit tests covering all sculpt algorithms including preserveTopHeight edge cases

## Test plan
- [ ] Select voxels, activate sculpt brush, switch to SmoothAdditive - short columns next to tall ones should fill upward
- [ ] SmoothErode on a bumpy surface - edge voxels removed from column tops per iteration
- [ ] SmoothErode with PreserveTopHeight checked on a 5x5 tower - should create pyramid shape, center keeps full height
- [ ] Trim-per-step slider: higher values create steeper slopes
- [ ] Bottom island (lowest height group) never eroded with PreserveTopHeight
- [ ] Lua scripts: `g_sculpt.smootherode(vol, "up", 3, true, 2)` works with all parameters
- [ ] Verify undo works correctly (single undo reverts entire sculpt session)