### PR TITLE
VOXEDIT: add SquashToPlane sculpt mode to project voxels onto a clicked plane

### DIFF
--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -2128,6 +2128,31 @@ static int luaVoxel_sculpt_bridgegap_jsonhelp(lua_State *s) {
 	return 1;
 }
 
+static int luaVoxel_sculpt_squashtoplane(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int planeCoord = (int)luaL_checkinteger(s, 3);
+	const int changed = voxelutil::sculptSquashToPlane(*volume->volume(), volume->volume()->region(), face, planeCoord);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_squashtoplane_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "squashtoplane",
+		"summary": "Project all solid voxels onto a single plane. For each column along the face normal, if any voxel exists, one is placed at the plane coordinate. All others are removed.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to squash."},
+			{"name": "face", "type": "string", "description": "Face direction defining the column axis: 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "planeCoord", "type": "integer", "description": "The coordinate along the face axis where voxels are projected to."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
 static int luaVoxel_sculpt_smoothgaussian(lua_State *s) {
 	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
 	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
@@ -5961,6 +5986,7 @@ static void prepareState(lua_State* s) {
 		{"smootherode", luaVoxel_sculpt_smootherode, luaVoxel_sculpt_smootherode_jsonhelp},
 		{"smoothgaussian", luaVoxel_sculpt_smoothgaussian, luaVoxel_sculpt_smoothgaussian_jsonhelp},
 		{"bridgegap", luaVoxel_sculpt_bridgegap, luaVoxel_sculpt_bridgegap_jsonhelp},
+		{"squashtoplane", luaVoxel_sculpt_squashtoplane, luaVoxel_sculpt_squashtoplane_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -899,6 +899,77 @@ void sculptSmoothGaussian(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap
 	}
 }
 
+void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face,
+						 int planeCoord) {
+	if (face == voxel::FaceNames::Max) {
+		return;
+	}
+
+	core_trace_scoped(SculptSquashToPlane);
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const int perp1 = (axisIdx + 1) % 3;
+	const int perp2 = (axisIdx + 2) % 3;
+
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	// For each (perp1, perp2) column, find if any solid voxel exists and pick
+	// the color from the voxel nearest to the plane coordinate.
+	for (int a1 = lo[perp1]; a1 <= hi[perp1]; ++a1) {
+		for (int a2 = lo[perp2]; a2 <= hi[perp2]; ++a2) {
+			bool hasAnySolid = false;
+			int bestDist = INT_MAX;
+			voxel::Voxel bestVoxel;
+
+			// Scan the column to find the nearest solid voxel to the plane
+			for (int av = lo[axisIdx]; av <= hi[axisIdx]; ++av) {
+				glm::ivec3 pos;
+				pos[axisIdx] = av;
+				pos[perp1] = a1;
+				pos[perp2] = a2;
+				if (!solid.hasValue(pos.x, pos.y, pos.z)) {
+					continue;
+				}
+				hasAnySolid = true;
+				const int dist = glm::abs(av - planeCoord);
+				if (dist < bestDist && voxelMap.hasVoxel(pos)) {
+					bestDist = dist;
+					bestVoxel = voxelMap.voxel(pos);
+				}
+			}
+
+			if (!hasAnySolid) {
+				continue;
+			}
+
+			// Clear all voxels in the column
+			for (int av = lo[axisIdx]; av <= hi[axisIdx]; ++av) {
+				glm::ivec3 pos;
+				pos[axisIdx] = av;
+				pos[perp1] = a1;
+				pos[perp2] = a2;
+				if (solid.hasValue(pos.x, pos.y, pos.z)) {
+					solid.setVoxel(pos, false);
+					voxelMap.setVoxel(pos, voxel::Voxel());
+				}
+			}
+
+			// Place the single voxel at the plane coordinate
+			glm::ivec3 planePos;
+			planePos[axisIdx] = planeCoord;
+			planePos[perp1] = a1;
+			planePos[perp2] = a2;
+			if (region.containsPoint(planePos)) {
+				bestVoxel.setFlags(voxel::FlagOutline);
+				solid.setVoxel(planePos, true);
+				voxelMap.setVoxel(planePos, bestVoxel);
+			}
+		}
+	}
+}
+
 // Helper to build solid, voxelMap, and anchor sets from a volume region
 static void buildFromVolume(const voxel::RawVolume &volume, const voxel::Region &region,
 							voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::BitVolume &anchors) {
@@ -1086,6 +1157,20 @@ int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, 
 	voxel::BitVolume anchors(anchorRegion);
 	buildFromVolume(volume, region, solid, voxelMap, anchors);
 	sculptSmoothGaussian(solid, voxelMap, anchors, face, kernelSize, sigma, iterations, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+					   int planeCoord) {
+	core_trace_scoped(SculptSquashToPlaneVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptSquashToPlane(solid, voxelMap, face, planeCoord);
 	return writeResultToVolume(volume, region, solid, voxelMap);
 }
 

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -198,4 +198,27 @@ int sculptBridgeGap(voxel::RawVolume &volume, const voxel::Region &region,
 int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
 						 int kernelSize, float sigma, int iterations, const voxel::Voxel &fillVoxel);
 
+/**
+ * @brief Squash all selected voxels onto a single plane.
+ *
+ * Projects all solid voxels along the face normal axis onto the specified plane coordinate.
+ * For each column: if any solid voxel exists, place one at the plane coordinate using the
+ * color of the voxel nearest to the plane. All other voxels in the column are removed.
+ *
+ * @param[in,out] solid BitVolume marking solid positions.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param face The face direction that defines the column axis.
+ * @param planeCoord The coordinate along the face axis where voxels are squashed to.
+ */
+void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face,
+						 int planeCoord);
+
+/**
+ * @brief Squash all solid voxels in a volume region onto a single plane.
+ *
+ * @return The number of voxels changed.
+ */
+int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+						int planeCoord);
+
 } // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -686,4 +686,88 @@ TEST_F(VolumeSculptTest, testBridgeGapSingleVoxelNoChange) {
 	EXPECT_EQ(countSolid(volume), before);
 }
 
+// --- SquashToPlane tests ---
+
+TEST_F(VolumeSculptTest, testSquashToPlaneProjectsToClickedLayer) {
+	// 3x3x3 cube. Squash to Y=2 plane. Every column has solid voxels, so all should
+	// project to Y=2. Other layers become air.
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	const int changed = sculptSquashToPlane(volume, region, voxel::FaceNames::PositiveY, 2);
+	EXPECT_GT(changed, 0);
+	// Y=2 layer should be fully solid (3x3)
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(x, 2, z).getMaterial()));
+		}
+	}
+	// Y=1 and Y=3 layers should be air
+	for (int x = 1; x <= 3; ++x) {
+		for (int z = 1; z <= 3; ++z) {
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 1, z).getMaterial()));
+			EXPECT_TRUE(voxel::isAir(volume.voxel(x, 3, z).getMaterial()));
+		}
+	}
+	// Total solid count should be 9 (one layer of 3x3)
+	EXPECT_EQ(countSolid(volume), 9);
+}
+
+TEST_F(VolumeSculptTest, testSquashToPlanePreservesNearestColor) {
+	// Column with different colors at different heights. The voxel nearest to the
+	// plane should donate its color.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+
+	// Column at (2,*,2): color 10 at Y=1, color 20 at Y=3
+	volume.setVoxel(2, 1, 2, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+	volume.setVoxel(2, 3, 2, voxel::createVoxel(voxel::VoxelType::Generic, 20));
+
+	// Squash to Y=3 plane — the voxel AT Y=3 (color 20) is nearest (dist=0)
+	sculptSquashToPlane(volume, region, voxel::FaceNames::PositiveY, 3);
+	EXPECT_EQ(volume.voxel(2, 3, 2).getColor(), 20);
+	EXPECT_TRUE(voxel::isAir(volume.voxel(2, 1, 2).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSquashToPlaneEmptyColumnNoChange) {
+	// Columns without any solid voxels should remain empty.
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Only fill a single column at (2,1..3,2)
+	for (int y = 1; y <= 3; ++y) {
+		volume.setVoxel(2, y, 2, solid);
+	}
+
+	sculptSquashToPlane(volume, region, voxel::FaceNames::PositiveY, 2);
+	// The filled column should have exactly 1 voxel at Y=2
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, 2, 2).getMaterial()));
+	EXPECT_EQ(countSolid(volume), 1);
+	// Adjacent empty column should still be empty
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 2, 1).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSquashToPlaneNegativeX) {
+	// Test with NegativeX face — squash along X axis to X=2 plane.
+	voxel::Region region(0, 4);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillRegion(volume, voxel::Region(1, 3), solid);
+
+	sculptSquashToPlane(volume, region, voxel::FaceNames::NegativeX, 2);
+	// X=2 plane should have 3x3 solid voxels
+	for (int y = 1; y <= 3; ++y) {
+		for (int z = 1; z <= 3; ++z) {
+			EXPECT_TRUE(voxel::isBlocked(volume.voxel(2, y, z).getMaterial()));
+		}
+	}
+	// X=1 and X=3 should be air
+	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 2, 2).getMaterial()));
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 2, 2).getMaterial()));
+	EXPECT_EQ(countSolid(volume), 9);
+}
+
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -32,12 +32,15 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "bridgegap") {
 		return SculptMode::BridgeGap;
 	}
+	if (mode == "squashtoplane") {
+		return SculptMode::SquashToPlane;
+	}
 	return SculptMode::Erode;
 }
 
 SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	_tool.set("description",
-			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap). "
+			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane). "
 			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting).");
 
 	json::Json inputSchema = json::Json::object();
@@ -56,7 +59,8 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 					   "The sculpt mode: 'erode' (remove surface voxels), 'grow' (add voxels to surface), "
 					   "'flatten' (flatten surface along a face), 'smoothadditive' (smooth by adding), "
 					   "'smootherode' (smooth by removing), 'smoothgaussian' (Gaussian height blur), "
-				   "'bridgegap' (connect boundary voxels with lines to bridge gaps)");
+				   "'bridgegap' (connect boundary voxels with lines to bridge gaps), "
+				   "'squashtoplane' (project all voxels onto the clicked plane)");
 	json::Json enumArr = json::Json::array();
 	enumArr.push("erode");
 	enumArr.push("grow");
@@ -65,6 +69,7 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	enumArr.push("smootherode");
 	enumArr.push("smoothgaussian");
 	enumArr.push("bridgegap");
+	enumArr.push("squashtoplane");
 	sculptModeProp.set("enum", enumArr);
 	sculptModeProp.set("default", "erode");
 	properties.set("sculptMode", sculptModeProp);

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -55,7 +55,7 @@ static constexpr const char *TransformModeStr[] = {NC_("Transform Modes", "Move"
 												   NC_("Transform Modes", "Scale"), NC_("Transform Modes", "Rotate")};
 static_assert(lengthof(TransformModeStr) == (int)TransformMode::Max, "TransformModeStr size mismatch");
 
-static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"), NC_("Sculpt Modes", "Bridge Gap")};
+static constexpr const char *SculptModeStr[] = {NC_("Sculpt Modes", "Erode"), NC_("Sculpt Modes", "Grow"), NC_("Sculpt Modes", "Flatten"), NC_("Sculpt Modes", "Smooth Additive"), NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"), NC_("Sculpt Modes", "Bridge Gap"), NC_("Sculpt Modes", "Squash to Plane")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
@@ -1227,7 +1227,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 			brush.setSigma(sigma);
 			executeSculptBrush();
 		}
-	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap) {
+	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane) {
 		float strength = brush.strength();
 		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
 			brush.setStrength(strength);
@@ -1235,7 +1235,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		}
 	}
 
-	if (currentMode != SculptMode::BridgeGap) {
+	if (currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane) {
 		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
 		if (needsFace) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -84,6 +84,10 @@ bool SculptBrush::beginBrush(const BrushContext &ctx) {
 	const bool needsFace = modeNeedsFace(_sculptMode);
 	if (needsFace && ctx.cursorFace != voxel::FaceNames::Max) {
 		_flattenFace = ctx.cursorFace;
+		if (_sculptMode == SculptMode::SquashToPlane) {
+			const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(ctx.cursorFace));
+			_squashPlaneCoord = ctx.cursorPosition[axisIdx];
+		}
 		_paramsDirty = true;
 	}
 	_active = true;
@@ -297,6 +301,8 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 		voxel::Voxel fillVoxel = ctx.cursorVoxel;
 		fillVoxel.setFlags(voxel::FlagOutline);
 		voxelutil::sculptBridgeGap(currentSolid, voxelMap, anchorSolid, fillVoxel);
+	} else if (_sculptMode == SculptMode::SquashToPlane && _flattenFace != voxel::FaceNames::Max) {
+		voxelutil::sculptSquashToPlane(currentSolid, voxelMap, _flattenFace, _squashPlaneCoord);
 	}
 
 	// Write results using the collected snapshot entries - no hash lookups needed.

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -22,6 +22,7 @@ enum class SculptMode : uint8_t {
 	SmoothErode,
 	SmoothGaussian,
 	BridgeGap,
+	SquashToPlane,
 
 	Max
 };
@@ -48,6 +49,7 @@ private:
 	int _kernelSize = 4;
 	float _sigma = 4.0f;
 	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
+	int _squashPlaneCoord = 0;
 	bool _active = false;
 	bool _hasSnapshot = false;
 	bool _paramsDirty = true;
@@ -101,7 +103,7 @@ public:
 	}
 
 	static bool modeNeedsFace(SculptMode mode) {
-		return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode || mode == SculptMode::SmoothGaussian;
+		return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode || mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane;
 	}
 
 	SculptMode sculptMode() const {


### PR DESCRIPTION
## Summary

- New **Squash to Plane** sculpt mode that projects all selected voxels onto a single plane defined by clicking a voxel face
- For each column along the face normal: if any solid voxel exists, one is placed at the clicked plane coordinate; all others are removed
- Color is picked from the voxel nearest to the target plane
- No strength or iterations needed — one-shot operation
- Lua API: `g_sculpt.squashtoplane(volume, face, planeCoord)`
- MCP: `squashtoplane` mode added to `voxedit_sculpt_brush` tool
- 4 unit tests: basic projection, color preservation, empty columns, alternate axis (NegativeX)

## Test plan

- [ ] Select a 3D volume (cube or irregular shape), switch to Sculpt > Squash to Plane
- [ ] Click a top face — verify all voxels collapse to that Y layer as a 2D silhouette
- [ ] Click a side face — verify projection along X or Z axis
- [ ] Verify colors come from the nearest voxel to the clicked plane
- [ ] Verify empty columns remain empty (no phantom voxels)