### PR TITLE
VOXEDIT: add Reskin sculpt mode for applying skin patterns onto surfaces

### DIFF
--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -2137,6 +2137,49 @@ static int luaVoxel_sculpt_squashtoplane(lua_State *s) {
 	return 1;
 }
 
+static int luaVoxel_sculpt_reskin(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	LuaRawVolumeWrapper *skinVolume = luaVoxel_tovolumewrapper(s, 2);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 3);
+	const char *modeStr = luaL_optstring(s, 4, "blend");
+	const char *followStr = luaL_optstring(s, 5, "voxel");
+	const int skinDepth = (int)luaL_optinteger(s, 6, 0);
+	const int surfaceOffset = (int)luaL_optinteger(s, 7, 0);
+	const char *skinUpStr = luaL_optstring(s, 8, "y");
+
+	voxelutil::ReskinConfig config;
+
+	if (core::string::iequals(modeStr, "replace")) {
+		config.mode = voxelutil::ReskinMode::Replace;
+	} else if (core::string::iequals(modeStr, "negate")) {
+		config.mode = voxelutil::ReskinMode::Negate;
+	} else {
+		config.mode = voxelutil::ReskinMode::Blend;
+	}
+
+	if (core::string::iequals(followStr, "none")) {
+		config.follow = voxelutil::ReskinFollow::None;
+	} else if (core::string::iequals(followStr, "median")) {
+		config.follow = voxelutil::ReskinFollow::Median;
+	} else {
+		config.follow = voxelutil::ReskinFollow::Voxel;
+	}
+
+	const math::Axis parsedAxis = math::toAxis(skinUpStr);
+	config.skinUpAxis = (parsedAxis != math::Axis::None) ? parsedAxis : math::Axis::Y;
+
+	const voxel::Region &skinRegion = skinVolume->volume()->region();
+	const int skinUpIdx = math::getIndexForAxis(config.skinUpAxis);
+	const int defaultDepth = skinRegion.getUpperCorner()[skinUpIdx] - skinRegion.getLowerCorner()[skinUpIdx] + 1;
+	config.skinDepth = skinDepth > 0 ? skinDepth : defaultDepth;
+	config.zOffset = surfaceOffset;
+
+	const int changed = voxelutil::sculptReskin(*volume->volume(), volume->volume()->region(),
+												*skinVolume->volume(), face, config);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
 static int luaVoxel_sculpt_squashtoplane_jsonhelp(lua_State *s) {
 	const char *json = R"({
 		"name": "squashtoplane",
@@ -2145,6 +2188,27 @@ static int luaVoxel_sculpt_squashtoplane_jsonhelp(lua_State *s) {
 			{"name": "volume", "type": "volume", "description": "The volume to squash."},
 			{"name": "face", "type": "string", "description": "Face direction defining the column axis: 'up', 'down', 'left', 'right', 'front', 'back'."},
 			{"name": "planeCoord", "type": "integer", "description": "The coordinate along the face axis where voxels are projected to."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static int luaVoxel_sculpt_reskin_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "reskin",
+		"summary": "Apply a skin volume (texture pattern) onto the selected surface. The skin tiles across the selection and can replace, blend, or carve voxels.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The target volume to reskin."},
+			{"name": "skin", "type": "volume", "description": "The skin volume providing the pattern."},
+			{"name": "face", "type": "string", "description": "Face direction defining surface normal: 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "mode", "type": "string", "description": "Reskin mode: 'replace' (skin overwrites, air removes), 'blend' (skin overwrites, air preserves), 'negate' (skin removes, air preserves) (optional, default 'blend')."},
+			{"name": "follow", "type": "string", "description": "Surface follow mode: 'none' (flat plane), 'median' (median height plane), 'voxel' (per-column) (optional, default 'voxel')."},
+			{"name": "skinDepth", "type": "integer", "description": "Number of skin layers to apply (optional, default: full skin depth along up axis)."},
+			{"name": "surfaceOffset", "type": "integer", "description": "Offset from surface: positive = above, negative = below (optional, default 0)."},
+			{"name": "skinUpAxis", "type": "string", "description": "Which skin axis is outward: 'x', 'y', 'z' (optional, default 'y')."}
 		],
 		"returns": [
 			{"type": "integer", "description": "Number of voxels changed."}
@@ -5987,6 +6051,7 @@ static void prepareState(lua_State* s) {
 		{"smoothgaussian", luaVoxel_sculpt_smoothgaussian, luaVoxel_sculpt_smoothgaussian_jsonhelp},
 		{"bridgegap", luaVoxel_sculpt_bridgegap, luaVoxel_sculpt_bridgegap_jsonhelp},
 		{"squashtoplane", luaVoxel_sculpt_squashtoplane, luaVoxel_sculpt_squashtoplane_jsonhelp},
+		{"reskin", luaVoxel_sculpt_reskin, luaVoxel_sculpt_reskin_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -17,6 +17,7 @@
 #include "voxel/Region.h"
 #include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
+#include "core/Algorithm.h"
 #include <cfloat>
 #include <climits>
 
@@ -970,6 +971,300 @@ void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap,
 	}
 }
 
+void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::RawVolume &skin,
+				  voxel::FaceNames face, const ReskinConfig &config) {
+	if (face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	core_trace_scoped(SculptReskin);
+
+	const voxel::Region &skinRegion = skin.region();
+	if (!skinRegion.isValid()) {
+		return;
+	}
+
+	// Determine which skin axis is the outward direction based on config
+	const int skinUpIdx = math::getIndexForAxis(config.skinUpAxis);
+	const int skinUIdx = (skinUpIdx + 1) % 3; // first tiling axis of skin
+	const int skinVIdx = (skinUpIdx + 2) % 3; // second tiling axis of skin
+
+	const glm::ivec3 &skinLo = skinRegion.getLowerCorner();
+	const glm::ivec3 &skinHi = skinRegion.getUpperCorner();
+	const int skinUExtent = skinHi[skinUIdx] - skinLo[skinUIdx] + 1; // tiling dim 1
+	const int skinVExtent = skinHi[skinVIdx] - skinLo[skinVIdx] + 1; // tiling dim 2
+	const int skinDExtent = skinHi[skinUpIdx] - skinLo[skinUpIdx] + 1; // depth dim
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const int perp1 = (axisIdx + 1) % 3; // U axis
+	const int perp2 = (axisIdx + 2) % 3; // V axis
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const int inwardStep = positiveUp ? -1 : 1;
+
+	const voxel::Region &selRegion = solid.region();
+	const glm::ivec3 &lo = selRegion.getLowerCorner();
+	const glm::ivec3 &hi = selRegion.getUpperCorner();
+
+	const int uMin = lo[perp1];
+	const int uMax = hi[perp1];
+	const int vMin = lo[perp2];
+	const int vMax = hi[perp2];
+	const int selW = uMax - uMin + 1;
+	const int selH = vMax - vMin + 1;
+
+	// Effective tile dimensions based on rotation
+	int tileW;
+	int tileH;
+	if (config.rotation == ReskinRotation::R0 || config.rotation == ReskinRotation::R180) {
+		tileW = skinUExtent;
+		tileH = skinVExtent;
+	} else {
+		tileW = skinVExtent;
+		tileH = skinUExtent;
+	}
+
+	// Build surface height map per (u,v) column
+	static constexpr int EMPTY = INT_MIN;
+	const int numCols = selW * selH;
+	core::DynamicArray<int> surfaceHeight(numCols);
+	for (int i = 0; i < numCols; ++i) {
+		surfaceHeight[i] = EMPTY;
+	}
+
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				if (!solid.hasValue(x, y, z)) {
+					continue;
+				}
+				const glm::ivec3 pos(x, y, z);
+				const int uCoord = pos[perp1];
+				const int vCoord = pos[perp2];
+				const int h = pos[axisIdx];
+				const int idx = (uCoord - uMin) * selH + (vCoord - vMin);
+				if (surfaceHeight[idx] == EMPTY) {
+					surfaceHeight[idx] = h;
+				} else if (positiveUp) {
+					surfaceHeight[idx] = glm::max(surfaceHeight[idx], h);
+				} else {
+					surfaceHeight[idx] = glm::min(surfaceHeight[idx], h);
+				}
+			}
+		}
+	}
+
+	// Compute reference height for None/Median modes
+	int referenceHeight = 0;
+	if (config.follow == ReskinFollow::None || config.follow == ReskinFollow::Median) {
+		core::DynamicArray<int> heights;
+		heights.reserve(numCols);
+		for (int i = 0; i < numCols; ++i) {
+			if (surfaceHeight[i] != EMPTY) {
+				heights.push_back(surfaceHeight[i]);
+			}
+		}
+		if (heights.empty()) {
+			return;
+		}
+
+		if (config.follow == ReskinFollow::None) {
+			referenceHeight = heights[0];
+			for (size_t i = 1; i < heights.size(); ++i) {
+				if (positiveUp) {
+					referenceHeight = glm::max(referenceHeight, heights[i]);
+				} else {
+					referenceHeight = glm::min(referenceHeight, heights[i]);
+				}
+			}
+		} else {
+			core::sort(heights.begin(), heights.end(), [](int a, int b) { return a < b; });
+			referenceHeight = heights[heights.size() / 2];
+		}
+	}
+
+	// Process each (u,v) column
+	const int maxDepth = glm::min(config.skinDepth, skinDExtent);
+	const voxel::Voxel air;
+
+	for (int uIdx = 0; uIdx < selW; ++uIdx) {
+		for (int vIdx = 0; vIdx < selH; ++vIdx) {
+			const int colIdx = uIdx * selH + vIdx;
+			if (surfaceHeight[colIdx] == EMPTY) {
+				continue;
+			}
+
+			const int uCoord = uMin + uIdx;
+			const int vCoord = vMin + vIdx;
+			const int surface = surfaceHeight[colIdx];
+
+			// Start height for skin application, with z offset
+			// Positive zOffset = outward (above surface), negative = inward (below surface)
+			const int outwardStep = -inwardStep;
+			int startHeight;
+			if (config.follow == ReskinFollow::Voxel) {
+				startHeight = surface + config.zOffset * outwardStep;
+			} else {
+				startHeight = referenceHeight + config.zOffset * outwardStep;
+			}
+
+			// Map (u,v) to skin coordinates
+			int localU;
+			int localV;
+			switch (config.anchor) {
+			case ReskinAnchor::MinMin:
+				localU = uIdx;
+				localV = vIdx;
+				break;
+			case ReskinAnchor::MinMax:
+				localU = uIdx;
+				localV = selH - 1 - vIdx;
+				break;
+			case ReskinAnchor::MaxMin:
+				localU = selW - 1 - uIdx;
+				localV = vIdx;
+				break;
+			case ReskinAnchor::MaxMax:
+				localU = selW - 1 - uIdx;
+				localV = selH - 1 - vIdx;
+				break;
+			default:
+				localU = uIdx;
+				localV = vIdx;
+				break;
+			}
+
+			// Apply offset (not for Stretch mode)
+			if (config.tile != ReskinTile::Stretch) {
+				localU += config.offsetU;
+				localV += config.offsetV;
+			}
+
+			// Apply tiling to get position in effective skin space [0, tileW) x [0, tileH)
+			int tU = 0;
+			int tV = 0;
+			bool skipColumn = false;
+			switch (config.tile) {
+			case ReskinTile::Once:
+				if (localU < 0 || localU >= tileW || localV < 0 || localV >= tileH) {
+					skipColumn = true;
+				}
+				tU = localU;
+				tV = localV;
+				break;
+			case ReskinTile::Repeat: {
+				tU = ((localU % tileW) + tileW) % tileW;
+				tV = ((localV % tileH) + tileH) % tileH;
+				if (config.mirrorU) {
+					const int tileIdxU = localU >= 0 ? localU / tileW : (localU - tileW + 1) / tileW;
+					if (glm::abs(tileIdxU) % 2 == 1) {
+						tU = tileW - 1 - tU;
+					}
+				}
+				if (config.mirrorV) {
+					const int tileIdxV = localV >= 0 ? localV / tileH : (localV - tileH + 1) / tileH;
+					if (glm::abs(tileIdxV) % 2 == 1) {
+						tV = tileH - 1 - tV;
+					}
+				}
+				break;
+			}
+			case ReskinTile::Stretch:
+				if (selW > 1) {
+					tU = localU * (tileW - 1) / (selW - 1);
+				}
+				if (selH > 1) {
+					tV = localV * (tileH - 1) / (selH - 1);
+				}
+				tU = glm::clamp(tU, 0, tileW - 1);
+				tV = glm::clamp(tV, 0, tileH - 1);
+				break;
+			default:
+				break;
+			}
+
+			if (skipColumn) {
+				continue;
+			}
+
+			// Apply rotation: tiled coords -> skin tiling plane offsets
+			// skinSU/skinSV are 0-based offsets along the skin's U and V axes
+			int skinSU;
+			int skinSV;
+			switch (config.rotation) {
+			case ReskinRotation::R0:
+				skinSU = tU;
+				skinSV = tV;
+				break;
+			case ReskinRotation::R90:
+				skinSU = skinUExtent - 1 - tV;
+				skinSV = tU;
+				break;
+			case ReskinRotation::R180:
+				skinSU = skinUExtent - 1 - tU;
+				skinSV = skinVExtent - 1 - tV;
+				break;
+			case ReskinRotation::R270:
+				skinSV = skinVExtent - 1 - tU;
+				skinSU = tV;
+				break;
+			default:
+				skinSU = tU;
+				skinSV = tV;
+				break;
+			}
+
+			// Step 3: Apply skin layers.
+			// Skin BASE sits at startHeight, layers grow OUTWARD from surface.
+			// d=0 = base of skin (skinLo along up axis), d=N = peak (skinHi along up axis).
+			for (int d = 0; d < maxDepth; ++d) {
+				glm::ivec3 worldPos;
+				worldPos[perp1] = uCoord;
+				worldPos[perp2] = vCoord;
+				worldPos[axisIdx] = startHeight + d * outwardStep;
+
+				// Build skin sample position using axis-independent indexing
+				glm::ivec3 skinPos;
+				skinPos[skinUIdx] = skinLo[skinUIdx] + skinSU;
+				skinPos[skinVIdx] = skinLo[skinVIdx] + skinSV;
+				skinPos[skinUpIdx] = skinLo[skinUpIdx] + d;
+				const voxel::Voxel skinVoxel = skin.voxel(skinPos.x, skinPos.y, skinPos.z);
+				const bool skinIsSolid = voxel::isBlocked(skinVoxel.getMaterial());
+				const bool effectiveSolid = config.invertSkin ? !skinIsSolid : skinIsSolid;
+
+				switch (config.mode) {
+				case ReskinMode::Replace:
+					if (effectiveSolid) {
+						voxel::Voxel v = skinVoxel;
+						v.setFlags(voxel::FlagOutline);
+						solid.setVoxel(worldPos, true);
+						voxelMap.setVoxel(worldPos, v);
+					} else {
+						solid.setVoxel(worldPos, false);
+						voxelMap.setVoxel(worldPos, air);
+					}
+					break;
+				case ReskinMode::Blend:
+					if (effectiveSolid) {
+						voxel::Voxel v = skinVoxel;
+						v.setFlags(voxel::FlagOutline);
+						solid.setVoxel(worldPos, true);
+						voxelMap.setVoxel(worldPos, v);
+					}
+					break;
+				case ReskinMode::Negate:
+					if (effectiveSolid) {
+						solid.setVoxel(worldPos, false);
+						voxelMap.setVoxel(worldPos, air);
+					}
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	}
+}
+
 // Helper to build solid, voxelMap, and anchor sets from a volume region
 static void buildFromVolume(const voxel::RawVolume &volume, const voxel::Region &region,
 							voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::BitVolume &anchors) {
@@ -1172,6 +1467,45 @@ int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, v
 	buildFromVolume(volume, region, solid, voxelMap, anchors);
 	sculptSquashToPlane(solid, voxelMap, face, planeCoord);
 	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptReskin(voxel::RawVolume &volume, const voxel::Region &region, const voxel::RawVolume &skin,
+				 voxel::FaceNames face, const ReskinConfig &config) {
+	core_trace_scoped(SculptReskinVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptReskin(solid, voxelMap, skin, face, config);
+
+	// Custom write-back that also handles color changes (not just add/remove)
+	int changed = 0;
+	const voxel::Voxel air;
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				const voxel::Voxel &current = volume.voxel(x, y, z);
+				const bool wasSolid = voxel::isBlocked(current.getMaterial());
+				const bool nowSolid = solid.hasValue(x, y, z);
+				if (wasSolid && !nowSolid) {
+					volume.setVoxel(x, y, z, air);
+					changed++;
+				} else if (nowSolid && voxelMap.hasVoxel(x, y, z)) {
+					const voxel::Voxel &newVoxel = voxelMap.voxel(x, y, z);
+					if (!wasSolid || current.getColor() != newVoxel.getColor()) {
+						volume.setVoxel(x, y, z, newVoxel);
+						changed++;
+					}
+				}
+			}
+		}
+	}
+	return changed;
 }
 
 } // namespace voxelutil

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include "math/Axis.h"
 #include "voxel/BitVolume.h"
 #include "voxel/Face.h"
 #include "voxel/SparseVolume.h"
+
+#include <stdint.h>
 
 namespace voxel {
 class RawVolume;
@@ -14,6 +17,69 @@ class Region;
 } // namespace voxel
 
 namespace voxelutil {
+
+enum class ReskinMode : uint8_t {
+	Replace, ///< Skin solid overwrites surface; skin air removes surface voxels
+	Blend,   ///< Skin solid overwrites surface; skin air preserves surface voxels
+	Negate,  ///< Skin solid removes surface voxels; skin air preserves surface voxels
+
+	Max
+};
+
+enum class ReskinFollow : uint8_t {
+	None,   ///< Flat plane at max/min surface height
+	Median, ///< Flat plane at median surface height
+	Voxel,  ///< Per-column surface following
+
+	Max
+};
+
+enum class ReskinAnchor : uint8_t {
+	MinMin, ///< UV origin at min-U, min-V corner
+	MinMax, ///< UV origin at min-U, max-V corner
+	MaxMin, ///< UV origin at max-U, min-V corner
+	MaxMax, ///< UV origin at max-U, max-V corner
+
+	Max
+};
+
+enum class ReskinRotation : uint8_t {
+	R0,   ///< No rotation
+	R90,  ///< 90 degrees clockwise
+	R180, ///< 180 degrees
+	R270, ///< 270 degrees clockwise
+
+	Max
+};
+
+enum class ReskinTile : uint8_t {
+	Once,    ///< Apply skin once, stop at skin boundary
+	Repeat,  ///< Tile across selection, with optional mirroring
+	Stretch, ///< Scale skin to fill selection UV extents
+
+	Max
+};
+
+/**
+ * @brief Configuration for the reskin sculpt operation.
+ */
+struct ReskinConfig {
+	ReskinMode mode = ReskinMode::Blend;
+	ReskinFollow follow = ReskinFollow::Voxel;
+	ReskinAnchor anchor = ReskinAnchor::MinMin;
+	ReskinRotation rotation = ReskinRotation::R0;
+	ReskinTile tile = ReskinTile::Repeat;
+	bool mirrorU = false;
+	bool mirrorV = false;
+	int offsetU = 0;
+	int offsetV = 0;
+	int skinDepth = 1;
+	/// Vertical offset: positive = skin floats above surface, negative = sinks below
+	int zOffset = 0;
+	bool invertSkin = false;
+	/// Which axis of the skin volume is the outward direction (default Y = natural up in editor)
+	math::Axis skinUpAxis = math::Axis::Y;
+};
 
 /**
  * @brief Erode surface voxels based on their solid face-neighbor count.
@@ -220,5 +286,34 @@ void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap,
  */
 int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
 						int planeCoord);
+
+/**
+ * @brief Reskin: apply a skin volume (texture pattern) onto the selected surface.
+ *
+ * The face defines the surface normal ("up"). The skin volume's +Z axis maps to the
+ * face normal direction. For each (U,V) column in the selection, the algorithm:
+ * 1. Finds the surface height along the face normal
+ * 2. Erodes erodeDepth layers inward from the surface
+ * 3. Applies skinDepth layers of the skin pattern from the original surface inward
+ *
+ * Tiling, rotation, mirroring, and anchor point control how the skin maps onto the
+ * selection's UV plane. ReskinMode controls how skin voxels interact with existing surface.
+ *
+ * @param[in,out] solid BitVolume marking solid positions.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] skin The skin volume to apply. Its +Z axis is treated as the surface normal.
+ * @param face The face direction that defines the surface normal.
+ * @param config Reskin configuration parameters.
+ */
+void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::RawVolume &skin,
+				  voxel::FaceNames face, const ReskinConfig &config);
+
+/**
+ * @brief Reskin on a volume region.
+ *
+ * @return The number of voxels changed.
+ */
+int sculptReskin(voxel::RawVolume &volume, const voxel::Region &region, const voxel::RawVolume &skin,
+				 voxel::FaceNames face, const ReskinConfig &config);
 
 } // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -770,4 +770,360 @@ TEST_F(VolumeSculptTest, testSquashToPlaneNegativeX) {
 	EXPECT_EQ(countSolid(volume), 9);
 }
 
+// --- Reskin tests ---
+
+TEST_F(VolumeSculptTest, testReskinBlendTiling) {
+	// 4x4 flat surface at y=0, 2x2 skin with two colors. Blend mode, Repeat tile.
+	// Skin should tile across the surface replacing colors.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 4x4 flat surface
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 2x2x1 skin: checkerboard pattern
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
+	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+
+	ReskinConfig config;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	config.skinUpAxis = math::Axis::Z;
+
+	const int changed = sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	EXPECT_GT(changed, 0);
+	// Verify tiling: (0,0) and (2,0) should have same color (period 2 in both axes)
+	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), volume.voxel(2, 0, 0).getColor());
+	EXPECT_EQ(volume.voxel(1, 0, 0).getColor(), volume.voxel(3, 0, 0).getColor());
+	// And the two should be different
+	EXPECT_NE(volume.voxel(0, 0, 0).getColor(), volume.voxel(1, 0, 0).getColor());
+	// All voxels still solid
+	EXPECT_EQ(countSolid(volume), 16);
+}
+
+TEST_F(VolumeSculptTest, testReskinBlendWithOffset) {
+	// Same 4x4 surface but with offset (1,1). The pattern should shift.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
+	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+
+	// First apply without offset
+	ReskinConfig config;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	const uint8_t colorAtOriginNoOffset = volume.voxel(0, 0, 0).getColor();
+
+	// Reset surface
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// Apply with offset
+	config.offsetU = 1;
+	config.offsetV = 1;
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	const uint8_t colorAtOriginWithOffset = volume.voxel(0, 0, 0).getColor();
+
+	// Offset should shift the pattern
+	EXPECT_NE(colorAtOriginNoOffset, colorAtOriginWithOffset);
+}
+
+TEST_F(VolumeSculptTest, testReskinNegateCarves) {
+	// Negate mode: skin solid voxels carve into the surface
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 4x4 flat surface
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 2x2x1 skin: only one voxel solid (at 0,0,0), rest air
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Negate;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+
+	const int before = countSolid(volume);
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Some voxels should be removed (where skin has solid at tiled positions)
+	EXPECT_LT(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testReskinReplaceRemovesWhereAir) {
+	// Replace mode: skin air voxels should remove surface voxels
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 2; ++x) {
+		for (int z = 0; z < 2; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 2x2x1 skin: only top-left is solid
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+	// (1,0,0), (0,1,0), (1,1,0) are air
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Replace;
+	config.tile = ReskinTile::Once;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Only 1 voxel should remain (where skin had solid)
+	EXPECT_EQ(countSolid(volume), 1);
+}
+
+TEST_F(VolumeSculptTest, testReskinFollowSurface) {
+	// Stepped surface: y=0 at x=0, y=1 at x=1. With Follow::Voxel, skin should follow the step.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Low step
+	volume.setVoxel(0, 0, 0, surface);
+	// High step
+	volume.setVoxel(1, 0, 0, surface);
+	volume.setVoxel(1, 1, 0, surface);
+
+	// 1x1x2 skin: 2 layers deep, both solid with different colors
+	voxel::Region skinRegion(0, 0, 0, 0, 0, 1);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 20)); // top layer
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 21)); // deeper layer
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 2;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Skin base (Z=0, color 21) placed at surface, peak (Z=1, color 20) one layer above.
+	// Low column surface at y=0: base goes to y=0
+	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), 21);
+	// High column surface at y=1: base goes to y=1
+	EXPECT_EQ(volume.voxel(1, 1, 0).getColor(), 21);
+	// High column y=0 is below the surface — not touched by skin, keeps original color
+	EXPECT_EQ(volume.voxel(1, 0, 0).getColor(), 1);
+}
+
+TEST_F(VolumeSculptTest, testReskinZOffsetNegative) {
+	// 4x4 surface 2 voxels thick. zOffset=-1 should apply skin one layer below surface.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 2-voxel thick floor
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+			volume.setVoxel(x, 1, z, surface);
+		}
+	}
+
+	// 1x1x1 solid skin
+	voxel::Region skinRegion(0, 0, 0, 0, 0, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 30));
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	config.zOffset = -1;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Surface is y=1. zOffset=-1 shifts down: skin applies at y=0.
+	// y=0 should have skin color (30)
+	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), 30);
+	// y=1 should keep original color (not touched by skin)
+	EXPECT_EQ(volume.voxel(0, 1, 0).getColor(), 1);
+	EXPECT_EQ(countSolid(volume), 32);
+}
+
+TEST_F(VolumeSculptTest, testReskinZOffsetPositive) {
+	// zOffset=+1 should apply skin one layer above the surface (floating).
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Single layer floor at y=0
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 1x1x1 solid skin
+	voxel::Region skinRegion(0, 0, 0, 0, 0, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 30));
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	config.zOffset = 1;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Surface is y=0. zOffset=+1 shifts up: skin applies at y=1 (above surface).
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 1, 0).getMaterial()));
+	EXPECT_EQ(volume.voxel(0, 1, 0).getColor(), 30);
+	// Original surface untouched
+	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), 1);
+}
+
+TEST_F(VolumeSculptTest, testReskinInvertSkin) {
+	// Invert: skin solid becomes "remove", skin air becomes "keep" (in Negate mode).
+	// Combined with invert: skin solid → keep, skin air → remove.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 2; ++x) {
+		for (int z = 0; z < 2; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 2x2x1 skin: only (0,0,0) is solid
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+
+	// Negate + Invert: where skin is solid → treated as air → keep. Where air → treated as solid → remove.
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Negate;
+	config.tile = ReskinTile::Once;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	config.invertSkin = true;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Position (0,0,0) had skin solid → inverted to air → Negate keeps it
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()));
+	// Position (1,0,0) had skin air → inverted to solid → Negate removes it
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 0, 0).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testReskinNoClipboardNoChange) {
+	// Empty skin volume should cause no changes
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// Empty skin (0-size region)
+	voxel::Region skinRegion(glm::ivec3(0), glm::ivec3(-1));
+	voxel::RawVolume skin(skinRegion);
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	const int before = countSolid(volume);
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	EXPECT_EQ(countSolid(volume), before);
+}
+
+TEST_F(VolumeSculptTest, testReskinStretchMode) {
+	// 4x4 surface with 2x2 skin in Stretch mode using BitVolume/SparseVolume API directly.
+	// PositiveY face: perp1=Z(U), perp2=X(V). 4x4 grid at Y=0.
+	voxel::Region selRegion(0, 0, 0, 3, 0, 3);
+	voxel::BitVolume solid(selRegion);
+	voxel::SparseVolume voxelMap;
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			solid.setVoxel(x, 0, z, true);
+			voxelMap.setVoxel(glm::ivec3(x, 0, z), surface);
+		}
+	}
+
+	// 2x2x1 skin: quadrants with different colors
+	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
+	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+
+	ReskinConfig config;
+	config.skinUpAxis = math::Axis::Z;
+	config.mode = ReskinMode::Blend;
+	config.tile = ReskinTile::Stretch;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+
+	sculptReskin(solid, voxelMap, skin, voxel::FaceNames::PositiveY, config);
+	// With PositiveY face: U=Z, V=X. Stretch maps V(X) 0..3 to skin V(Y) 0..1.
+	// Nearest-neighbor: X=0,1,2 -> skinV=0, X=3 -> skinV=1.
+	// Corner (X=0,Z=0) and corner (X=3,Z=3) should have different colors.
+	const voxel::Voxel v00 = voxelMap.voxel(glm::ivec3(0, 0, 0));
+	const voxel::Voxel v30 = voxelMap.voxel(glm::ivec3(3, 0, 0));
+	const voxel::Voxel v03 = voxelMap.voxel(glm::ivec3(0, 0, 3));
+	const voxel::Voxel v33 = voxelMap.voxel(glm::ivec3(3, 0, 3));
+	// X=0 and X=3 should differ (different V mapping)
+	EXPECT_NE(v00.getColor(), v30.getColor());
+	// Z=0 and Z=3 should differ (different U mapping)
+	EXPECT_NE(v00.getColor(), v03.getColor());
+	// Opposite corners should differ
+	EXPECT_NE(v00.getColor(), v33.getColor());
+}
+
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -8,6 +8,7 @@
 #include "voxedit-util/modifier/Modifier.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxedit-util/modifier/brush/SculptBrush.h"
+#include "voxel/ClipboardData.h"
 #include "voxel/Face.h"
 #include "voxel/RawVolume.h"
 
@@ -35,13 +36,17 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "squashtoplane") {
 		return SculptMode::SquashToPlane;
 	}
+	if (mode == "reskin") {
+		return SculptMode::Reskin;
+	}
 	return SculptMode::Erode;
 }
 
 SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	_tool.set("description",
-			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane). "
-			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting).");
+			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane, Reskin). "
+			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting). "
+			  "Reskin mode applies a skin pattern from the clipboard onto the selected surface.");
 
 	json::Json inputSchema = json::Json::object();
 	inputSchema.set("type", "object");
@@ -60,7 +65,8 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 					   "'flatten' (flatten surface along a face), 'smoothadditive' (smooth by adding), "
 					   "'smootherode' (smooth by removing), 'smoothgaussian' (Gaussian height blur), "
 				   "'bridgegap' (connect boundary voxels with lines to bridge gaps), "
-				   "'squashtoplane' (project all voxels onto the clicked plane)");
+				   "'squashtoplane' (project all voxels onto the clicked plane), "
+				   "'reskin' (apply skin pattern from clipboard onto surface)");
 	json::Json enumArr = json::Json::array();
 	enumArr.push("erode");
 	enumArr.push("grow");
@@ -70,6 +76,7 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	enumArr.push("smoothgaussian");
 	enumArr.push("bridgegap");
 	enumArr.push("squashtoplane");
+	enumArr.push("reskin");
 	sculptModeProp.set("enum", enumArr);
 	sculptModeProp.set("default", "erode");
 	properties.set("sculptMode", sculptModeProp);
@@ -156,6 +163,16 @@ bool SculptBrushTool::execute(const json::Json &id, const json::Json &args, Tool
 	sculptBrush.setSculptMode(sculptMode);
 	sculptBrush.setStrength(strength);
 	sculptBrush.setIterations(iterations);
+
+	// For Reskin mode, set up the skin volume from the global clipboard
+	if (sculptMode == SculptMode::Reskin) {
+		const voxel::ClipboardData &clip = ctx.sceneMgr->clipboardData();
+		if (clip && clip.volume != nullptr) {
+			sculptBrush.setSkinVolume(clip.volume);
+		} else {
+			return ctx.result(id, "Reskin mode requires voxels in the clipboard - copy voxels first", true);
+		}
+	}
 
 	// Begin and execute the brush
 	sculptBrush.beginBrush(brushContext);

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -10,6 +10,7 @@
 #include "command/Command.h"
 #include "command/CommandHandler.h"
 #include "core/Bits.h"
+#include "core/Log.h"
 #include "core/Enum.h"
 #include "core/StringUtil.h"
 #include "dearimgui/imgui_internal.h"
@@ -27,7 +28,11 @@
 #include "voxedit-util/modifier/brush/NormalBrush.h"
 #include "voxedit-util/modifier/brush/ShapeBrush.h"
 #include "math/Axis.h"
+#include "io/FilesystemArchive.h"
+#include "scenegraph/SceneGraph.h"
+#include "voxel/ClipboardData.h"
 #include "voxel/Face.h"
+#include "voxelformat/VolumeFormat.h"
 #include "voxedit-util/modifier/brush/ExtrudeBrush.h"
 #include "voxedit-util/modifier/brush/TransformBrush.h"
 #include "voxedit-util/modifier/brush/SculptBrush.h"
@@ -55,8 +60,26 @@ static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"
 												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
 static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
 
-static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"), NC_("Sculpt Modes", "Bridge Gap"), NC_("Sculpt Modes", "Squash to Plane")};
+static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"), NC_("Sculpt Modes", "Bridge Gap"), NC_("Sculpt Modes", "Squash to Plane"), NC_("Sculpt Modes", "Reskin")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
+
+static constexpr const char *ReskinModeStr[] = {NC_("Reskin Modes", "Replace"), NC_("Reskin Modes", "Blend"), NC_("Reskin Modes", "Negate")};
+static_assert(lengthof(ReskinModeStr) == (int)voxelutil::ReskinMode::Max, "ReskinModeStr size mismatch");
+
+static constexpr const char *ReskinFollowStr[] = {NC_("Reskin Follow", "None"), NC_("Reskin Follow", "Median"), NC_("Reskin Follow", "Voxel")};
+static_assert(lengthof(ReskinFollowStr) == (int)voxelutil::ReskinFollow::Max, "ReskinFollowStr size mismatch");
+
+static constexpr const char *ReskinAnchorStr[] = {NC_("Reskin Anchor", "Min/Min"), NC_("Reskin Anchor", "Min/Max"), NC_("Reskin Anchor", "Max/Min"), NC_("Reskin Anchor", "Max/Max")};
+static_assert(lengthof(ReskinAnchorStr) == (int)voxelutil::ReskinAnchor::Max, "ReskinAnchorStr size mismatch");
+
+static constexpr const char *ReskinRotationStr[] = {NC_("Reskin Rotation", "0"), NC_("Reskin Rotation", "90"), NC_("Reskin Rotation", "180"), NC_("Reskin Rotation", "270")};
+static_assert(lengthof(ReskinRotationStr) == (int)voxelutil::ReskinRotation::Max, "ReskinRotationStr size mismatch");
+
+static constexpr const char *ReskinTileStr[] = {NC_("Reskin Tile", "Once"), NC_("Reskin Tile", "Repeat"), NC_("Reskin Tile", "Stretch")};
+static_assert(lengthof(ReskinTileStr) == (int)voxelutil::ReskinTile::Max, "ReskinTileStr size mismatch");
+
+static constexpr const char *ReskinSkinAxisStr[] = {NC_("Reskin Skin Axis", "X"), NC_("Reskin Skin Axis", "Y"), NC_("Reskin Skin Axis", "Z")};
+static_assert(lengthof(ReskinSkinAxisStr) == 3, "ReskinSkinAxisStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
 												   NC_("Scale Sampling", "Cubic")};
@@ -1138,6 +1161,31 @@ void BrushPanel::executeSculptBrush() {
 	modifier.endBrush();
 }
 
+void BrushPanel::loadSkinFromFile(const core::String &filename) {
+	const io::ArchivePtr &archive = io::openFilesystemArchive(_app->filesystem());
+	scenegraph::SceneGraph sceneGraph;
+	voxelformat::LoadContext loadCtx;
+	io::FileDescription fileDesc;
+	fileDesc.set(filename);
+	if (!voxelformat::loadFormat(fileDesc, archive, sceneGraph, loadCtx)) {
+		Log::error("Failed to load skin file: %s", filename.c_str());
+		return;
+	}
+
+	scenegraph::SceneGraph::MergeResult merged = sceneGraph.merge();
+	// volume() transfers ownership (nullifies internal pointer)
+	voxel::RawVolume *volume = merged.volume();
+	if (volume == nullptr) {
+		Log::error("No model node found in skin file: %s", filename.c_str());
+		return;
+	}
+
+	Modifier &modifier = _sceneMgr->modifier();
+	SculptBrush &brush = modifier.sculptBrush();
+	brush.setOwnedSkinVolume(volume, filename);
+	executeSculptBrush();
+}
+
 void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &listener) {
 	Modifier &modifier = _sceneMgr->modifier();
 	SculptBrush &brush = modifier.sculptBrush();
@@ -1149,6 +1197,16 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 	}
 
 	const SculptMode currentMode = brush.sculptMode();
+
+	// Keep skin volume up to date for Reskin mode so it's ready when the user clicks a face.
+	// Only recompute the color remap when the clipboard volume pointer changes.
+	if (currentMode == SculptMode::Reskin) {
+		const voxel::ClipboardData &clip = _sceneMgr->clipboardData();
+		if (clip && clip.volume != nullptr && clip.volume != brush.skinVolume()) {
+			brush.setSkinVolume(clip.volume);
+		}
+	}
+
 	if (ImGui::BeginCombo(_("Sculpt mode"), _(SculptModeStr[(int)currentMode]), ImGuiComboFlags_None)) {
 		for (int i = 0; i < (int)SculptMode::Max; ++i) {
 			const SculptMode mode = (SculptMode)i;
@@ -1227,6 +1285,227 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 			brush.setSigma(sigma);
 			executeSculptBrush();
 		}
+	} else if (currentMode == SculptMode::Reskin) {
+		if (brush.skinVolume() == nullptr) {
+			const glm::vec4 &warningTextColor = style::color(style::StyleColor::ColorWarningText);
+			ImGui::TextColored(warningTextColor, "%s", _("Copy voxels to clipboard or load a skin file"));
+		}
+
+		// Load skin from file / Reload buttons
+		if (ImGui::Button(_("Load skin"))) {
+			_app->openDialog(
+				[this](const core::String &filename, const io::FormatDescription *) {
+					loadSkinFromFile(filename);
+				},
+				{}, voxelformat::voxelLoad());
+		}
+		const core::String &skinPath = brush.skinFilePath();
+		if (!skinPath.empty()) {
+			ImGui::SameLine();
+			if (ImGui::Button(_("Reload"))) {
+				loadSkinFromFile(skinPath);
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::SetTooltip("%s", skinPath.c_str());
+			}
+		}
+
+		const voxelutil::ReskinConfig &cfg = brush.reskinConfig();
+
+		// Skin up axis combo (which axis of the skin is outward)
+		{
+			static constexpr math::Axis skinAxisValues[] = {math::Axis::X, math::Axis::Y, math::Axis::Z};
+			const int currentAxisIdx = math::getIndexForAxis(cfg.skinUpAxis);
+			if (ImGui::BeginCombo(_("Skin up axis"), _(ReskinSkinAxisStr[currentAxisIdx]), ImGuiComboFlags_None)) {
+				for (int i = 0; i < 3; ++i) {
+					const bool selected = i == currentAxisIdx;
+					if (ImGui::Selectable(_(ReskinSkinAxisStr[i]), selected)) {
+						brush.setReskinSkinUpAxis(skinAxisValues[i]);
+						executeSculptBrush();
+					}
+					if (selected) {
+						ImGui::SetItemDefaultFocus();
+					}
+				}
+				ImGui::EndCombo();
+			}
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::SetTooltip("%s", _("Which axis of the skin points outward from the surface. "
+									  "Set to Y if your skin was built with the pattern facing up."));
+		}
+
+		// Reskin mode combo
+		if (ImGui::BeginCombo(_("Reskin mode"), _(ReskinModeStr[(int)cfg.mode]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::ReskinMode::Max; ++i) {
+				const bool selected = i == (int)cfg.mode;
+				if (ImGui::Selectable(_(ReskinModeStr[i]), selected)) {
+					brush.setReskinMode((voxelutil::ReskinMode)i);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		// Follow mode combo
+		if (ImGui::BeginCombo(_("Follow surface"), _(ReskinFollowStr[(int)cfg.follow]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::ReskinFollow::Max; ++i) {
+				const bool selected = i == (int)cfg.follow;
+				if (ImGui::Selectable(_(ReskinFollowStr[i]), selected)) {
+					brush.setReskinFollow((voxelutil::ReskinFollow)i);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		// Anchor combo
+		if (ImGui::BeginCombo(_("Anchor"), _(ReskinAnchorStr[(int)cfg.anchor]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::ReskinAnchor::Max; ++i) {
+				const bool selected = i == (int)cfg.anchor;
+				if (ImGui::Selectable(_(ReskinAnchorStr[i]), selected)) {
+					brush.setReskinAnchor((voxelutil::ReskinAnchor)i);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		// Rotation combo
+		if (ImGui::BeginCombo(_("Rotation"), _(ReskinRotationStr[(int)cfg.rotation]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::ReskinRotation::Max; ++i) {
+				const bool selected = i == (int)cfg.rotation;
+				if (ImGui::Selectable(_(ReskinRotationStr[i]), selected)) {
+					brush.setReskinRotation((voxelutil::ReskinRotation)i);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		// Tile mode combo
+		if (ImGui::BeginCombo(_("Tile"), _(ReskinTileStr[(int)cfg.tile]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::ReskinTile::Max; ++i) {
+				const bool selected = i == (int)cfg.tile;
+				if (ImGui::Selectable(_(ReskinTileStr[i]), selected)) {
+					brush.setReskinTile((voxelutil::ReskinTile)i);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		// Mirror checkboxes (only for Repeat tile mode)
+		if (cfg.tile == voxelutil::ReskinTile::Repeat) {
+			bool mirrorU = cfg.mirrorU;
+			if (ImGui::Checkbox(_("Mirror U"), &mirrorU)) {
+				brush.setReskinMirrorU(mirrorU);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			bool mirrorV = cfg.mirrorV;
+			if (ImGui::Checkbox(_("Mirror V"), &mirrorV)) {
+				brush.setReskinMirrorV(mirrorV);
+				executeSculptBrush();
+			}
+		}
+
+		// Offset sliders (not for Stretch)
+		if (cfg.tile != voxelutil::ReskinTile::Stretch) {
+			int offsetU = cfg.offsetU;
+			ImGui::TextUnformatted(_("Offset U"));
+			if (ImGui::Button("-##reskin_ou")) {
+				brush.setReskinOffsetU(offsetU - 1);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::SliderInt("##reskin_ou_slider", &offsetU, -32, 32)) {
+				brush.setReskinOffsetU(offsetU);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("+##reskin_ou")) {
+				brush.setReskinOffsetU(offsetU + 1);
+				executeSculptBrush();
+			}
+
+			int offsetV = cfg.offsetV;
+			ImGui::TextUnformatted(_("Offset V"));
+			if (ImGui::Button("-##reskin_ov")) {
+				brush.setReskinOffsetV(offsetV - 1);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::SliderInt("##reskin_ov_slider", &offsetV, -32, 32)) {
+				brush.setReskinOffsetV(offsetV);
+				executeSculptBrush();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("+##reskin_ov")) {
+				brush.setReskinOffsetV(offsetV + 1);
+				executeSculptBrush();
+			}
+		}
+
+		// Surface offset and skin depth
+		int surfaceOffset = cfg.zOffset;
+		ImGui::TextUnformatted(_("Surface offset"));
+		if (ImGui::Button("-##reskin_so")) {
+			brush.setReskinZOffset(surfaceOffset - 1);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##reskin_so_slider", &surfaceOffset, -SculptBrush::MaxReskinDepth, SculptBrush::MaxReskinDepth)) {
+			brush.setReskinZOffset(surfaceOffset);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##reskin_so")) {
+			brush.setReskinZOffset(surfaceOffset + 1);
+			executeSculptBrush();
+		}
+		if (ImGui::IsItemHovered()) {
+			ImGui::SetTooltip("%s", _("Positive = skin floats above surface, negative = sinks below"));
+		}
+
+		int skinDepth = cfg.skinDepth;
+		ImGui::TextUnformatted(_("Skin layers"));
+		if (ImGui::Button("-##reskin_sd")) {
+			brush.setReskinSkinDepth(skinDepth - 1);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##reskin_sd_slider", &skinDepth, 1, SculptBrush::MaxReskinDepth)) {
+			brush.setReskinSkinDepth(skinDepth);
+			executeSculptBrush();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##reskin_sd")) {
+			brush.setReskinSkinDepth(skinDepth + 1);
+			executeSculptBrush();
+		}
+
+		// Invert checkbox
+		bool invertSkin = cfg.invertSkin;
+		if (ImGui::Checkbox(_("Invert skin"), &invertSkin)) {
+			brush.setReskinInvertSkin(invertSkin);
+			executeSculptBrush();
+		}
 	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane) {
 		float strength = brush.strength();
 		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
@@ -1235,7 +1514,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		}
 	}
 
-	if (currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane) {
+	if (currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane && currentMode != SculptMode::Reskin) {
 		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
 		if (needsFace) {

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.h
@@ -67,6 +67,7 @@ private:
 	void executeTransformBrush();
 	void updateSculptBrushPanel(command::CommandExecutionListener &listener);
 	void executeSculptBrush();
+	void loadSkinFromFile(const core::String &filename);
 
 	void addBrushClampingOption(Brush &brush);
 	void aabbBrushOptions(command::CommandExecutionListener &listener, AABBBrush &brush);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -112,9 +112,15 @@ void SculptBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *vo
 		}
 	}
 	if (_hasSnapshot) {
-		// Expand by iterations since smoothing can grow surface by 1 voxel per iteration
 		_cachedRegion = _snapshotRegion;
-		_cachedRegion.grow(_iterations);
+		if (_sculptMode == SculptMode::Reskin) {
+			// Expand along face normal for z offset + skin layers growing outward
+			const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
+			_cachedRegion.grow(expand);
+		} else {
+			// Expand by iterations since smoothing can grow surface by 1 voxel per iteration
+			_cachedRegion.grow(_iterations);
+		}
 		_cachedRegionValid = true;
 	}
 }
@@ -216,7 +222,24 @@ void SculptBrush::writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &p
 void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
 	core_trace_scoped(SculptBrushApplySculpt);
 
-	voxel::BitVolume currentSolid(_snapshotRegion);
+	// For Reskin mode, expand the working region along the face normal to accommodate
+	// the z offset and skin layers growing outward from the surface.
+	voxel::Region workRegion = _snapshotRegion;
+	if (_sculptMode == SculptMode::Reskin && _flattenFace != voxel::FaceNames::Max) {
+		const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
+		const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
+		glm::ivec3 lo = workRegion.getLowerCorner();
+		glm::ivec3 hi = workRegion.getUpperCorner();
+		lo[axisIdx] -= expand;
+		hi[axisIdx] += expand;
+		// Clamp to volume bounds
+		const voxel::Region &volRegion = wrapper.volume()->region();
+		lo = glm::max(lo, volRegion.getLowerCorner());
+		hi = glm::min(hi, volRegion.getUpperCorner());
+		workRegion = voxel::Region(lo, hi);
+	}
+
+	voxel::BitVolume currentSolid(workRegion);
 	voxel::SparseVolume voxelMap;
 
 	const glm::ivec3 &snapLo = _snapshotRegion.getLowerCorner();
@@ -303,6 +326,8 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 		voxelutil::sculptBridgeGap(currentSolid, voxelMap, anchorSolid, fillVoxel);
 	} else if (_sculptMode == SculptMode::SquashToPlane && _flattenFace != voxel::FaceNames::Max) {
 		voxelutil::sculptSquashToPlane(currentSolid, voxelMap, _flattenFace, _squashPlaneCoord);
+	} else if (_sculptMode == SculptMode::Reskin && _skinVolume != nullptr && _flattenFace != voxel::FaceNames::Max) {
+		voxelutil::sculptReskin(currentSolid, voxelMap, *_skinVolume, _flattenFace, _reskinConfig);
 	}
 
 	// Write results using the collected snapshot entries - no hash lookups needed.
@@ -310,10 +335,16 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 	// currentSolid tells us what survived (BitVolume, O(1) bit test).
 	const voxel::Voxel air;
 
-	// Pass 1: remove sculpted-away voxels + write surviving snapshot voxels
+	// Pass 1: remove sculpted-away voxels + write surviving snapshot voxels.
+	// Read from voxelMap (not snapshot) so color changes from reskin are applied.
+	// For non-reskin modes, voxelMap entries match the snapshot for surviving positions.
 	for (const voxel::VoxelPosition &entry : snapshotEntries) {
 		if (!currentSolid.hasValue(entry.pos.x, entry.pos.y, entry.pos.z)) {
 			writeVoxel(wrapper, entry.pos, air);
+		} else if (voxelMap.hasVoxel(entry.pos)) {
+			voxel::Voxel v = voxelMap.voxel(entry.pos);
+			v.setFlags(voxel::FlagOutline);
+			writeVoxel(wrapper, entry.pos, v);
 		} else {
 			voxel::Voxel v = entry.voxel;
 			v.setFlags(voxel::FlagOutline);
@@ -322,11 +353,13 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 	}
 
 	// Pass 2: write newly grown voxels (added by sculpt, not in original snapshot).
-	// Scan the bounding box with O(1) bit tests: currentSolid && !snapshotSolid.
+	// Scan the working region (may be expanded for reskin) with O(1) bit tests.
 	// Only new positions need voxelMap hash lookup for color.
-	for (int z = snapLo.z; z <= snapHi.z; ++z) {
-		for (int y = snapLo.y; y <= snapHi.y; ++y) {
-			for (int x = snapLo.x; x <= snapHi.x; ++x) {
+	const glm::ivec3 &workLo = workRegion.getLowerCorner();
+	const glm::ivec3 &workHi = workRegion.getUpperCorner();
+	for (int z = workLo.z; z <= workHi.z; ++z) {
+		for (int y = workLo.y; y <= workHi.y; ++y) {
+			for (int x = workLo.x; x <= workHi.x; ++x) {
 				if (!currentSolid.hasValue(x, y, z)) {
 					continue;
 				}

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -6,11 +6,18 @@
 
 #include "Brush.h"
 #include "core/GLM.h"
+#include "core/ScopedPtr.h"
+#include "core/String.h"
 #include "voxel/Face.h"
 #include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
+#include "voxelutil/VolumeSculpt.h"
 
 #include <glm/vec3.hpp>
+
+namespace voxel {
+class RawVolume;
+}
 
 namespace voxedit {
 
@@ -23,6 +30,7 @@ enum class SculptMode : uint8_t {
 	SmoothGaussian,
 	BridgeGap,
 	SquashToPlane,
+	Reskin,
 
 	Max
 };
@@ -53,6 +61,12 @@ private:
 	bool _active = false;
 	bool _hasSnapshot = false;
 	bool _paramsDirty = true;
+
+	// Reskin parameters
+	voxelutil::ReskinConfig _reskinConfig;
+	const voxel::RawVolume *_skinVolume = nullptr;
+	core::ScopedPtr<voxel::RawVolume> _ownedSkinVolume;
+	core::String _skinFilePath;
 
 	// Original selected voxels captured at brush activation
 	voxel::SparseVolume _snapshot;
@@ -103,7 +117,7 @@ public:
 	}
 
 	static bool modeNeedsFace(SculptMode mode) {
-		return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode || mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane;
+		return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode || mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane || mode == SculptMode::Reskin;
 	}
 
 	SculptMode sculptMode() const {
@@ -201,6 +215,115 @@ public:
 	void setSigma(float sigma) {
 		_sigma = glm::clamp(sigma, MinSigma, MaxSigma);
 		_paramsDirty = true;
+	}
+
+	// Reskin accessors
+	static constexpr int MaxReskinDepth = 32;
+
+	const voxelutil::ReskinConfig &reskinConfig() const {
+		return _reskinConfig;
+	}
+
+	void setReskinMode(voxelutil::ReskinMode mode) {
+		_reskinConfig.mode = mode;
+		_paramsDirty = true;
+	}
+
+	void setReskinFollow(voxelutil::ReskinFollow follow) {
+		_reskinConfig.follow = follow;
+		_paramsDirty = true;
+	}
+
+	void setReskinAnchor(voxelutil::ReskinAnchor anchor) {
+		_reskinConfig.anchor = anchor;
+		_paramsDirty = true;
+	}
+
+	void setReskinRotation(voxelutil::ReskinRotation rotation) {
+		_reskinConfig.rotation = rotation;
+		_paramsDirty = true;
+	}
+
+	void setReskinTile(voxelutil::ReskinTile tile) {
+		_reskinConfig.tile = tile;
+		_paramsDirty = true;
+	}
+
+	void setReskinMirrorU(bool mirror) {
+		_reskinConfig.mirrorU = mirror;
+		_paramsDirty = true;
+	}
+
+	void setReskinMirrorV(bool mirror) {
+		_reskinConfig.mirrorV = mirror;
+		_paramsDirty = true;
+	}
+
+	void setReskinOffsetU(int offset) {
+		_reskinConfig.offsetU = offset;
+		_paramsDirty = true;
+	}
+
+	void setReskinOffsetV(int offset) {
+		_reskinConfig.offsetV = offset;
+		_paramsDirty = true;
+	}
+
+	void setReskinSkinDepth(int depth) {
+		_reskinConfig.skinDepth = glm::clamp(depth, 1, MaxReskinDepth);
+		_paramsDirty = true;
+	}
+
+	void setReskinZOffset(int offset) {
+		_reskinConfig.zOffset = glm::clamp(offset, -MaxReskinDepth, MaxReskinDepth);
+		_paramsDirty = true;
+	}
+
+	void setReskinInvertSkin(bool invert) {
+		_reskinConfig.invertSkin = invert;
+		_paramsDirty = true;
+	}
+
+	void setReskinSkinUpAxis(math::Axis axis) {
+		_reskinConfig.skinUpAxis = axis;
+		// Re-populate skin depth for the new axis
+		if (_skinVolume != nullptr) {
+			setSkinVolume(_skinVolume);
+		}
+		_paramsDirty = true;
+	}
+
+	/**
+	 * @brief Set the skin volume for reskin mode.
+	 * @param skinVolume The skin volume to apply (not owned, must outlive the brush operation).
+	 */
+	void setSkinVolume(const voxel::RawVolume *skinVolume) {
+		_skinVolume = skinVolume;
+		// Auto-populate skin depth from the skin volume's depth along the configured up axis
+		if (skinVolume != nullptr) {
+			const voxel::Region &sr = skinVolume->region();
+			const int upIdx = math::getIndexForAxis(_reskinConfig.skinUpAxis);
+			const int depthExtent = sr.getUpperCorner()[upIdx] - sr.getLowerCorner()[upIdx] + 1;
+			_reskinConfig.skinDepth = glm::clamp(depthExtent, 1, MaxReskinDepth);
+		}
+		_paramsDirty = true;
+	}
+
+	/**
+	 * @brief Set an owned skin volume loaded from a file. The brush takes ownership.
+	 */
+	void setOwnedSkinVolume(voxel::RawVolume *skinVolume, const core::String &filePath) {
+		_ownedSkinVolume = skinVolume;
+		_skinFilePath = filePath;
+		setSkinVolume(skinVolume);
+	}
+
+	const voxel::RawVolume *skinVolume() const {
+		return _skinVolume;
+	}
+
+	const core::String &skinFilePath() const {
+		return _skinFilePath;
 	}
 };
 


### PR DESCRIPTION
## Summary

- New **Reskin** sculpt mode that applies a 3D skin volume (texture pattern) onto a selected surface with tiling, rotation, and surface following
- Skin source: global clipboard or loaded from any supported voxel file (Load/Reload buttons in panel)
- Three application modes: **Replace** (skin overwrites, air removes), **Blend** (skin overwrites, air preserves), **Negate** (skin carves, air preserves)
- Tiling: Once (single stamp), Repeat (with optional mirror U/V), Stretch (scale to fit)
- Configurable: skin up axis (X/Y/Z), anchor corner, 4-way rotation, UV offsets, surface offset (float above/sink below), skin layers count
- Surface following: None (flat plane), Median (statistical center), Voxel (per-column contour)
- Invert skin option swaps solid/air interpretation
- Lua API: `g_sculpt.reskin(volume, skin, face, mode, follow, skinDepth, surfaceOffset, skinUpAxis)`
- MCP integration: `reskin` added to `voxedit_sculpt_brush` tool
- 10 unit tests covering tiling, offset, negate, replace, follow surface, z offset, invert, empty skin, stretch

## Test plan

- [ ] Select a region on a flat surface, copy a small pattern to clipboard, switch to Sculpt > Reskin, click a face, verify tiling
- [ ] Test Blend vs Replace vs Negate modes
- [ ] Test Load skin from file button and Reload
- [ ] Test surface offset slider (positive = float, negative = sink)
- [ ] Test skin up axis selector (Y for Y-up skins, Z for Z-up)
- [ ] Test on a sloped/stepped surface with Follow Surface = Voxel
- [ ] Test stretch and mirror tiling modes
- [ ] Verify no crash with empty clipboard and no skin loaded