### PR TITLE
Rendering optimizations, merge/stamp workflow, sprint, camera focus

### DIFF
--- a/src/modules/voxel/MeshState.cpp
+++ b/src/modules/voxel/MeshState.cpp
@@ -17,6 +17,7 @@
 namespace voxel {
 
 MeshState::MeshState() {
+	_pendingMeshDirty.fill(false);
 }
 
 bool MeshState::init() {
@@ -111,7 +112,20 @@ void MeshState::addOrReplaceMeshes(MeshState::ExtractionResult &result, MeshType
 int MeshState::pop() {
 	int result = -1;
 	_pendingMeshes.try_pop(result);
+	if (result >= 0 && result < MAX_VOLUMES) {
+		_pendingMeshDirty[result] = false;
+	}
 	return result;
+}
+
+void MeshState::deferPendingMesh(int idx) {
+	if (idx < 0 || idx >= MAX_VOLUMES) {
+		return;
+	}
+	if (!_pendingMeshDirty[idx]) {
+		_pendingMeshDirty[idx] = true;
+		_pendingMeshes.push(idx);
+	}
 }
 
 bool MeshState::deleteMeshes(const glm::ivec3 &pos, int idx) {
@@ -222,6 +236,9 @@ bool MeshState::runScheduledExtractions(size_t maxExtraction) {
 			if (_volumeData[idx]._generation != extractRegion.generation) {
 				continue;
 			}
+			if (_volumeData[idx]._hidden) {
+				continue;
+			}
 			const voxel::Region finalRegion = extractRegion.region;
 			const voxel::Region copyRegion(finalRegion.getLowerCorner() - 2, finalRegion.getUpperCorner() + 2);
 			if (!copyRegion.isValid()) {
@@ -245,7 +262,12 @@ bool MeshState::runScheduledExtractions(size_t maxExtraction) {
 		}
 		addOrReplaceMeshes(result, MeshType_Opaque);
 		addOrReplaceMeshes(result, MeshType_Transparency);
-		_pendingMeshes.push(result.idx);
+		// Only enqueue once per volume index: if already dirty, the existing queue
+		// entry will trigger a full re-upload that includes this new chunk too.
+		if (!_pendingMeshDirty[result.idx]) {
+			_pendingMeshDirty[result.idx] = true;
+			_pendingMeshes.push(result.idx);
+		}
 	}
 
 	return true;
@@ -258,7 +280,10 @@ bool MeshState::update() {
 		_meshMode->markClean();
 		clearPendingExtractions();
 
-		for (int i = 0; i < MAX_VOLUMES; ++i) {
+		for (int i : _activeIndices) {
+			if (hidden(i)) {
+				continue;
+			}
 			if (voxel::RawVolume *v = volume(i)) {
 				scheduleRegionExtraction(i, v->region());
 			}
@@ -305,7 +330,7 @@ bool MeshState::scheduleRegionExtraction(int idx, const voxel::Region &region) {
 				}
 
 				Log::debug("extract region: %s", finalRegion.toString().c_str());
-				_extractRegions.emplace(finalRegion, bufferIndex, hidden(bufferIndex), _volumeData[bufferIndex]._generation);
+				_extractRegions.emplace(finalRegion, bufferIndex, _volumeData[bufferIndex]._generation);
 			}
 		}
 	}
@@ -321,6 +346,7 @@ void MeshState::extractAllPending() {
 void MeshState::clearPendingExtractions() {
 	core_trace_scoped(MeshStateClearPendingExtractions);
 	_pendingMeshes.clear();
+	_pendingMeshDirty.fill(false);
 	_extractRegions.clear();
 }
 
@@ -364,6 +390,17 @@ voxel::RawVolume *MeshState::setVolume(int idx, voxel::RawVolume *v, palette::Pa
 		return nullptr;
 	}
 	core_trace_scoped(RawVolumeRendererSetVolume);
+	if (v != nullptr && old == nullptr) {
+		_activeIndices.push_back(idx);
+	} else if (v == nullptr && old != nullptr) {
+		for (int i = 0; i < (int)_activeIndices.size(); ++i) {
+			if (_activeIndices[i] == idx) {
+				_activeIndices[i] = _activeIndices.back();
+				_activeIndices.pop();
+				break;
+			}
+		}
+	}
 	_volumeData[idx]._rawVolume = v;
 	_volumeData[idx]._generation++;
 	if (meshDelete) {
@@ -382,6 +419,8 @@ voxel::RawVolume *MeshState::setVolume(int idx, voxel::RawVolume *v, palette::Pa
 
 core::Buffer<voxel::RawVolume *> MeshState::shutdown() {
 	clearMeshes();
+	_activeIndices.clear();
+	_pendingMeshDirty.fill(false);
 	core::Buffer<voxel::RawVolume *> old;
 	old.reserve(MAX_VOLUMES);
 	for (int idx = 0; idx < (int)_volumeData.size(); ++idx) {
@@ -394,8 +433,8 @@ core::Buffer<voxel::RawVolume *> MeshState::shutdown() {
 }
 
 void MeshState::resetReferences() {
-	for (auto &s : _volumeData) {
-		s._reference = -1;
+	for (int idx : _activeIndices) {
+		_volumeData[idx]._reference = -1;
 	}
 }
 
@@ -425,7 +464,14 @@ void MeshState::hide(int idx, bool hide) {
 	if (idx < 0 || idx >= MAX_VOLUMES) {
 		return;
 	}
+	const bool wasHidden = _volumeData[idx]._hidden;
 	_volumeData[idx]._hidden = hide;
+	if (wasHidden && !hide) {
+		const voxel::RawVolume *v = volume(idx);
+		if (v != nullptr) {
+			scheduleRegionExtraction(idx, v->region());
+		}
+	}
 }
 
 video::Face MeshState::cullFace(int idx) const {

--- a/src/modules/voxel/MeshState.h
+++ b/src/modules/voxel/MeshState.h
@@ -9,6 +9,7 @@
 #include "core/SharedPtr.h"
 #include "core/Var.h"
 #include "core/collection/Array.h"
+#include "core/collection/Buffer.h"
 #include "core/collection/DynamicMap.h"
 #include "core/collection/PriorityQueue.h"
 #include "core/collection/Queue.h"
@@ -81,28 +82,35 @@ private:
 
 	MeshesMap _meshes[MeshType_Max];
 	Volumes _volumeData;
+	core::Buffer<int> _activeIndices;
 	core::VarPtr _meshSize;
 
 	struct ExtractRegion {
-		ExtractRegion(const voxel::Region &_region, int _idx, bool _visible, uint32_t _generation)
-			: region(_region), idx(_idx), visible(_visible), generation(_generation) {
+		ExtractRegion(const voxel::Region &_region, int _idx, uint32_t _generation)
+			: region(_region), idx(_idx), generation(_generation) {
 		}
 		ExtractRegion() {
 		}
 		voxel::Region region{};
 		int idx = 0;
-		bool visible = false;
 		uint32_t generation = 0;
 
 		inline bool operator<(const ExtractRegion &rhs) const {
-			return idx < rhs.idx && visible < rhs.visible;
+			return idx < rhs.idx;
 		}
 	};
 	using RegionQueue = core::PriorityQueue<ExtractRegion>;
 	RegionQueue _extractRegions;
 
 	voxel::Region calculateExtractRegion(int x, int y, int z, const glm::ivec3 &meshSize) const;
+	// Queue of volume indices that need GPU buffer re-upload. Each index appears
+	// at most once thanks to _pendingMeshDirty deduplication: N extracted chunks
+	// for the same volume cause only ONE re-upload instead of N re-uploads of
+	// increasing size (which was O(N^2) total work for large models).
+	// Hidden volumes are NOT uploaded; their entries are deferred and replayed
+	// when the volume becomes visible again.
 	core::Queue<int> _pendingMeshes;
+	core::Array<bool, MAX_VOLUMES> _pendingMeshDirty;
 	core::VarPtr _meshMode;
 	bool deleteMeshes(const glm::ivec3 &pos, int idx);
 	bool runScheduledExtractions(size_t maxExtraction = 0);
@@ -138,6 +146,11 @@ public:
 	int pendingExtractions() const;
 	void clearPendingExtractions();
 	int pendingMeshes() const;
+	/**
+	 * @brief Re-queues a pending GPU upload that was skipped (e.g. because the volume
+	 * was hidden). Deduplication ensures the index is queued at most once.
+	 */
+	void deferPendingMesh(int idx);
 
 	/**
 	 * @sa shutdown()
@@ -172,6 +185,10 @@ public:
 	 * @return @c true if the mesh should get deleted in the renderer
 	 */
 	bool scheduleRegionExtraction(int idx, const voxel::Region &region);
+
+	const core::Buffer<int> &activeIndices() const {
+		return _activeIndices;
+	}
 
 	bool sameNormalPalette(int idx, const palette::NormalPalette *palette) const;
 

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -201,12 +201,23 @@ void RawVolumeRenderer::update(const voxel::MeshStatePtr &meshState) {
 
 	int cnt = 0;
 
+	// Collect hidden-volume entries that need to be re-queued after the loop.
+	// Re-queuing inside the loop would spin: pop() clears _pendingMeshDirty,
+	// deferPendingMesh() immediately re-pushes, and the next iteration pops it
+	// again - burning the full 10ms budget every frame for hidden volumes.
+	core::Buffer<int> deferred;
 	const core::TimeProviderPtr& timeProvider = app::App::getInstance()->timeProvider();
 	const uint64_t startTime = timeProvider->systemMillis();
 	for (;;) {
 		const int idx = meshState->pop();
 		if (idx == -1) {
 			break;
+		}
+		if (meshState->hidden(idx)) {
+			// Skip the expensive GPU upload; re-queue after the loop so it is
+			// processed when the volume becomes visible again.
+			deferred.push_back(idx);
+			continue;
 		}
 		if (!updateBufferForVolume(meshState, idx)) {
 			Log::error("Failed to update the mesh at index %i", idx);
@@ -217,6 +228,9 @@ void RawVolumeRenderer::update(const voxel::MeshStatePtr &meshState) {
 			Log::debug("Update took too long: %u ms", (int32_t)(deltaT));
 			break;
 		}
+	}
+	for (int idx : deferred) {
+		meshState->deferPendingMesh(idx);
 	}
 	if (cnt > 0) {
 		Log::debug("Perform %i mesh updates in this frame", cnt);
@@ -558,7 +572,7 @@ void RawVolumeRenderer::renderNormals(const voxel::MeshStatePtr &meshState, cons
 	}
 
 	core_trace_scoped(RenderNormals);
-	for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+	for (int idx : meshState->activeIndices()) {
 		if (!isVisible(meshState, idx)) {
 			continue;
 		}
@@ -607,7 +621,7 @@ void RawVolumeRenderer::renderOpaque(const voxel::MeshStatePtr &meshState, const
 	const video::PolygonMode mode = camera.polygonMode();
 	const video::Face oldCullFace = video::currentCullFace();
 	video::ScopedPolygonMode polygonMode(mode);
-	for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+	for (int idx : meshState->activeIndices()) {
 		if (!isVisible(meshState, idx)) {
 			continue;
 		}
@@ -654,8 +668,8 @@ void RawVolumeRenderer::renderTransparency(const voxel::MeshStatePtr &meshState,
 	core::Buffer<int> sorted;
 	{
 		core_trace_scoped(Sort);
-		sorted.reserve(voxel::MAX_VOLUMES);
-		for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+		sorted.reserve(meshState->activeIndices().size());
+		for (int idx : meshState->activeIndices()) {
 			if (!isVisible(meshState, idx)) {
 				continue;
 			}
@@ -723,11 +737,12 @@ void RawVolumeRenderer::sortBeforeRender(const voxel::MeshStatePtr &meshState, c
 	}
 	core::Buffer<int> indices;
 	indices.resize(voxel::MAX_VOLUMES);
+	const core::Buffer<int> &active = meshState->activeIndices();
 	for (const auto &i : transparencyMeshes) {
-		indices.fill(-1);
+		for (int idx : active) { indices[idx] = -1; }
 		const glm::vec3 worldPosition = camera.worldPosition();
 		const voxel::MeshState::Meshes &meshes = i->second;
-		for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+		for (int idx : active) {
 			if (!isVisible(meshState, idx, true)) {
 				continue;
 			}
@@ -743,12 +758,12 @@ void RawVolumeRenderer::sortBeforeRender(const voxel::MeshStatePtr &meshState, c
 			}
 		}
 		core_trace_scoped(UpdateBuffers);
-		for (size_t idx = 0; idx < indices.size(); ++idx) {
+		for (int idx : active) {
 			if (indices[idx] == -1) {
 				continue;
 			}
 			if (!updateBufferForVolume(meshState, indices[idx], voxel::MeshType_Transparency, UpdateBufferFlags::Indices)) {
-				Log::error("Failed to update the transparency mesh at index %i", (int)idx);
+				Log::error("Failed to update the transparency mesh at index %i", idx);
 			}
 		}
 	}
@@ -759,8 +774,10 @@ void RawVolumeRenderer::render(const voxel::MeshStatePtr &meshState, RenderConte
 	core_trace_scoped(RawVolumeRendererRender);
 
 	bool visible = false;
-	app::for_parallel(0, voxel::MAX_VOLUMES, [&](int start, int end) {
-		for (int idx = start; idx < end; ++idx) {
+	const core::Buffer<int> &activeForRender = meshState->activeIndices();
+	app::for_parallel(0, (int)activeForRender.size(), [&](int start, int end) {
+		for (int i = start; i < end; ++i) {
+			const int idx = activeForRender[i];
 			updateCulling(meshState, idx, camera);
 			if (!isVisible(meshState, idx)) {
 				continue;
@@ -774,7 +791,7 @@ void RawVolumeRenderer::render(const voxel::MeshStatePtr &meshState, RenderConte
 
 	if (_cullBuffers->boolVal()) {
 		core_trace_scoped(CullBuffers);
-		for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+		for (int idx : activeForRender) {
 			if (!isVisible(meshState, idx)) {
 				continue;
 			}
@@ -803,13 +820,13 @@ void RawVolumeRenderer::render(const voxel::MeshStatePtr &meshState, RenderConte
 		_shadow.update(camera, true);
 		if (shadow) {
 			video::ScopedShader scoped(_shadowMapShader);
-			auto renderFunc = [this, &meshState](int depthBufferIndex, const glm::mat4 &lightViewProjection) {
+			auto renderFunc = [this, &meshState, &activeForRender](int depthBufferIndex, const glm::mat4 &lightViewProjection) {
 				math::Frustum frustum;
 				frustum.updatePlanes(glm::mat4(1.0f), lightViewProjection);
 				alignas(16) shader::ShadowmapData::BlockData var;
 				var.lightviewprojection = lightViewProjection;
 
-				for (int idx = 0; idx < voxel::MAX_VOLUMES; ++idx) {
+				for (int idx : activeForRender) {
 					if (meshState->hidden(idx)) {
 						continue;
 					}

--- a/src/modules/voxelrender/SceneGraphRenderer.cpp
+++ b/src/modules/voxelrender/SceneGraphRenderer.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "SceneGraphRenderer.h"
+#include "app/Async.h"
 #include "color/Color.h"
 #include "core/Log.h"
 #include "core/Trace.h"
@@ -262,8 +263,11 @@ void SceneGraphRenderer::prepareCameraNodes(const RenderContext &renderContext) 
 
 void SceneGraphRenderer::resetVolumes(const voxel::MeshStatePtr &meshState, const scenegraph::SceneGraph &sceneGraph) {
 	core_trace_scoped(ResetVolumes);
-	for (int i = 0; i < voxel::MAX_VOLUMES; ++i) {
-		const int nodeId = getNodeId(i);
+	// Copy active indices to avoid modifying the list while iterating
+	// (resetVolume calls setVolume(nullptr) which removes from active list)
+	const core::Buffer<int> activeSnapshot = meshState->activeIndices();
+	for (int idx : activeSnapshot) {
+		const int nodeId = getNodeId(idx);
 		if (sceneGraph.hasNode(nodeId)) {
 			continue;
 		}
@@ -297,24 +301,43 @@ void SceneGraphRenderer::prepareModelNodes(const voxel::MeshStatePtr &meshState,
 		_sliceVolumeNodeId = -1;
 	}
 	const scenegraph::SceneGraphNode &activeNode = sceneGraph.node(activeNodeId);
-	sceneGraph.nodes().for_parallel([&](int nodeId, const scenegraph::SceneGraphNode &node) {
+
+	// Phase 1: update visibility flags sequentially (cheap, avoids thread pool overhead)
+	struct VisibleNode {
+		int nodeId;
+		int idx;
+	};
+	core::Buffer<VisibleNode> visibleNodes;
+	visibleNodes.reserve(sceneGraph.size());
+	for (auto entry : sceneGraph.nodes()) {
+		const scenegraph::SceneGraphNode &node = entry->value;
 		if (!node.isModelNode()) {
-			return;
+			continue;
 		}
+		const int nodeId = entry->key;
 		const int idx = getVolumeIdx(nodeId);
 		updateNodeState(meshState, renderContext, activeNode, node, idx);
 
 		if (meshState->hidden(idx)) {
-			return;
+			continue;
 		}
-
-		// also check the volume here on the first run, as they are added after this step for the first time
 		if (meshState->volume(idx) == nullptr) {
-			return;
+			continue;
 		}
+		visibleNodes.push_back({nodeId, idx});
+	}
 
-		applyTransform(meshState, renderContext, sceneGraph, node, idx);
-	});
+	// Phase 2: compute transforms in parallel (expensive, only for visible nodes)
+	if (!visibleNodes.empty()) {
+		app::for_parallel(0, (int)visibleNodes.size(), [&](int start, int end) {
+			for (int i = start; i < end; ++i) {
+				const VisibleNode &vn = visibleNodes[i];
+				const scenegraph::SceneGraphNode &node = sceneGraph.node(vn.nodeId);
+				applyTransform(meshState, renderContext, sceneGraph, node, vn.idx);
+			}
+		});
+	}
+
 	for (auto entry : sceneGraph.nodes()) {
 		scenegraph::SceneGraphNode &node = entry->value;
 		if (!node.isModelNode()) {

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -2716,6 +2716,7 @@ bool SceneManager::setGridResolution(int resolution) {
 
 void SceneManager::render(voxelrender::RenderContext &renderContext, const video::Camera& camera, uint8_t renderMask) {
 	renderContext.frameBuffer.bind(true);
+
 	_sceneRenderer->updateLockedPlanes(_modifierFacade.lockedAxis(), _sceneGraph, cursorPosition());
 
 	renderContext.frame = _currentFrameIdx;
@@ -2725,6 +2726,7 @@ void SceneManager::render(voxelrender::RenderContext &renderContext, const video
 	if (renderScene) {
 		_sceneRenderer->renderScene(renderContext, camera);
 	}
+
 	const bool renderUI = (renderMask & RenderUI) != 0u;
 	if (renderUI) {
 		_sceneRenderer->renderUI(renderContext, camera);


### PR DESCRIPTION
## Summary

- **Rendering performance**: skip mesh extraction/GPU upload for hidden volumes, deduplicate pending mesh queue (O(N) vs O(N^2)), use active-index lists instead of iterating all MAX_VOLUMES slots, cache AABB/bone mesh rebuilds, parallel transform computation for visible nodes only
- **Cross-node editing workflow**: `mergevisibletotemp` merges visible nodes into one editable temp node (hiding originals), `mergeactivetobackground` stamps edits back (including air voxels) and restores visibility
- **Camera**: `camera_focus` command sets orbit center to active node, `nodetogglevisibleatcamera` toggles visibility of nodes the camera is inside
- **Sprint**: `+sprint` action button (default: left_shift) for 3x camera movement speed in editing mode
- **Selection tracking**: cache `hasSelection` as bool flag on SceneGraphNode instead of scanning all voxels each query
- **Scene mode persistence**: `ve_scenemode` cvar remembers scene/edit mode across sessions

## Test plan

- [ ] Load multi-node model, run `mergevisibletotemp`, edit merged node, run `mergeactivetobackground` — verify edits applied to original nodes including air overwrites
- [ ] Verify undo restores original state after merge/stamp workflow
- [ ] Hold left_shift while pressing WASD — camera moves 3x faster
- [ ] Run `camera_focus` — orbit center moves to active node
- [ ] Walk camera inside a node, run `nodetogglevisibleatcamera` — node toggles visibility
- [ ] Toggle scene/edit mode, restart — mode is preserved
- [ ] Load large model — verify no performance regression from rendering changes
- [ ] Unit tests: `testMergeActiveToBackground`, `testMergeVisibleToTemp`