### PR TITLE
VOXEDIT: global paste as node, splat merge, copy visible, deferred transform

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -61,6 +61,8 @@ static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Neares
 												   NC_("Scale Sampling", "Cubic")};
 static_assert(lengthof(VoxelSamplingStr) == (int)voxel::VoxelSampling::Max, "VoxelSamplingStr size mismatch");
 
+static constexpr size_t DeferredTransformThreshold = 10000;
+
 void BrushPanel::init() {
 	_renderNormals = core::getVar(cfg::RenderNormals);
 	_viewMode = core::getVar(cfg::VoxEditViewMode);
@@ -1010,8 +1012,9 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 			const TransformMode mode = (TransformMode)i;
 			const bool selected = mode == currentTransformMode;
 			if (ImGui::Selectable(_(TransformModeStr[i]), selected)) {
-				if (brush.hasSnapshot()) {
+				if (_transformDirty || brush.hasSnapshot()) {
 					executeTransformBrush();
+					_transformDirty = false;
 				}
 				brush.setTransformMode(mode);
 			}
@@ -1045,7 +1048,11 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 		_transformScale = brush.scale();
 		if (ImGui::AxisSliders(_transformScale, 0.01f, 4.0f, "%.2f")) {
 			brush.setScale(_transformScale);
-			executeTransformBrush();
+			if (brush.snapshotVoxelCount() <= DeferredTransformThreshold) {
+				executeTransformBrush();
+			} else {
+				_transformDirty = true;
+			}
 		}
 		break;
 	}
@@ -1054,7 +1061,11 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 		_transformRotation = brush.rotationDegrees();
 		if (ImGui::AxisSliders(_transformRotation, -360.0f, 360.0f, "%.1f")) {
 			brush.setRotationDegrees(_transformRotation);
-			executeTransformBrush();
+			if (brush.snapshotVoxelCount() <= DeferredTransformThreshold) {
+				executeTransformBrush();
+			} else {
+				_transformDirty = true;
+			}
 		}
 		break;
 	}
@@ -1063,13 +1074,20 @@ void BrushPanel::updateTransformBrushPanel(command::CommandExecutionListener &li
 		break;
 	}
 
-	if (brush.transformMode() == TransformMode::Scale || brush.transformMode() == TransformMode::Rotate	) {
+	if (brush.transformMode() == TransformMode::Scale || brush.transformMode() == TransformMode::Rotate) {
+		if (_transformDirty) {
+			if (ImGui::ButtonFullWidth(_("Apply"))) {
+				executeTransformBrush();
+				_transformDirty = false;
+			}
+		}
 		int samplingInt = (int)brush.voxelSampling();
 		if (ImGui::BeginCombo(_("Sampling"), _(VoxelSamplingStr[samplingInt]))) {
 			for (int i = 0; i < (int)voxel::VoxelSampling::Max; ++i) {
 				const bool selected = samplingInt == i;
 				if (ImGui::Selectable(_(VoxelSamplingStr[i]), selected)) {
 					brush.setVoxelSampling((voxel::VoxelSampling)i);
+					_transformDirty = true;
 				}
 				if (selected) {
 					ImGui::SetItemDefaultFocus();

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
@@ -39,6 +39,7 @@ private:
 	glm::ivec3 _transformShearOffset{0};
 	glm::vec3 _transformScale{1.0f};
 	glm::vec3 _transformRotation{0.0f};
+	bool _transformDirty = false;
 
 	void createPopups(command::CommandExecutionListener &listener);
 

--- a/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
@@ -147,8 +147,10 @@ bool MenuBar::update(ui::IMGUIApp *app, command::CommandExecutionListener &liste
 			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_PASTE, _("Paste as stamp"), "stampbrushpaste",
 									   _sceneMgr->clipboardData(), &listener);
 			ImGui::Separator();
-			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_COPY, _("Global copy"), "globalcopy", hasSelection, &listener);
+			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_COPY, _("Global copy selected"), "globalcopy", hasSelection, &listener);
+			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_COPY, _("Global copy visible"), "globalcopyvisible", true, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_PASTE, _("Global paste to ref"), "globalpastetoref", true, &listener);
+			ImGui::CommandIconMenuItem(ICON_LC_CLIPBOARD_PASTE, _("Global paste as node"), "globalpastenode", true, &listener);
 			ImGui::Separator();
 			if (ImGui::IconMenuItem(ICON_LC_SETTINGS, _("Options"))) {
 				if (_optionsPanel) {

--- a/src/tools/voxedit/modules/voxedit-ui/ToolsPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/ToolsPanel.cpp
@@ -112,6 +112,7 @@ void ToolsPanel::updateEditMode(command::CommandExecutionListener &listener) {
 		toolbar.button(ICON_LC_X, "clear");
 		toolbar.button(ICON_LC_TRASH, "deleteselected");
 		toolbar.button(ICON_LC_PAINT_BUCKET, "fill");
+		toolbar.button(ICON_LC_MERGE, "splatmerge");
 	}
 
 	const float buttonWidth = ImGui::GetFontSize() * 4;

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -73,6 +73,7 @@
 #include "voxelutil/VolumeRotator.h"
 #include "voxelutil/VolumeSplitter.h"
 #include "voxelutil/VolumeVisitor.h"
+#include "voxelutil/VolumeMerger.h"
 #include "voxelutil/VoxelUtil.h"
 
 #include "Clipboard.h"
@@ -1261,6 +1262,47 @@ bool SceneManager::nodePasteAsNewNode(int nodeId) {
 	return moveNodeToSceneGraph(newNode, node->parent()) != InvalidNodeId;
 }
 
+void SceneManager::autoSelectSolidVoxels(scenegraph::SceneGraphNode *node, const voxel::Region &region) {
+	if (node == nullptr) {
+		return;
+	}
+	if (!core::getVar(cfg::VoxEditAutoSelect)->boolVal()) {
+		return;
+	}
+	node->clearSelection();
+	voxel::RawVolume *volume = node->volume();
+	voxelutil::visitVolumeParallel(*volume, region,
+		[volume](int x, int y, int z, const voxel::Voxel &srcVoxel) {
+			voxel::Voxel selected = srcVoxel;
+			selected.setFlags(selected.getFlags() | voxel::FlagOutline);
+			volume->setVoxel(x, y, z, selected);
+		},
+		voxelutil::VisitSolid());
+}
+
+bool SceneManager::loadGlobalClipboard(voxel::ClipboardData &clipData) {
+	const core::String clipboardFile = _filesystem->homeWritePath("globalclipboard.vengi");
+	const io::ArchivePtr &archive = io::openFilesystemArchive(_filesystem);
+	scenegraph::SceneGraph loadedSceneGraph;
+	voxelformat::LoadContext loadCtx;
+	io::FileDescription fileDesc;
+	fileDesc.set(clipboardFile);
+	if (!voxelformat::loadFormat(fileDesc, archive, loadedSceneGraph, loadCtx)) {
+		Log::warn("Failed to read global clipboard from %s", clipboardFile.c_str());
+		return false;
+	}
+	for (auto iter = loadedSceneGraph.beginModel(); iter != loadedSceneGraph.end(); ++iter) {
+		scenegraph::SceneGraphNode &srcNode = *iter;
+		if (srcNode.volume() == nullptr) {
+			continue;
+		}
+		clipData = voxel::ClipboardData(new voxel::RawVolume(*srcNode.volume()), srcNode.palette(), true);
+		return true;
+	}
+	Log::warn("Global clipboard file contained no model data");
+	return false;
+}
+
 bool SceneManager::paste(const glm::ivec3& pos) {
 	if (!_copy) {
 		Log::debug("Nothing copied yet - failed to paste");
@@ -1287,6 +1329,7 @@ bool SceneManager::paste(const glm::ivec3& pos) {
 		Log::warn("paste: modified region %s does not intersect destination volume %s - voxels out of bounds",
 				  modifiedRegion.toString().c_str(), destRegion.toString().c_str());
 	}
+	autoSelectSolidVoxels(node, modifiedRegion);
 	const int64_t dismissMillis = core::getVar(cfg::VoxEditModificationDismissMillis)->intVal();
 	modified(nodeId, modifiedRegion, SceneModifiedFlags::All, dismissMillis);
 	return true;
@@ -1343,27 +1386,30 @@ bool SceneManager::globalCopy() {
 	return true;
 }
 
-bool SceneManager::globalPaste(const glm::ivec3 &pos) {
-	const core::String clipboardFile = _filesystem->homeWritePath("globalclipboard.vengi");
-	const io::ArchivePtr &archive = io::openFilesystemArchive(_filesystem);
-	scenegraph::SceneGraph loadedSceneGraph;
-	voxelformat::LoadContext loadCtx;
-	io::FileDescription fileDesc;
-	fileDesc.set(clipboardFile);
-	if (!voxelformat::loadFormat(fileDesc, archive, loadedSceneGraph, loadCtx)) {
-		Log::warn("Failed to read global clipboard from %s", clipboardFile.c_str());
+bool SceneManager::globalCopyVisible() {
+	const scenegraph::SceneGraph::MergeResult &merged = _sceneGraph.merge(true);
+	if (!merged.hasVolume()) {
+		Log::warn("globalcopyvisible: no visible model nodes to copy");
 		return false;
 	}
-	for (auto iter = loadedSceneGraph.beginModel(); iter != loadedSceneGraph.end(); ++iter) {
-		scenegraph::SceneGraphNode &srcNode = *iter;
-		if (srcNode.volume() == nullptr) {
-			continue;
-		}
-		_copy = voxel::ClipboardData(new voxel::RawVolume(*srcNode.volume()), srcNode.palette(), true);
-		break;
+	scenegraph::SceneGraph newSceneGraph;
+	scenegraph::SceneGraphNode newNode(scenegraph::SceneGraphNodeType::Model);
+	newNode.setVolume(merged.volume(), true);
+	newNode.setPalette(merged.palette);
+	newSceneGraph.emplace(core::move(newNode));
+	const core::String clipboardFile = _filesystem->homeWritePath("globalclipboard.vengi");
+	const io::ArchivePtr &archive = io::openFilesystemArchive(_filesystem);
+	voxelformat::SaveContext saveCtx;
+	if (!voxelformat::saveFormat(newSceneGraph, clipboardFile, nullptr, archive, saveCtx)) {
+		Log::warn("Failed to write global clipboard to %s", clipboardFile.c_str());
+		return false;
 	}
-	if (!_copy) {
-		Log::warn("Global clipboard file contained no model data");
+	Log::debug("Global clipboard (visible nodes) written to %s", clipboardFile.c_str());
+	return true;
+}
+
+bool SceneManager::globalPaste(const glm::ivec3 &pos) {
+	if (!loadGlobalClipboard(_copy)) {
 		return false;
 	}
 
@@ -1388,9 +1434,118 @@ bool SceneManager::globalPaste(const glm::ivec3 &pos) {
 	newNode.setName("clipboard");
 	newNode.setVolume(vol, true);
 	newNode.setPalette(*_copy.palette);
-	if (moveNodeToSceneGraph(newNode) == InvalidNodeId) {
+	const int newNodeId = moveNodeToSceneGraph(newNode);
+	if (newNodeId == InvalidNodeId) {
 		Log::warn("globalPaste: failed to create node from clipboard");
 		return false;
+	}
+	scenegraph::SceneGraphNode *addedNode = sceneGraphModelNode(newNodeId);
+	autoSelectSolidVoxels(addedNode, vol->region());
+	return true;
+}
+
+bool SceneManager::globalPasteNode(const glm::ivec3 &pos) {
+	voxel::ClipboardData clipData;
+	if (!loadGlobalClipboard(clipData)) {
+		return false;
+	}
+
+	voxel::RawVolume *vol = new voxel::RawVolume(*clipData.volume);
+	vol->translate(pos - vol->region().getLowerCorner());
+	Log::debug("globalPasteNode: creating new node at %i:%i:%i (region %s)", pos.x, pos.y, pos.z,
+			  vol->region().toString().c_str());
+	scenegraph::SceneGraphNode newNode(scenegraph::SceneGraphNodeType::Model);
+	newNode.setName("clipboard");
+	newNode.setVolume(vol, true);
+	newNode.setPalette(*clipData.palette);
+	const int newNodeId = moveNodeToSceneGraph(newNode);
+	if (newNodeId == InvalidNodeId) {
+		Log::warn("globalPasteNode: failed to create node from clipboard");
+		return false;
+	}
+	autoSelectSolidVoxels(sceneGraphModelNode(newNodeId), vol->region());
+	return true;
+}
+
+bool SceneManager::splatMerge(int sourceNodeId) {
+	scenegraph::SceneGraphNode *sourceNode = sceneGraphModelNode(sourceNodeId);
+	if (sourceNode == nullptr) {
+		Log::warn("splatmerge: no valid source node");
+		return false;
+	}
+	const voxel::RawVolume *sourceVolume = _sceneGraph.resolveVolume(*sourceNode);
+	if (sourceVolume == nullptr) {
+		Log::warn("splatmerge: source node has no volume");
+		return false;
+	}
+
+	// Bake source into world space (apply scene graph transform if any)
+	const scenegraph::FrameTransform &srcTransform =
+		_sceneGraph.transformForFrame(*sourceNode, _currentFrameIdx);
+	core::ScopedPtr<voxel::RawVolume> bakedSource;
+	const voxel::RawVolume *worldSource = sourceVolume;
+	if (!srcTransform.isIdentity()) {
+		bakedSource = voxelutil::applyTransformToVolume(
+			*sourceVolume, srcTransform.worldMatrix(), sourceNode->pivot());
+		worldSource = &(*bakedSource);
+	}
+	const voxel::Region &sourceWorldRegion = worldSource->region();
+	const palette::Palette &sourcePalette = sourceNode->palette();
+
+	memento::ScopedMementoGroup mementoGroup(_mementoHandler, "splatmerge");
+
+	int mergedCount = 0;
+	for (auto iter = _sceneGraph.beginModel(); iter != _sceneGraph.end(); ++iter) {
+		scenegraph::SceneGraphNode &targetNode = *iter;
+		if (targetNode.id() == sourceNodeId) {
+			continue;
+		}
+		if (!targetNode.isModelNode()) {
+			continue;
+		}
+		voxel::RawVolume *targetVolume = targetNode.volume();
+		if (targetVolume == nullptr) {
+			continue;
+		}
+
+		// Get the target's world-space region (accounts for scene graph transforms)
+		const voxel::Region targetWorldRegion =
+			_sceneGraph.sceneRegion(targetNode, _currentFrameIdx);
+		if (!targetWorldRegion.isValid()) {
+			continue;
+		}
+		if (!voxel::intersects(sourceWorldRegion, targetWorldRegion)) {
+			continue;
+		}
+
+		// Compute the overlapping region in world coordinates
+		voxel::Region worldOverlap = sourceWorldRegion;
+		worldOverlap.cropTo(targetWorldRegion);
+
+		// Map world overlap back to target local coordinates
+		const glm::ivec3 worldToLocal =
+			targetVolume->region().getLowerCorner() - targetWorldRegion.getLowerCorner();
+		const voxel::Region targetLocalOverlap(
+			worldOverlap.getLowerCorner() + worldToLocal,
+			worldOverlap.getUpperCorner() + worldToLocal);
+
+		const int count = voxelutil::mergeVolumes(targetVolume, targetNode.palette(),
+			worldSource, sourcePalette, targetLocalOverlap, worldOverlap);
+		if (count > 0) {
+			modified(targetNode.id(), targetLocalOverlap, SceneModifiedFlags::All);
+			mergedCount += count;
+		}
+	}
+
+	if (mergedCount == 0) {
+		Log::warn("splatmerge: no overlapping nodes found for source node %i", sourceNodeId);
+		return false;
+	}
+
+	Log::info("splatmerge: merged %i voxels into overlapping nodes", mergedCount);
+	_mementoHandler.markNodeRemove(_sceneGraph, *sourceNode);
+	if (_sceneGraph.removeNode(sourceNodeId, false)) {
+		_sceneRenderer->removeNode(sourceNodeId);
 	}
 	return true;
 }
@@ -2863,6 +3018,11 @@ void SceneManager::construct() {
 			globalCopy();
 		}).setHelp(_("Copy selection to a file-based clipboard shared across editor instances"));
 
+	command::Command::registerCommand("globalcopyvisible")
+		.setHandler([&] (const command::CommandArgs&) {
+			globalCopyVisible();
+		}).setHelp(_("Merge all visible nodes and copy to the file-based clipboard"));
+
 	command::Command::registerCommand("globalpaste")
 		.setHandler([&] (const command::CommandArgs&) {
 			globalPaste(cursorPosition());
@@ -2872,6 +3032,16 @@ void SceneManager::construct() {
 		.setHandler([&] (const command::CommandArgs&) {
 			globalPaste(referencePosition());
 		}).setHelp(_("Paste from the file-based clipboard shared across editor instances to the reference position"));
+
+	command::Command::registerCommand("globalpastenode")
+		.setHandler([&] (const command::CommandArgs&) {
+			globalPasteNode(cursorPosition());
+		}).setHelp(_("Paste from the file-based clipboard as a new node at the cursor position"));
+
+	command::Command::registerCommand("splatmerge")
+		.setHandler([&] (const command::CommandArgs&) {
+			splatMerge(activeNode());
+		}).setHelp(_("Merge active node voxels into all overlapping nodes and remove the source node"));
 
 	command::Command::registerCommand("undo")
 		.setHandler([&] (const command::CommandArgs& args) {

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -151,6 +151,9 @@ protected:
 
 	voxelutil::PickResult _result;
 
+	void autoSelectSolidVoxels(scenegraph::SceneGraphNode *node, const voxel::Region &region);
+	bool loadGlobalClipboard(voxel::ClipboardData &clipData);
+
 	/**
 	 * @note This might return @c nullptr in the case where the active node is no model node
 	 */
@@ -389,7 +392,10 @@ public:
 	bool copy(int nodeId);
 	bool paste(const glm::ivec3 &pos);
 	bool globalCopy();
+	bool globalCopyVisible();
 	bool globalPaste(const glm::ivec3 &pos);
+	bool globalPasteNode(const glm::ivec3 &pos);
+	bool splatMerge(int sourceNodeId);
 
 	void selectionInvert(int nodeId);
 	void selectionUnselect(int nodeId);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -178,6 +178,10 @@ public:
 		return _hasSnapshot;
 	}
 
+	size_t snapshotVoxelCount() const {
+		return _snapshot.size();
+	}
+
 	bool wantBrushGizmo(const BrushContext &ctx) const override;
 	void brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const override;
 	bool applyBrushGizmo(BrushContext &ctx, const glm::mat4 &matrix,

--- a/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "voxedit-util/SceneManager.h"
+#include "voxedit-util/Config.h"
 #include "AbstractSceneManagerTest.h"
 #include "image/Image.h"
 #include "io/FilesystemArchive.h"
@@ -1439,6 +1440,142 @@ TEST_F(SceneManagerTest, testUndoInvalidatesAABBBrush) {
 	// undo - AABB mode should be cancelled
 	EXPECT_TRUE(_sceneMgr->undo());
 	EXPECT_FALSE(sb.aabbMode());
+}
+
+TEST_F(SceneManagerTest, testSplatMerge) {
+	// Create a scene with two sibling model nodes that overlap at region [0,9]
+	const voxel::Region region{0, 9};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "splatmerge_test", region));
+
+	// Target node (first model node from newScene)
+	const int targetNodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *targetVol = _sceneMgr->volume(targetNodeId);
+	ASSERT_NE(nullptr, targetVol);
+	targetVol->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	_sceneMgr->modified(targetNodeId, targetVol->region());
+
+	// Create source as sibling (parent = root) so transforms are independent
+	const int rootNodeId = _sceneMgr->sceneGraph().root().id();
+	scenegraph::SceneGraphNode sourceNode(scenegraph::SceneGraphNodeType::Model);
+	sourceNode.setVolume(new voxel::RawVolume(region), true);
+	sourceNode.setName("source");
+	const int sourceNodeId = _sceneMgr->moveNodeToSceneGraph(sourceNode, rootNodeId);
+	ASSERT_NE(InvalidNodeId, sourceNodeId);
+	voxel::RawVolume *sourceVol = _sceneMgr->volume(sourceNodeId);
+	ASSERT_NE(nullptr, sourceVol);
+	sourceVol->setVoxel(5, 5, 5, voxel::createVoxel(voxel::VoxelType::Generic, 2));
+	sourceVol->setVoxel(6, 6, 6, voxel::createVoxel(voxel::VoxelType::Generic, 2));
+	_sceneMgr->modified(sourceNodeId, sourceVol->region());
+
+	ASSERT_TRUE(_sceneMgr->splatMerge(sourceNodeId));
+
+	// Source node should be removed
+	EXPECT_EQ(nullptr, _sceneMgr->sceneGraphNode(sourceNodeId));
+
+	// Target should have the original voxel plus the merged ones
+	EXPECT_FALSE(voxel::isAir(targetVol->voxel(0, 0, 0).getMaterial()));
+	EXPECT_FALSE(voxel::isAir(targetVol->voxel(5, 5, 5).getMaterial()));
+	EXPECT_FALSE(voxel::isAir(targetVol->voxel(6, 6, 6).getMaterial()));
+	EXPECT_EQ(3, voxelutil::countVoxels(*targetVol));
+}
+
+TEST_F(SceneManagerTest, testSplatMergeNoOverlap) {
+	const voxel::Region region{0, 4};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "splatmerge_nooverlap", region));
+
+	const int targetNodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *targetVol = _sceneMgr->volume(targetNodeId);
+	ASSERT_NE(nullptr, targetVol);
+	targetVol->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	_sceneMgr->modified(targetNodeId, targetVol->region());
+
+	// Create source at a non-overlapping region
+	const voxel::Region farRegion{100, 104};
+	const int rootNodeId = _sceneMgr->sceneGraph().root().id();
+	scenegraph::SceneGraphNode sourceNode(scenegraph::SceneGraphNodeType::Model);
+	sourceNode.setVolume(new voxel::RawVolume(farRegion), true);
+	sourceNode.setName("source_far");
+	const int sourceNodeId = _sceneMgr->moveNodeToSceneGraph(sourceNode, rootNodeId);
+	ASSERT_NE(InvalidNodeId, sourceNodeId);
+	voxel::RawVolume *sourceVol = _sceneMgr->volume(sourceNodeId);
+	ASSERT_NE(nullptr, sourceVol);
+	sourceVol->setVoxel(100, 100, 100, voxel::createVoxel(voxel::VoxelType::Generic, 2));
+	_sceneMgr->modified(sourceNodeId, sourceVol->region());
+
+	// splatMerge should fail - no overlapping nodes
+	EXPECT_FALSE(_sceneMgr->splatMerge(sourceNodeId));
+
+	// Source node should still exist since merge failed
+	EXPECT_NE(nullptr, _sceneMgr->sceneGraphNode(sourceNodeId));
+}
+
+TEST_F(SceneManagerTest, testGlobalCopyVisibleAndPasteNode) {
+	const voxel::Region region{0, 4};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "globalcopyvisible_test", region));
+
+	// Fill first node
+	const int node1Id = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v1 = _sceneMgr->volume(node1Id);
+	ASSERT_NE(nullptr, v1);
+	v1->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	_sceneMgr->modified(node1Id, v1->region());
+
+	// Create and fill second visible node
+	const int node2Id = _sceneMgr->addModelChild("visible", 5, 5, 5);
+	ASSERT_NE(-1, node2Id);
+	ASSERT_TRUE(_sceneMgr->nodeActivate(node2Id));
+	voxel::RawVolume *v2 = _sceneMgr->volume(node2Id);
+	ASSERT_NE(nullptr, v2);
+	v2->setVoxel(1, 1, 1, voxel::createVoxel(voxel::VoxelType::Generic, 2));
+	_sceneMgr->modified(node2Id, v2->region());
+
+	// Global copy visible should succeed
+	ASSERT_TRUE(_sceneMgr->globalCopyVisible());
+
+	// Now paste as new node
+	const size_t nodeCountBefore = _sceneMgr->sceneGraph().size();
+	ASSERT_TRUE(_sceneMgr->globalPasteNode(glm::ivec3(0)));
+
+	// A new node should have been created
+	EXPECT_GT(_sceneMgr->sceneGraph().size(), nodeCountBefore);
+}
+
+TEST_F(SceneManagerTest, testAutoSelectOnPaste) {
+	const voxel::Region region{0, 4};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "autoselect_paste", region));
+
+	// Enable auto-select
+	core::getVar(cfg::VoxEditAutoSelect)->setVal("true");
+
+	// Set a voxel and select it for copy
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+	v->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	v->setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 1));
+	scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	ASSERT_NE(nullptr, node);
+	node->select(voxel::Region{glm::ivec3(0), glm::ivec3(1, 0, 0)});
+	ASSERT_TRUE(node->hasSelection());
+
+	// Copy and then paste
+	ASSERT_TRUE(_sceneMgr->copy(nodeId));
+	ASSERT_TRUE(_sceneMgr->paste(glm::ivec3(2, 0, 0)));
+
+	// The pasted voxels should have FlagOutline set
+	const voxel::Voxel &pasted1 = v->voxel(2, 0, 0);
+	const voxel::Voxel &pasted2 = v->voxel(3, 0, 0);
+	EXPECT_FALSE(voxel::isAir(pasted1.getMaterial()));
+	EXPECT_FALSE(voxel::isAir(pasted2.getMaterial()));
+	EXPECT_TRUE((pasted1.getFlags() & voxel::FlagOutline) != 0) << "Pasted voxel should be auto-selected";
+	EXPECT_TRUE((pasted2.getFlags() & voxel::FlagOutline) != 0) << "Pasted voxel should be auto-selected";
+
+	// The original voxels should NOT have FlagOutline (clearSelection was called)
+	const voxel::Voxel &orig = v->voxel(0, 0, 0);
+	EXPECT_TRUE((orig.getFlags() & voxel::FlagOutline) == 0) << "Original voxels should be deselected";
+
+	// Disable auto-select for cleanup
+	core::getVar(cfg::VoxEditAutoSelect)->setVal("false");
 }
 
 TEST_F(SceneManagerTest, testRedoInvalidatesBrushState) {


### PR DESCRIPTION
## Summary
- **globalpastenode**: Always creates a new geometry node from global clipboard, regardless of whether it fits in the active node. Useful for positioning large pasted content before merging.
- **splatmerge**: Distributes the active node's voxels into all overlapping nodes (with palette remapping), then removes the source node. Handles world-space transforms via `sceneRegion()` and `applyTransformToVolume()`. Use case: precise voxel-level merging of pasted content into existing multi-node structure.
- **globalcopyvisible**: Merges all visible nodes into the global clipboard (uses `SceneGraph::merge(true)` to skip hidden nodes). Solves the lack of multi-node selection for clipboard operations.
- **Auto-select on paste**: When `ve_autoselect` is enabled, pasted voxels now get `FlagOutline` selection. Previously paste bypassed `executeBrush()` where auto-select lived.
- **Deferred transform execution**: Scale/Rotate on selections >10k voxels show an "Apply" button instead of executing on every slider tick. Threshold: `DeferredTransformThreshold = 10000`.
- Extracted `autoSelectSolidVoxels()` and `loadGlobalClipboard()` helpers to avoid duplication.
- Menu items: renamed "Global copy" to "Global copy selected", added "Global copy visible" and "Global paste as node".
- Toolbar button for splat merge (`ICON_LC_MERGE`).

## Test plan
- [x] `testSplatMerge` - overlapping nodes, voxels distributed, source removed
- [x] `testSplatMergeNoOverlap` - non-overlapping nodes, merge fails, source preserved
- [x] `testGlobalCopyVisibleAndPasteNode` - copy visible nodes, paste as new node
- [x] `testAutoSelectOnPaste` - pasted voxels get FlagOutline when ve_autoselect on