### PR TITLE
VOXEDIT: add brush apply/cancel and selection color commands

### DIFF
--- a/src/modules/voxelutil/VoxelUtil.cpp
+++ b/src/modules/voxelutil/VoxelUtil.cpp
@@ -496,4 +496,14 @@ voxel::RawVolume *diffVolumes(const voxel::RawVolume *v1, const voxel::RawVolume
 	return v;
 }
 
+void recolorSelected(voxel::RawVolumeWrapper &in, const voxel::RawVolume &volume, const voxel::Region &region,
+					 uint8_t colorIndex) {
+	voxelutil::visitVolume(volume, region, [&](int x, int y, int z, const voxel::Voxel &voxel) {
+		if ((voxel.getFlags() & voxel::FlagOutline) != 0 && voxel.getColor() != colorIndex) {
+			voxel::Voxel recolored = voxel::createVoxel(voxel.getMaterial(), colorIndex, voxel.getNormal(), voxel.getFlags(), voxel.getBoneIdx());
+			in.setVoxel(x, y, z, recolored);
+		}
+	}, voxelutil::VisitSolid(), voxelutil::VisitorOrder::ZYX);
+}
+
 } // namespace voxelutil

--- a/src/modules/voxelutil/VoxelUtil.h
+++ b/src/modules/voxelutil/VoxelUtil.h
@@ -118,6 +118,16 @@ void fill(voxel::RawVolumeWrapper &in, const voxel::Voxel &voxel, bool overwrite
 void clear(voxel::RawVolumeWrapper &in);
 
 /**
+ * @brief Recolor all selected (FlagOutline) voxels in the given region to the specified color index
+ * @param in The volume wrapper to modify
+ * @param volume The source volume to read voxels from
+ * @param region The region to scan for selected voxels
+ * @param colorIndex The new color index to apply
+ */
+void recolorSelected(voxel::RawVolumeWrapper &in, const voxel::RawVolume &volume, const voxel::Region &region,
+					 uint8_t colorIndex);
+
+/**
  * @brief Remaps or converts the voxel colors to the new given palette by searching for the closest color
  * @param skipColorIndex One particular palette color index that is not taken into account. This can be used to e.g.
  * search for replacements

--- a/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/MenuBar.cpp
@@ -169,6 +169,10 @@ bool MenuBar::update(ui::IMGUIApp *app, command::CommandExecutionListener &liste
 			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("Invert"), "select invert", true, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("All"), "select all", true, &listener);
 			ImGui::Separator();
+			ImGui::CommandIconMenuItem(ICON_LC_PAINTBRUSH, _("Color Selected"), "colorselected", true, &listener);
+			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("Deselect Color"), "deselectcolor", true, &listener);
+			ImGui::CommandIconMenuItem(ICON_LC_SCAN, _("Select Only Color"), "selectonlycolor", true, &listener);
+			ImGui::Separator();
 			ImGui::CheckboxVar(cfg::VoxEditAutoSelect);
 			ImGui::EndMenu();
 		}

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -330,6 +330,68 @@ void SceneManager::nodeGroupDeleteSelected() {
 	});
 }
 
+void SceneManager::nodeGroupColorSelected(uint8_t colorIndex) {
+	nodeForeachGroup([&](int groupNodeId) {
+		scenegraph::SceneGraphNode *node = sceneGraphModelNode(groupNodeId);
+		if (node == nullptr) {
+			return;
+		}
+		if (!node->hasSelection()) {
+			return;
+		}
+		voxel::RawVolume *v = node->volume();
+		if (v == nullptr) {
+			return;
+		}
+		const voxel::Region selRegion = selectionCalculateRegion(groupNodeId);
+		if (!selRegion.isValid()) {
+			return;
+		}
+		voxel::RawVolumeWrapper wrapper = _modifierFacade.createRawVolumeWrapper(v);
+		voxelutil::recolorSelected(wrapper, *v, selRegion, colorIndex);
+		modified(groupNodeId, wrapper.dirtyRegion());
+	});
+}
+
+void SceneManager::nodeGroupFilterSelection(uint8_t colorIndex, bool deselectMatching) {
+	nodeForeachGroup([&](int groupNodeId) {
+		scenegraph::SceneGraphNode *node = sceneGraphModelNode(groupNodeId);
+		if (node == nullptr) {
+			return;
+		}
+		if (!node->hasSelection()) {
+			return;
+		}
+		voxel::RawVolume *v = node->volume();
+		if (v == nullptr) {
+			return;
+		}
+		const voxel::Region selRegion = selectionCalculateRegion(groupNodeId);
+		if (!selRegion.isValid()) {
+			return;
+		}
+		voxelutil::visitVolume(*v, selRegion, [&](int x, int y, int z, const voxel::Voxel &voxel) {
+			const bool matches = voxel.getColor() == colorIndex;
+			if ((voxel.getFlags() & voxel::FlagOutline) != 0 && (matches == deselectMatching)) {
+				voxel::Voxel updated = voxel;
+				updated.setFlags(voxel.getFlags() & ~voxel::FlagOutline);
+				v->setVoxel(x, y, z, updated);
+			}
+		}, voxelutil::VisitSolid(), voxelutil::VisitorOrder::ZYX);
+		_selectionCacheNodeId = -1;
+		modified(groupNodeId, selRegion, SceneModifiedFlags::NoUndo);
+		_sceneRenderer->updateSelectionGizmo(selectionCalculateRegion(groupNodeId));
+	});
+}
+
+void SceneManager::nodeGroupDeselectColor(uint8_t colorIndex) {
+	nodeGroupFilterSelection(colorIndex, true);
+}
+
+void SceneManager::nodeGroupSelectOnlyColor(uint8_t colorIndex) {
+	nodeGroupFilterSelection(colorIndex, false);
+}
+
 void SceneManager::nodeGroupHollow() {
 	nodeForeachGroup([&](int groupNodeId) {
 		scenegraph::SceneGraphNode *node = sceneGraphModelNode(groupNodeId);
@@ -2826,6 +2888,11 @@ void SceneManager::construct() {
 			_modifierFacade.abort();
 		}).setHelp(_("Aborts the current modifier action"));
 
+	command::Command::registerCommand("brushapply")
+		.setHandler([&] (const command::CommandArgs& args) {
+			_modifierFacade.brushApply();
+		}).setHelp(_("Apply pending brush changes without switching brushes"));
+
 	command::Command::registerCommand("fillhollow")
 		.setHandler([&] (const command::CommandArgs& args) {
 			nodeGroupFillHollow();
@@ -2850,6 +2917,21 @@ void SceneManager::construct() {
 		.setHandler([&] (const command::CommandArgs& args) {
 			nodeGroupDeleteSelected();
 		}).setHelp(_("Remove selected voxels"));
+
+	command::Command::registerCommand("colorselected")
+		.setHandler([&] (const command::CommandArgs& args) {
+			nodeGroupColorSelected(_modifierFacade.cursorVoxel().getColor());
+		}).setHelp(_("Recolor selected voxels with the active palette color"));
+
+	command::Command::registerCommand("deselectcolor")
+		.setHandler([&] (const command::CommandArgs& args) {
+			nodeGroupDeselectColor(_modifierFacade.cursorVoxel().getColor());
+		}).setHelp(_("Deselect all voxels matching the active palette color"));
+
+	command::Command::registerCommand("selectonlycolor")
+		.setHandler([&] (const command::CommandArgs& args) {
+			nodeGroupSelectOnlyColor(_modifierFacade.cursorVoxel().getColor());
+		}).setHelp(_("Deselect all voxels not matching the active palette color"));
 
 	command::Command::registerCommand("setreferenceposition")
 		.addArg({"x", command::ArgType::Int, false, "", "X coordinate"})

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -192,6 +192,10 @@ protected:
 	void nodeGroupFill();
 	void nodeGroupClear();
 	void nodeGroupDeleteSelected();
+	void nodeGroupColorSelected(uint8_t colorIndex);
+	void nodeGroupFilterSelection(uint8_t colorIndex, bool deselectMatching);
+	void nodeGroupDeselectColor(uint8_t colorIndex);
+	void nodeGroupSelectOnlyColor(uint8_t colorIndex);
 	void nodeGroupRotate(math::Axis axis);
 	void nodeGroupFlip(math::Axis axis);
 	void nodeGroupResize(const glm::ivec3 &size);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -464,9 +464,56 @@ void Modifier::endBrush() {
 }
 
 void Modifier::abort() {
-	if (Brush* brush = currentBrush()) {
-		brush->abort(_brushContext);
+	Brush *brush = currentBrush();
+	if (!brush) {
+		return;
 	}
+	if (brush->hasPendingChanges()) {
+		_sceneMgr->nodeForeachGroup([&](int nodeId) {
+			scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId);
+			if (node == nullptr || !node->visible()) {
+				return;
+			}
+			voxel::RawVolume *volume = node->volume();
+			if (volume == nullptr) {
+				return;
+			}
+			const voxel::Region dirtyRegion = brush->revertChanges(volume);
+			if (dirtyRegion.isValid()) {
+				_sceneMgr->modified(nodeId, dirtyRegion, SceneModifiedFlags::NoUndo);
+			}
+		});
+		brush->reset();
+		brush->onActivated();
+		return;
+	}
+	brush->abort(_brushContext);
+}
+
+void Modifier::brushApply() {
+	Brush *brush = currentBrush();
+	if (!brush) {
+		return;
+	}
+	if (!brush->onDeactivated()) {
+		return;
+	}
+	if (beginBrushFromPanel()) {
+		_sceneMgr->nodeForeachGroup([&](int nodeId) {
+			if (scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphNode(nodeId)) {
+				if (!node->visible()) {
+					return;
+				}
+				auto callback = [&](const voxel::Region &region, ModifierType modType, SceneModifiedFlags flags) {
+					_sceneMgr->modified(nodeId, region, flags);
+				};
+				execute(_sceneMgr->sceneGraph(), *node, callback);
+			}
+		});
+		endBrush();
+	}
+	brush->reset();
+	brush->onActivated();
 }
 
 bool Modifier::modifierTypeRequiresExistingVoxel() const {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.h
@@ -214,6 +214,11 @@ public:
 	bool execute(scenegraph::SceneGraph &sceneGraph, scenegraph::SceneGraphNode &node,
 				 const ModifiedRegionCallback &callback = {});
 	void endBrush();
+	/**
+	 * @brief Apply pending brush changes without switching brushes.
+	 * Commits any accumulated state (e.g. sculpt iterations, extrude depth).
+	 */
+	void brushApply();
 	void abort();
 	/**
 	 * @brief Actions could get aborted by some external action like hitting esc

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
@@ -266,6 +266,14 @@ public:
 	}
 
 	/**
+	 * @brief Revert any NoUndo preview changes on the volume by restoring from
+	 * the brush's internal history. Returns the region that was modified.
+	 */
+	virtual voxel::Region revertChanges(voxel::RawVolume *volume) {
+		return voxel::Region::InvalidRegion;
+	}
+
+	/**
 	 * @brief Called when the scene has changed externally (e.g. via undo/redo)
 	 *
 	 * Brushes should override this to invalidate any cached state that depends
@@ -280,6 +288,14 @@ public:
 	 * @brief Called when this brush becomes the active brush.
 	 */
 	virtual void onActivated() {
+	}
+
+	/**
+	 * @brief Check if the brush has pending preview changes on the real volume
+	 * that have not been committed to the undo stack yet.
+	 */
+	virtual bool hasPendingChanges() const {
+		return false;
 	}
 
 	/**

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.cpp
@@ -28,9 +28,27 @@ void ExtrudeBrush::onActivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
+bool ExtrudeBrush::hasPendingChanges() const {
+	return _depth != 0 && _hasCachedSelection;
+}
+
 bool ExtrudeBrush::onDeactivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::All;
-	return _depth != 0 && _hasCachedSelection;
+	return hasPendingChanges();
+}
+
+voxel::Region ExtrudeBrush::revertChanges(voxel::RawVolume *volume) {
+	voxel::Region dirtyRegion = voxel::Region::InvalidRegion;
+	for (const voxel::VoxelPosition &entry : _history) {
+		volume->setVoxel(entry.pos, entry.voxel);
+		if (dirtyRegion.isValid()) {
+			dirtyRegion.accumulate(entry.pos);
+		} else {
+			dirtyRegion = voxel::Region(entry.pos, entry.pos);
+		}
+	}
+	_history.clear();
+	return dirtyRegion;
 }
 
 void ExtrudeBrush::reset() {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/ExtrudeBrush.h
@@ -80,7 +80,9 @@ public:
 	void onSceneChange() override;
 	void reset() override;
 	void onActivated() override;
+	bool hasPendingChanges() const override;
 	bool onDeactivated() override;
+	voxel::Region revertChanges(voxel::RawVolume *volume) override;
 	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -10,6 +10,7 @@
 #include "voxel/BitVolume.h"
 #include "voxel/Connectivity.h"
 #include "voxel/RawVolume.h"
+#include "voxel/RawVolumeWrapper.h"
 #include "voxel/Region.h"
 #include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
@@ -34,10 +35,21 @@ void SculptBrush::onActivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
+bool SculptBrush::hasPendingChanges() const {
+	return _hasSnapshot;
+}
+
+voxel::Region SculptBrush::revertChanges(voxel::RawVolume *volume) {
+	voxel::RawVolumeWrapper wrapper(volume);
+	_history.copyTo(wrapper);
+	_history.clear();
+	return wrapper.dirtyRegion();
+}
+
 bool SculptBrush::onDeactivated() {
 	// Restore undo registration so the final execute in setBrushType() records the undo entry
 	_sceneModifiedFlags = SceneModifiedFlags::All;
-	return _hasSnapshot;
+	return hasPendingChanges();
 }
 
 void SculptBrush::reset() {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -83,7 +83,9 @@ public:
 	void onSceneChange() override;
 	void reset() override;
 	void onActivated() override;
+	bool hasPendingChanges() const override;
 	bool onDeactivated() override;
+	voxel::Region revertChanges(voxel::RawVolume *volume) override;
 	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.cpp
@@ -9,6 +9,7 @@
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxel/DynamicVoxelArray.h"
 #include "voxel/RawVolume.h"
+#include "voxel/RawVolumeWrapper.h"
 #include "voxel/Region.h"
 #include "voxel/SparseVolume.h"
 #include "voxel/VolumeSampler.h"
@@ -45,9 +46,20 @@ void TransformBrush::onActivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
 }
 
+bool TransformBrush::hasPendingChanges() const {
+	return _hasSnapshot;
+}
+
+voxel::Region TransformBrush::revertChanges(voxel::RawVolume *volume) {
+	voxel::RawVolumeWrapper wrapper(volume);
+	_history.copyTo(wrapper);
+	_history.clear();
+	return wrapper.dirtyRegion();
+}
+
 bool TransformBrush::onDeactivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::All;
-	return _hasSnapshot;
+	return hasPendingChanges();
 }
 
 void TransformBrush::reset() {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/TransformBrush.h
@@ -96,7 +96,9 @@ public:
 	void onSceneChange() override;
 	void reset() override;
 	void onActivated() override;
+	bool hasPendingChanges() const override;
 	bool onDeactivated() override;
+	voxel::Region revertChanges(voxel::RawVolume *volume) override;
 	void preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) override;
 	bool beginBrush(const BrushContext &ctx) override;
 	void endBrush(BrushContext &ctx) override;

--- a/src/tools/voxedit/modules/voxedit-util/tests/AbstractSceneManagerTest.h
+++ b/src/tools/voxedit/modules/voxedit-util/tests/AbstractSceneManagerTest.h
@@ -62,6 +62,18 @@ public:
 		nodeGroupDeleteSelected();
 	}
 
+	void testColorSelected(uint8_t colorIndex) {
+		nodeGroupColorSelected(colorIndex);
+	}
+
+	void testDeselectColor(uint8_t colorIndex) {
+		nodeGroupDeselectColor(colorIndex);
+	}
+
+	void testSelectOnlyColor(uint8_t colorIndex) {
+		nodeGroupSelectOnlyColor(colorIndex);
+	}
+
 	void testFlip(math::Axis axis) {
 		nodeGroupFlip(axis);
 	}

--- a/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
@@ -1596,4 +1596,104 @@ TEST_F(SceneManagerTest, testRedoInvalidatesBrushState) {
 	EXPECT_FALSE(tb.active());
 }
 
+TEST_F(SceneManagerTest, testColorSelected) {
+	const voxel::Region region{0, 3};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "colorselected_test", region));
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+
+	const uint8_t originalColor = 1;
+	const uint8_t newColor = 5;
+	for (int x = 0; x <= 3; ++x) {
+		for (int y = 0; y <= 3; ++y) {
+			for (int z = 0; z <= 3; ++z) {
+				v->setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, originalColor));
+			}
+		}
+	}
+
+	// Select a sub-region
+	const voxel::Region selRegion{0, 1};
+	scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	ASSERT_NE(nullptr, node);
+	node->select(selRegion);
+
+	sceneMgr()->testColorSelected(newColor);
+
+	// Selected voxels should have new color
+	EXPECT_EQ(newColor, v->voxel(0, 0, 0).getColor());
+	EXPECT_EQ(newColor, v->voxel(1, 1, 1).getColor());
+	// Non-selected voxels should keep original color
+	EXPECT_EQ(originalColor, v->voxel(2, 2, 2).getColor());
+	EXPECT_EQ(originalColor, v->voxel(3, 3, 3).getColor());
+}
+
+TEST_F(SceneManagerTest, testColorSelectedNoSelection) {
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	ASSERT_TRUE(testSetVoxel(testMins(), 1));
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+	const uint8_t colorBefore = v->voxel(testMins()).getColor();
+
+	sceneMgr()->testColorSelected(5);
+	EXPECT_EQ(colorBefore, v->voxel(testMins()).getColor());
+}
+
+TEST_F(SceneManagerTest, testDeselectColor) {
+	const voxel::Region region{0, 3};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "deselectcolor_test", region));
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+
+	// Place voxels with two different colors
+	const uint8_t colorA = 1;
+	const uint8_t colorB = 2;
+	v->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorA));
+	v->setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorB));
+	v->setVoxel(2, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorA));
+
+	// Select all three
+	scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	ASSERT_NE(nullptr, node);
+	node->select(voxel::Region{glm::ivec3(0, 0, 0), glm::ivec3(2, 0, 0)});
+
+	// Deselect colorA
+	sceneMgr()->testDeselectColor(colorA);
+
+	// colorA voxels should no longer be selected
+	EXPECT_FALSE((v->voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+	EXPECT_FALSE((v->voxel(2, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+	// colorB voxel should still be selected
+	EXPECT_TRUE((v->voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+}
+
+TEST_F(SceneManagerTest, testSelectOnlyColor) {
+	const voxel::Region region{0, 3};
+	ASSERT_TRUE(_sceneMgr->newScene(true, "selectonlycolor_test", region));
+	const int nodeId = _sceneMgr->sceneGraph().activeNode();
+	voxel::RawVolume *v = _sceneMgr->volume(nodeId);
+	ASSERT_NE(nullptr, v);
+
+	const uint8_t colorA = 1;
+	const uint8_t colorB = 2;
+	v->setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorA));
+	v->setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorB));
+	v->setVoxel(2, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, colorA));
+
+	scenegraph::SceneGraphNode *node = _sceneMgr->sceneGraphModelNode(nodeId);
+	ASSERT_NE(nullptr, node);
+	node->select(voxel::Region{glm::ivec3(0, 0, 0), glm::ivec3(2, 0, 0)});
+
+	// Keep only colorA selected
+	sceneMgr()->testSelectOnlyColor(colorA);
+
+	// colorA voxels should still be selected
+	EXPECT_TRUE((v->voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+	EXPECT_TRUE((v->voxel(2, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+	// colorB voxel should be deselected
+	EXPECT_FALSE((v->voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0);
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- **`brushapply` command**: Commits pending NoUndo preview changes (Extrude, Sculpt, Transform) as a single undo entry without switching brushes. Bindable to Enter via `bind return "brushapply" model`
- **`abort` (ESC) fix**: Reverts pending preview changes by restoring from the brush's internal history instead of calling undo. Preserves selection state that was previously lost
- **`colorselected`**: Recolors all selected voxels with the active palette color
- **`deselectcolor`**: Deselects voxels matching the active palette color
- **`selectonlycolor`**: Deselects voxels not matching the active palette color
- New Mask menu items: "Color Selected", "Deselect Color", "Select Only Color" with tooltips
- Added `hasPendingChanges()` and `revertChanges()` virtual methods on Brush base class

## Test plan
- [ ] Extrude brush: adjust depth, press Enter (bound to brushapply) — commits and resets sliders
- [ ] Extrude brush: adjust depth, press ESC — reverts to pre-extrude state, selection preserved
- [ ] Same for Sculpt and Transform brushes
- [ ] ESC with no pending changes still works (cancels AABB selection)
- [ ] Select voxels with mixed colors, pick color in palette, Mask > Color Selected — recolors only selected voxels
- [ ] Mask > Deselect Color — deselects voxels matching palette color
- [ ] Mask > Select Only Color — keeps only matching color selected
- [ ] 4 new unit tests pass: `testColorSelected`, `testColorSelectedNoSelection`, `testDeselectColor`, `testSelectOnlyColor`