### PR TITLE
VOXELUTIL: Add Smooth Gaussian and Bridge Gap sculpt modes

### DIFF
--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -2103,6 +2103,63 @@ static int luaVoxel_sculpt_smootherode_jsonhelp(lua_State *s) {
 	return 1;
 }
 
+static int luaVoxel_sculpt_bridgegap(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const int color = (int)luaL_optinteger(s, 2, 1);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed = voxelutil::sculptBridgeGap(*volume->volume(), volume->volume()->region(), fillVoxel);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_bridgegap_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "bridgegap",
+		"summary": "Connect boundary voxels by drawing 3D lines between all pairs, filling air along each line. Bridges gaps and cracks across openings.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to bridge."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothgaussian(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int kernelSize = (int)luaL_optinteger(s, 3, 1);
+	const float sigma = (float)luaL_optnumber(s, 4, 1.0);
+	const int iterations = (int)luaL_optinteger(s, 5, 1);
+	const int color = (int)luaL_optinteger(s, 6, 1);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed = voxelutil::sculptSmoothGaussian(*volume->volume(), volume->volume()->region(), face,
+														kernelSize, sigma, iterations, fillVoxel);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothgaussian_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "smoothgaussian",
+		"summary": "Blur the height map using a 2D Gaussian kernel along a face normal. Columns taller than the weighted average are trimmed, shorter ones are filled. Uses circular sampling within the kernel radius.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to smooth."},
+			{"name": "face", "type": "string", "description": "Face direction defining 'up': 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "kernelSize", "type": "integer", "description": "Radius of the Gaussian kernel (optional, default 1). 1=3x3, 2=5x5, 3=7x7, 4=9x9."},
+			{"name": "sigma", "type": "number", "description": "Standard deviation of the Gaussian bell curve (optional, default 1.0). Lower = sharper, higher = broader smoothing."},
+			{"name": "iterations", "type": "integer", "description": "Number of blur passes (optional, default 1)."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
 // VoxelFont bindings
 
 static int luaVoxel_voxelfont_new(lua_State *s) {
@@ -5901,6 +5958,8 @@ static void prepareState(lua_State* s) {
 		{"flatten", luaVoxel_sculpt_flatten, luaVoxel_sculpt_flatten_jsonhelp},
 		{"smoothadditive", luaVoxel_sculpt_smoothadditive, luaVoxel_sculpt_smoothadditive_jsonhelp},
 		{"smootherode", luaVoxel_sculpt_smootherode, luaVoxel_sculpt_smootherode_jsonhelp},
+		{"smoothgaussian", luaVoxel_sculpt_smoothgaussian, luaVoxel_sculpt_smoothgaussian_jsonhelp},
+		{"bridgegap", luaVoxel_sculpt_bridgegap, luaVoxel_sculpt_bridgegap_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "VolumeSculpt.h"
+#include "app/ForParallel.h"
 #include "core/GLM.h"
 #include "core/Trace.h"
 #include "core/collection/DynamicArray.h"
@@ -601,6 +602,303 @@ void sculptSmoothErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, c
 	}
 }
 
+void sculptBridgeGap(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					 const voxel::Voxel &fillVoxel) {
+	core_trace_scoped(SculptBridgeGap);
+
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	// Step 1: Find boundary voxels (solid with at least one air face-neighbor)
+	core::DynamicArray<glm::ivec3> boundary;
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				const glm::ivec3 pos(x, y, z);
+				if (!isSolid(solid, anchors, pos)) {
+					continue;
+				}
+				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+					const glm::ivec3 neighbor = pos + offset;
+					if (region.containsPoint(neighbor) && !isSolid(solid, anchors, neighbor)) {
+						boundary.push_back(pos);
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	if (boundary.size() < 2) {
+		return;
+	}
+
+	// Step 2: For each pair of boundary voxels, draw a 3D line and fill air along it.
+	const int numBoundary = (int)boundary.size();
+	for (int idxA = 0; idxA < numBoundary; ++idxA) {
+		for (int idxB = idxA + 1; idxB < numBoundary; ++idxB) {
+			const glm::ivec3 diff = boundary[idxB] - boundary[idxA];
+			const int distSq = diff.x * diff.x + diff.y * diff.y + diff.z * diff.z;
+			// Skip pairs that are already adjacent (face/edge/corner neighbors)
+			if (distSq <= 3) {
+				continue;
+			}
+
+			const glm::ivec3 &start = boundary[idxA];
+			const glm::ivec3 &end = boundary[idxB];
+			const int dx = glm::abs(end.x - start.x);
+			const int dy = glm::abs(end.y - start.y);
+			const int dz = glm::abs(end.z - start.z);
+			const int sx = (end.x > start.x) ? 1 : (end.x < start.x) ? -1 : 0;
+			const int sy = (end.y > start.y) ? 1 : (end.y < start.y) ? -1 : 0;
+			const int sz = (end.z > start.z) ? 1 : (end.z < start.z) ? -1 : 0;
+			const int totalSteps = dx + dy + dz;
+
+			glm::ivec3 pos = start;
+			int ex = 0;
+			int ey = 0;
+			int ez = 0;
+			for (int step = 0; step <= totalSteps; ++step) {
+				if (!solid.hasValue(pos.x, pos.y, pos.z) && region.containsPoint(pos)) {
+					solid.setVoxel(pos, true);
+					voxel::Voxel newVoxel = fillVoxel;
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+						const glm::ivec3 neighbor = pos + offset;
+						if (voxelMap.hasVoxel(neighbor)) {
+							newVoxel = voxelMap.voxel(neighbor);
+							break;
+						}
+					}
+					voxelMap.setVoxel(pos, newVoxel);
+				}
+				ex += dx;
+				ey += dy;
+				ez += dz;
+				if (ex >= ey && ex >= ez) {
+					pos.x += sx;
+					ex -= totalSteps;
+				} else if (ey >= ez) {
+					pos.y += sy;
+					ey -= totalSteps;
+				} else {
+					pos.z += sz;
+					ez -= totalSteps;
+				}
+			}
+		}
+	}
+}
+
+void sculptSmoothGaussian(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+						  voxel::FaceNames face, int kernelSize, float sigma, int iterations,
+						  const voxel::Voxel &fillVoxel) {
+	if (face == voxel::FaceNames::Max || kernelSize < 1 || sigma <= 0.0f) {
+		return;
+	}
+
+	core_trace_scoped(SculptSmoothGaussian);
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+	const int step = positiveUp ? 1 : -1;
+
+	const int axis1 = (axisIdx == 0) ? 1 : 0;
+	const int axis2 = (axisIdx == 2) ? 1 : 2;
+
+	// 2D grid extents on the two planar axes
+	const int base1 = lo[axis1];
+	const int base2 = lo[axis2];
+	const int extent1 = hi[axis1] - base1 + 1;
+	const int extent2 = hi[axis2] - base2 + 1;
+	const int numColumns = extent1 * extent2;
+
+	// Sentinel value for empty columns
+	static constexpr int EMPTY = INT_MIN;
+
+	// Precompute kernel entries: only non-zero weight (da, db) pairs stored with flat index offsets
+	struct KernelEntry {
+		int da;
+		int db;
+		int offset; // flat index offset: da * extent2 + db
+		float weight;
+	};
+	const int kernelDiameter = kernelSize * 2 + 1;
+	core::DynamicArray<KernelEntry> kernelEntries;
+	kernelEntries.reserve(kernelDiameter * kernelDiameter);
+	const float twoSigmaSq = 2.0f * sigma * sigma;
+	const float radiusSq = (float)(kernelSize * kernelSize);
+	for (int da = -kernelSize; da <= kernelSize; ++da) {
+		for (int db = -kernelSize; db <= kernelSize; ++db) {
+			const float distSq = (float)(da * da + db * db);
+			if (distSq > radiusSq) {
+				continue;
+			}
+			KernelEntry entry;
+			entry.da = da;
+			entry.db = db;
+			entry.offset = da * extent2 + db;
+			entry.weight = glm::exp(-distSq / twoSigmaSq);
+			kernelEntries.push_back(entry);
+		}
+	}
+	const int numKernelEntries = (int)kernelEntries.size();
+	const KernelEntry *kernelData = kernelEntries.data();
+
+	// Flat 2D arrays for column top/bottom coordinates (reused across iterations)
+	core::DynamicArray<int> colTopArr(numColumns);
+	core::DynamicArray<int> colBotArr(numColumns);
+	core::DynamicArray<int> targetArr(numColumns);
+
+	for (int iter = 0; iter < iterations; ++iter) {
+		// Step 1: Build column top/bottom from the solid BitVolume
+		// Initialize all columns to empty
+		for (int i = 0; i < numColumns; ++i) {
+			colTopArr[i] = EMPTY;
+			colBotArr[i] = EMPTY;
+		}
+
+		const int axisLo = lo[axisIdx];
+		const int axisHi = hi[axisIdx];
+		for (int a1 = 0; a1 < extent1; ++a1) {
+			for (int a2 = 0; a2 < extent2; ++a2) {
+				const int flatIdx = a1 * extent2 + a2;
+				const int coord1 = base1 + a1;
+				const int coord2 = base2 + a2;
+				int topVal = EMPTY;
+				int botVal = EMPTY;
+				for (int av = axisLo; av <= axisHi; ++av) {
+					glm::ivec3 pos;
+					pos[axis1] = coord1;
+					pos[axis2] = coord2;
+					pos[axisIdx] = av;
+					if (!isSolid(solid, anchors, pos)) {
+						continue;
+					}
+					if (topVal == EMPTY) {
+						topVal = av;
+						botVal = av;
+					} else if (positiveUp) {
+						topVal = glm::max(topVal, av);
+						botVal = glm::min(botVal, av);
+					} else {
+						topVal = glm::min(topVal, av);
+						botVal = glm::max(botVal, av);
+					}
+				}
+				colTopArr[flatIdx] = topVal;
+				colBotArr[flatIdx] = botVal;
+			}
+		}
+
+		// Step 2: Gaussian convolution on the height map (parallel over rows)
+		// Initialize targets to EMPTY (no change needed)
+		for (int i = 0; i < numColumns; ++i) {
+			targetArr[i] = EMPTY;
+		}
+
+		bool anyChange = false;
+		const int *topData = colTopArr.data();
+
+		app::for_parallel(0, extent1, [&](int startRow, int endRow) {
+			for (int a1 = startRow; a1 < endRow; ++a1) {
+				for (int a2 = 0; a2 < extent2; ++a2) {
+					const int flatIdx = a1 * extent2 + a2;
+					const int myTop = topData[flatIdx];
+					if (myTop == EMPTY) {
+						continue;
+					}
+
+					float weightSum = 0.0f;
+					float heightSum = 0.0f;
+
+					for (int ki = 0; ki < numKernelEntries; ++ki) {
+						const int na1 = a1 + kernelData[ki].da;
+						const int na2 = a2 + kernelData[ki].db;
+						if (na1 < 0 || na1 >= extent1 || na2 < 0 || na2 >= extent2) {
+							continue;
+						}
+						const int neighborTop = topData[flatIdx + kernelData[ki].offset];
+						if (neighborTop == EMPTY) {
+							continue;
+						}
+						heightSum += kernelData[ki].weight * (float)neighborTop;
+						weightSum += kernelData[ki].weight;
+					}
+
+					if (weightSum > 0.0f) {
+						const int target = (int)glm::round(heightSum / weightSum);
+						if (target != myTop) {
+							targetArr[flatIdx] = target;
+						}
+					}
+				}
+			}
+		});
+
+		// Step 3: Apply height changes (sequential - mutates shared BitVolume/SparseVolume)
+		for (int a1 = 0; a1 < extent1; ++a1) {
+			for (int a2 = 0; a2 < extent2; ++a2) {
+				const int flatIdx = a1 * extent2 + a2;
+				const int target = targetArr[flatIdx];
+				if (target == EMPTY) {
+					continue;
+				}
+				const int currentTop = colTopArr[flatIdx];
+				const int currentBottom = colBotArr[flatIdx];
+				const int coord1 = base1 + a1;
+				const int coord2 = base2 + a2;
+
+				if ((positiveUp && target < currentTop) || (!positiveUp && target > currentTop)) {
+					// Trim from top down to target, but not below column bottom
+					const int trimLimit = positiveUp
+						? glm::max(target + 1, currentBottom)
+						: glm::min(target - 1, currentBottom);
+					for (int v = currentTop; v != trimLimit; v -= step) {
+						glm::ivec3 pos;
+						pos[axis1] = coord1;
+						pos[axis2] = coord2;
+						pos[axisIdx] = v;
+						if (solid.hasValue(pos.x, pos.y, pos.z)) {
+							solid.setVoxel(pos, false);
+							voxelMap.setVoxel(pos, voxel::Voxel());
+							anyChange = true;
+						}
+					}
+				} else if ((positiveUp && target > currentTop) || (!positiveUp && target < currentTop)) {
+					// Grow from current top up to target
+					for (int v = currentTop + step; v != target + step; v += step) {
+						glm::ivec3 pos;
+						pos[axis1] = coord1;
+						pos[axis2] = coord2;
+						pos[axisIdx] = v;
+						if (region.containsPoint(pos) && !solid.hasValue(pos.x, pos.y, pos.z)) {
+							solid.setVoxel(pos, true);
+							voxel::Voxel newVoxel = fillVoxel;
+							for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+								const glm::ivec3 neighbor = pos + offset;
+								if (voxelMap.hasVoxel(neighbor)) {
+									newVoxel = voxelMap.voxel(neighbor);
+									break;
+								}
+							}
+							voxelMap.setVoxel(pos, newVoxel);
+							anyChange = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (!anyChange) {
+			break;
+		}
+	}
+}
+
 // Helper to build solid, voxelMap, and anchor sets from a volume region
 static void buildFromVolume(const voxel::RawVolume &volume, const voxel::Region &region,
 							voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::BitVolume &anchors) {
@@ -760,6 +1058,34 @@ int sculptSmoothErode(voxel::RawVolume &volume, const voxel::Region &region, vox
 	voxel::BitVolume anchors(anchorRegion);
 	buildFromVolume(volume, region, solid, voxelMap, anchors);
 	sculptSmoothErode(solid, voxelMap, anchors, face, iterations, preserveTopHeight, trimPerStep);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptBridgeGap(voxel::RawVolume &volume, const voxel::Region &region,
+					const voxel::Voxel &fillVoxel) {
+	core_trace_scoped(SculptBridgeGapVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptBridgeGap(solid, voxelMap, anchors, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+						 int kernelSize, float sigma, int iterations, const voxel::Voxel &fillVoxel) {
+	core_trace_scoped(SculptSmoothGaussianVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptSmoothGaussian(solid, voxelMap, anchors, face, kernelSize, sigma, iterations, fillVoxel);
 	return writeResultToVolume(volume, region, solid, voxelMap);
 }
 

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -104,6 +104,43 @@ void sculptSmoothErode(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, c
 					   int trimPerStep = 1);
 
 /**
+ * @brief Bridge gap: connect boundary voxels by drawing 3D lines between them.
+ *
+ * Finds all boundary voxels (solid with at least one air face-neighbor) and draws
+ * 6-connected lines between every pair, filling air voxels along each line. This
+ * bridges gaps and cracks by connecting edges across openings. No face direction
+ * needed - works in full 3D.
+ *
+ * @param[in,out] solid BitVolume marking solid positions. New positions are set.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions that participate in boundary detection.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ */
+void sculptBridgeGap(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					 const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Smooth gaussian: blur the height map using a 2D Gaussian kernel along a face normal.
+ *
+ * The face defines "up". Builds a height map of all columns. For each iteration,
+ * computes a Gaussian-weighted average of neighbor column heights within the kernel
+ * radius. Columns taller than the target are trimmed, columns shorter are filled.
+ * Uses circular sampling (only neighbors within the kernel radius are included).
+ *
+ * @param[in,out] solid BitVolume marking solid positions. Modified to match blurred heights.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions included in height computation.
+ * @param face The face direction that defines "up".
+ * @param kernelSize Radius of the Gaussian kernel (1=3x3, 2=5x5, 3=7x7, 4=9x9).
+ * @param sigma Standard deviation of the Gaussian bell curve. Lower = sharper, higher = broader.
+ * @param iterations Number of blur passes.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ */
+void sculptSmoothGaussian(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+						  voxel::FaceNames face, int kernelSize, float sigma, int iterations,
+						  const voxel::Voxel &fillVoxel);
+
+/**
  * @brief Erode surface voxels in a volume region.
  *
  * Convenience wrapper that builds BitVolume/SparseVolume from all solid voxels in
@@ -144,5 +181,21 @@ int sculptSmoothAdditive(voxel::RawVolume &volume, const voxel::Region &region, 
  */
 int sculptSmoothErode(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face, int iterations,
 					  bool preserveTopHeight = false, int trimPerStep = 1);
+
+/**
+ * @brief Bridge gap on a volume region by drawing lines between boundary voxels.
+ *
+ * @return The number of voxels added.
+ */
+int sculptBridgeGap(voxel::RawVolume &volume, const voxel::Region &region,
+					const voxel::Voxel &fillVoxel);
+
+/**
+ * @brief Smooth gaussian on a volume region along a face normal.
+ *
+ * @return The number of voxels changed.
+ */
+int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+						 int kernelSize, float sigma, int iterations, const voxel::Voxel &fillVoxel);
 
 } // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -512,4 +512,178 @@ TEST_F(VolumeSculptTest, testSmoothErodePreserveTopHeightNoSinkBelowBottom) {
 	}
 }
 
+TEST_F(VolumeSculptTest, testSmoothGaussianLevelsColumns) {
+	// Two columns side by side: one is 4 tall, the other is 0 tall.
+	// Gaussian smoothing should bring the tall one down and fill the short one.
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Tall column at (3, 0..3, 3) - height 4
+	for (int y = 0; y <= 3; ++y) {
+		volume.setVoxel(3, y, 3, solid);
+	}
+	// Neighbor column at (4, 0, 3) - height 1
+	volume.setVoxel(4, 0, 3, solid);
+
+	const int before = countSolid(volume);
+	// kernelSize=1, sigma=1.0, 1 iteration
+	sculptSmoothGaussian(volume, region, voxel::FaceNames::PositiveY, 1, 1.0f, 1, fill);
+	// Heights should redistribute: total count may change but smoothing should occur
+	const int after = countSolid(volume);
+	EXPECT_NE(before, after);
+}
+
+TEST_F(VolumeSculptTest, testSmoothGaussianNoChangeWhenFlat) {
+	// A flat 3x3 surface at y=0 should not change under Gaussian smoothing
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+
+	const int before = countSolid(volume);
+	sculptSmoothGaussian(volume, region, voxel::FaceNames::PositiveY, 1, 1.0f, 3, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testSmoothGaussianMultipleIterations) {
+	// Spike on flat surface should be progressively smoothed
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// 5x5 flat base at y=0
+	for (int x = 1; x <= 5; ++x) {
+		for (int z = 1; z <= 5; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// Spike at center (3, 1..4, 3) - 4 voxels tall above base
+	for (int y = 1; y <= 4; ++y) {
+		volume.setVoxel(3, y, 3, solid);
+	}
+
+	// Multiple iterations should flatten the spike
+	sculptSmoothGaussian(volume, region, voxel::FaceNames::PositiveY, 2, 1.5f, 5, fill);
+	// The very top of the spike should be gone
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 4, 3).getMaterial()));
+	// Base should still be intact
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 3).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothGaussianLargerKernel) {
+	// With kernel size 2 (5x5), smoothing should be more aggressive
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// 5x5 flat base at y=0
+	for (int x = 1; x <= 5; ++x) {
+		for (int z = 1; z <= 5; ++z) {
+			volume.setVoxel(x, 0, z, solid);
+		}
+	}
+	// 3x3 tower at center (2..4, 1..3, 2..4)
+	for (int x = 2; x <= 4; ++x) {
+		for (int z = 2; z <= 4; ++z) {
+			for (int y = 1; y <= 3; ++y) {
+				volume.setVoxel(x, y, z, solid);
+			}
+		}
+	}
+
+	const int before = countSolid(volume);
+	// kernel=2, sigma=2.0, 3 iterations: should significantly smooth the step
+	sculptSmoothGaussian(volume, region, voxel::FaceNames::PositiveY, 2, 2.0f, 3, fill);
+	// Center base should still exist
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 3).getMaterial()));
+	// Smoothing should change the voxel count (may grow or shrink depending on geometry)
+	EXPECT_NE(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testBridgeGapFillsBetweenSurfaces) {
+	// Two solid blocks separated by a gap. Lines between boundary voxels fill it.
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Bottom block at y=1
+	volume.setVoxel(3, 1, 3, solid);
+	// Top block at y=5
+	volume.setVoxel(3, 5, 3, solid);
+
+	const int before = countSolid(volume);
+	sculptBridgeGap(volume, region, fill);
+	EXPECT_GT(countSolid(volume), before);
+	// Gap at y=2,3,4 should be filled
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 2, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 4, 3).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testBridgeGapNoChangeWhenSolid) {
+	// A solid column with no gaps should not change
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	for (int y = 1; y <= 3; ++y) {
+		volume.setVoxel(2, y, 2, solid);
+	}
+
+	const int before = countSolid(volume);
+	sculptBridgeGap(volume, region, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testBridgeGapTwoFlatSurfaces) {
+	// Two flat surfaces with a gap between them
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	// Bottom surface at y=1
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 1, z, solid);
+		}
+	}
+	// Top surface at y=4
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			volume.setVoxel(x, 4, z, solid);
+		}
+	}
+
+	sculptBridgeGap(volume, region, fill);
+	// Center columns should have y=2 and y=3 filled
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 3, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testBridgeGapSingleVoxelNoChange) {
+	// A single isolated voxel has no gap to bridge
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	const voxel::Voxel fill = voxel::createVoxel(voxel::VoxelType::Generic, 2);
+
+	volume.setVoxel(2, 2, 2, solid);
+	const int before = countSolid(volume);
+	sculptBridgeGap(volume, region, fill);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -26,12 +26,18 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "smootherode") {
 		return SculptMode::SmoothErode;
 	}
+	if (mode == "smoothgaussian") {
+		return SculptMode::SmoothGaussian;
+	}
+	if (mode == "bridgegap") {
+		return SculptMode::BridgeGap;
+	}
 	return SculptMode::Erode;
 }
 
 SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	_tool.set("description",
-			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode). "
+			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap). "
 			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting).");
 
 	json::Json inputSchema = json::Json::object();
@@ -49,13 +55,16 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	sculptModeProp.set("description",
 					   "The sculpt mode: 'erode' (remove surface voxels), 'grow' (add voxels to surface), "
 					   "'flatten' (flatten surface along a face), 'smoothadditive' (smooth by adding), "
-					   "'smootherode' (smooth by removing)");
+					   "'smootherode' (smooth by removing), 'smoothgaussian' (Gaussian height blur), "
+				   "'bridgegap' (connect boundary voxels with lines to bridge gaps)");
 	json::Json enumArr = json::Json::array();
 	enumArr.push("erode");
 	enumArr.push("grow");
 	enumArr.push("flatten");
 	enumArr.push("smoothadditive");
 	enumArr.push("smootherode");
+	enumArr.push("smoothgaussian");
+	enumArr.push("bridgegap");
 	sculptModeProp.set("enum", enumArr);
 	sculptModeProp.set("default", "erode");
 	properties.set("sculptMode", sculptModeProp);

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -55,7 +55,7 @@ static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"
 												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
 static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
 
-static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode")};
+static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"), NC_("Sculpt Modes", "Bridge Gap")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
@@ -1148,6 +1148,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 			const bool selected = mode == currentMode;
 			if (ImGui::Selectable(_(SculptModeStr[i]), selected)) {
 				brush.setSculptMode(mode);
+				executeSculptBrush();
 			}
 			if (selected) {
 				ImGui::SetItemDefaultFocus();
@@ -1156,7 +1157,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		ImGui::EndCombo();
 	}
 
-	const bool needsFace = currentMode == SculptMode::Flatten || currentMode == SculptMode::SmoothAdditive || currentMode == SculptMode::SmoothErode;
+	const bool needsFace = SculptBrush::modeNeedsFace(currentMode);
 	if (needsFace) {
 		const voxel::FaceNames flattenFace = brush.flattenFace();
 		if (flattenFace == voxel::FaceNames::Max) {
@@ -1197,7 +1198,29 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 				executeSculptBrush();
 			}
 		}
-	} else if (currentMode != SculptMode::Flatten) {
+	} else if (currentMode == SculptMode::SmoothGaussian) {
+		int kernelSize = brush.kernelSize();
+		ImGui::TextUnformatted(_("Kernel size"));
+		if (ImGui::Button("-##sculpt_kernel")) {
+			brush.setKernelSize(kernelSize - 1);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##sculpt_kernel_slider", &kernelSize, 1, SculptBrush::MaxKernelSize)) {
+			brush.setKernelSize(kernelSize);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##sculpt_kernel")) {
+			brush.setKernelSize(kernelSize + 1);
+			executeSculptBrush();
+		}
+		float sigma = brush.sigma();
+		if (ImGui::SliderFloat(_("Sigma"), &sigma, SculptBrush::MinSigma, SculptBrush::MaxSigma)) {
+			brush.setSigma(sigma);
+			executeSculptBrush();
+		}
+	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap) {
 		float strength = brush.strength();
 		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
 			brush.setStrength(strength);
@@ -1205,7 +1228,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		}
 	}
 
-	{
+	if (currentMode != SculptMode::BridgeGap) {
 		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
 		if (needsFace) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -45,6 +45,7 @@ void SculptBrush::reset() {
 	_sceneModifiedFlags = SceneModifiedFlags::All;
 	_active = false;
 	_hasSnapshot = false;
+	_paramsDirty = true;
 	_snapshot.clear();
 	_history.clear();
 	_snapshotRegion = voxel::Region::InvalidRegion;
@@ -56,6 +57,8 @@ void SculptBrush::reset() {
 	_heightThreshold = 1;
 	_preserveTopHeight = false;
 	_trimPerStep = 1;
+	_kernelSize = 4;
+	_sigma = 4.0f;
 	_sculptMode = SculptMode::Erode;
 	_flattenFace = voxel::FaceNames::Max;
 }
@@ -64,9 +67,10 @@ bool SculptBrush::beginBrush(const BrushContext &ctx) {
 	if (_active) {
 		return false;
 	}
-	const bool needsFace = _sculptMode == SculptMode::Flatten || _sculptMode == SculptMode::SmoothAdditive || _sculptMode == SculptMode::SmoothErode;
+	const bool needsFace = modeNeedsFace(_sculptMode);
 	if (needsFace && ctx.cursorFace != voxel::FaceNames::Max) {
 		_flattenFace = ctx.cursorFace;
+		_paramsDirty = true;
 	}
 	_active = true;
 	return true;
@@ -206,22 +210,35 @@ void SculptBrush::writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &p
 
 void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
 	core_trace_scoped(SculptBrushApplySculpt);
+
 	voxel::BitVolume currentSolid(_snapshotRegion);
 	voxel::SparseVolume voxelMap;
 
 	const glm::ivec3 &snapLo = _snapshotRegion.getLowerCorner();
 	const glm::ivec3 &snapHi = _snapshotRegion.getUpperCorner();
-	for (int z = snapLo.z; z <= snapHi.z; ++z) {
-		for (int y = snapLo.y; y <= snapHi.y; ++y) {
-			for (int x = snapLo.x; x <= snapHi.x; ++x) {
-				if (!_snapshot.hasVoxel(x, y, z)) {
-					continue;
-				}
-				currentSolid.setVoxel(x, y, z, true);
-				voxelMap.setVoxel(x, y, z, _snapshot.voxel(x, y, z));
-			}
+
+	// Collect snapshot entries: positions + voxels for reuse in write-back phase
+	struct SnapshotEntry {
+		glm::ivec3 pos;
+		voxel::Voxel voxel;
+	};
+	core::DynamicArray<SnapshotEntry> snapshotEntries;
+	snapshotEntries.reserve(_snapshot.size());
+
+	struct SnapshotLoader {
+		voxel::BitVolume *solid;
+		voxel::SparseVolume *voxelMap;
+		core::DynamicArray<SnapshotEntry> *entries;
+		bool setVoxel(int x, int y, int z, const voxel::Voxel &v) {
+			const glm::ivec3 pos(x, y, z);
+			solid->setVoxel(x, y, z, true);
+			voxelMap->setVoxel(pos, v);
+			entries->push_back({pos, v});
+			return true;
 		}
-	}
+	};
+	SnapshotLoader loader{&currentSolid, &voxelMap, &snapshotEntries};
+	_snapshot.copyTo(loader);
 
 	voxel::RawVolume *vol = wrapper.volume();
 	const voxel::Region &volRegion = vol->region();
@@ -254,6 +271,10 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 		}
 	}
 
+	// Save snapshot positions as a BitVolume before sculpt modifies currentSolid.
+	// Used later to distinguish original vs newly grown positions (O(1) bit test).
+	voxel::BitVolume snapshotSolid(currentSolid);
+
 	if (_sculptMode == SculptMode::Erode) {
 		voxelutil::sculptErode(currentSolid, voxelMap, anchorSolid, _strength, _iterations);
 	} else if (_sculptMode == SculptMode::Grow) {
@@ -270,32 +291,43 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 	} else if (_sculptMode == SculptMode::SmoothErode && _flattenFace != voxel::FaceNames::Max) {
 		voxelutil::sculptSmoothErode(currentSolid, voxelMap, anchorSolid, _flattenFace, _iterations, _preserveTopHeight,
 								_trimPerStep);
+	} else if (_sculptMode == SculptMode::SmoothGaussian && _flattenFace != voxel::FaceNames::Max) {
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		voxelutil::sculptSmoothGaussian(currentSolid, voxelMap, anchorSolid, _flattenFace, _kernelSize, _sigma,
+										_iterations, fillVoxel);
+	} else if (_sculptMode == SculptMode::BridgeGap) {
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		voxelutil::sculptBridgeGap(currentSolid, voxelMap, anchorSolid, fillVoxel);
 	}
 
-	// Write the result: remove voxels that were in snapshot but not in result,
-	// add voxels that are in result but not in snapshot
+	// Write results using the collected snapshot entries - no hash lookups needed.
+	// Snapshot entries have the original positions and colors. After sculpt,
+	// currentSolid tells us what survived (BitVolume, O(1) bit test).
 	const voxel::Voxel air;
 
-	// Remove snapshot voxels that were sculpted away
-	for (int z = snapLo.z; z <= snapHi.z; ++z) {
-		for (int y = snapLo.y; y <= snapHi.y; ++y) {
-			for (int x = snapLo.x; x <= snapHi.x; ++x) {
-				if (!_snapshot.hasVoxel(x, y, z)) {
-					continue;
-				}
-				const glm::ivec3 pos(x, y, z);
-				if (!currentSolid.hasValue(x, y, z)) {
-					writeVoxel(wrapper, pos, air);
-				}
-			}
+	// Pass 1: remove sculpted-away voxels + write surviving snapshot voxels
+	for (const SnapshotEntry &entry : snapshotEntries) {
+		if (!currentSolid.hasValue(entry.pos.x, entry.pos.y, entry.pos.z)) {
+			writeVoxel(wrapper, entry.pos, air);
+		} else {
+			voxel::Voxel v = entry.voxel;
+			v.setFlags(voxel::FlagOutline);
+			writeVoxel(wrapper, entry.pos, v);
 		}
 	}
 
-	// Write all solid voxels with FlagOutline
+	// Pass 2: write newly grown voxels (added by sculpt, not in original snapshot).
+	// Scan the bounding box with O(1) bit tests: currentSolid && !snapshotSolid.
+	// Only new positions need voxelMap hash lookup for color.
 	for (int z = snapLo.z; z <= snapHi.z; ++z) {
 		for (int y = snapLo.y; y <= snapHi.y; ++y) {
 			for (int x = snapLo.x; x <= snapHi.x; ++x) {
 				if (!currentSolid.hasValue(x, y, z)) {
+					continue;
+				}
+				if (snapshotSolid.hasValue(x, y, z)) {
 					continue;
 				}
 				const glm::ivec3 pos(x, y, z);
@@ -314,6 +346,10 @@ void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrap
 	if (!_hasSnapshot) {
 		return;
 	}
+	if (!_paramsDirty) {
+		return;
+	}
+	_paramsDirty = false;
 
 	voxel::RawVolume *vol = wrapper.volume();
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -20,6 +20,8 @@ enum class SculptMode : uint8_t {
 	Flatten,
 	SmoothAdditive,
 	SmoothErode,
+	SmoothGaussian,
+	BridgeGap,
 
 	Max
 };
@@ -43,9 +45,12 @@ private:
 	int _heightThreshold = 1;
 	bool _preserveTopHeight = false;
 	int _trimPerStep = 1;
+	int _kernelSize = 4;
+	float _sigma = 4.0f;
 	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
 	bool _active = false;
 	bool _hasSnapshot = false;
+	bool _paramsDirty = true;
 
 	// Original selected voxels captured at brush activation
 	voxel::SparseVolume _snapshot;
@@ -93,17 +98,25 @@ public:
 		return true;
 	}
 
+	static bool modeNeedsFace(SculptMode mode) {
+		return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode || mode == SculptMode::SmoothGaussian;
+	}
+
 	SculptMode sculptMode() const {
 		return _sculptMode;
 	}
 
 	void setSculptMode(SculptMode mode) {
-		const bool needsFace = mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode;
-		const bool hadFace = _sculptMode == SculptMode::Flatten || _sculptMode == SculptMode::SmoothAdditive || _sculptMode == SculptMode::SmoothErode;
+		const bool needsFace = modeNeedsFace(mode);
+		const bool hadFace = modeNeedsFace(_sculptMode);
 		if (needsFace && !hadFace) {
 			_flattenFace = voxel::FaceNames::Max;
 		}
+		if (mode == SculptMode::SmoothGaussian && _sculptMode != SculptMode::SmoothGaussian) {
+			_iterations = 3;
+		}
 		_sculptMode = mode;
+		_paramsDirty = true;
 	}
 
 	float strength() const {
@@ -112,6 +125,7 @@ public:
 
 	void setStrength(float strength) {
 		_strength = glm::clamp(strength, 0.0f, 1.0f);
+		_paramsDirty = true;
 	}
 
 	int iterations() const {
@@ -120,6 +134,7 @@ public:
 
 	void setIterations(int iterations) {
 		_iterations = glm::clamp(iterations, 1, MaxFlattenIterations);
+		_paramsDirty = true;
 	}
 
 	bool hasSnapshot() const {
@@ -138,6 +153,7 @@ public:
 
 	void setHeightThreshold(int threshold) {
 		_heightThreshold = glm::clamp(threshold, 1, MaxHeightThreshold);
+		_paramsDirty = true;
 	}
 
 	bool preserveTopHeight() const {
@@ -146,6 +162,7 @@ public:
 
 	void setPreserveTopHeight(bool preserve) {
 		_preserveTopHeight = preserve;
+		_paramsDirty = true;
 	}
 
 	static constexpr int MaxTrimPerStep = 16;
@@ -156,6 +173,30 @@ public:
 
 	void setTrimPerStep(int value) {
 		_trimPerStep = glm::clamp(value, 1, MaxTrimPerStep);
+		_paramsDirty = true;
+	}
+
+	static constexpr int MaxKernelSize = 7;
+
+	int kernelSize() const {
+		return _kernelSize;
+	}
+
+	void setKernelSize(int size) {
+		_kernelSize = glm::clamp(size, 1, MaxKernelSize);
+		_paramsDirty = true;
+	}
+
+	static constexpr float MaxSigma = 8.0f;
+	static constexpr float MinSigma = 0.1f;
+
+	float sigma() const {
+		return _sigma;
+	}
+
+	void setSigma(float sigma) {
+		_sigma = glm::clamp(sigma, MinSigma, MaxSigma);
+		_paramsDirty = true;
 	}
 };
 


### PR DESCRIPTION
## Summary
- **Smooth Gaussian**: blurs the height map using a 2D Gaussian kernel along a face normal. Configurable kernel size (1-7), sigma (0.1-8.0), and iterations. Uses flat 2D arrays and parallel convolution for performance on large selections
- **Bridge Gap**: connects boundary voxels (solid with air face-neighbor) by drawing 6-connected 3D lines between all pairs, filling air voxels along each path to bridge gaps and cracks

## Test plan
- [ ] Select voxels on a surface, switch to Sculpt > Smooth Gaussian, adjust kernel/sigma/iterations and verify height map smoothing
- [ ] Select edges on two separate surfaces, switch to Sculpt > Bridge Gap and verify gap is filled with connecting lines
- [ ] Run `tests-voxelutil` to verify 8 new unit tests pass (4 Gaussian, 4 BridgeGap)
- [ ] Verify Lua API: `g_sculpt.smoothgaussian()` and `g_sculpt.bridgegap()`
- [ ] Test with large selections (~256x256) to verify performance is acceptable