### PR TITLE
Add resize option to scene graph node context menu

### DIFF
--- a/src/tools/voxedit/modules/voxedit-ui/MainWindow.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/MainWindow.cpp
@@ -836,6 +836,10 @@ void MainWindow::registerPopups() {
 		ImGui::OpenPopup(POPUP_TITLE_MODEL_NODE_SETTINGS);
 		_sceneGraphPanel._popupNewModelNode = false;
 	}
+	if (_sceneGraphPanel._popupResizeNode) {
+		ImGui::OpenPopup(POPUP_TITLE_RESIZE_NODE);
+		_sceneGraphPanel._popupResizeNode = false;
+	}
 
 	// popups that can get triggers externally
 	if (_popupTipOfTheDay->boolVal()) {
@@ -873,8 +877,50 @@ void MainWindow::registerPopups() {
 	popupMinecraftMapping();
 	popupNodeRename();
 	popupModelUnreference();
+	popupNodeResize();
 
 	_animationPanel.registerPopups();
+}
+
+void MainWindow::popupNodeResize() {
+	const core::String title = makeTitle(_("Resize node"), POPUP_TITLE_RESIZE_NODE);
+	if (ImGui::BeginPopupModal(title.c_str(), nullptr,
+							   ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
+		glm::ivec3 &mins = _sceneGraphPanel._resizeMins;
+		glm::ivec3 &maxs = _sceneGraphPanel._resizeMaxs;
+
+		ImGui::TextUnformatted(_("Lower bound"));
+		ImGui::Separator();
+		ImGui::InputAxisInt(math::Axis::X, "##minx", &mins.x);
+		ImGui::InputAxisInt(math::Axis::Y, "##miny", &mins.y);
+		ImGui::InputAxisInt(math::Axis::Z, "##minz", &mins.z);
+		ImGui::NewLine();
+
+		ImGui::TextUnformatted(_("Upper bound"));
+		ImGui::Separator();
+		ImGui::InputAxisInt(math::Axis::X, "##maxx", &maxs.x);
+		ImGui::InputAxisInt(math::Axis::Y, "##maxy", &maxs.y);
+		ImGui::InputAxisInt(math::Axis::Z, "##maxz", &maxs.z);
+
+		maxs = glm::max(maxs, mins);
+
+		const glm::ivec3 size = maxs - mins + 1;
+		ImGui::NewLine();
+		ImGui::Text(_("Size: %ix%ix%i"), size.x, size.y, size.z);
+		ImGui::NewLine();
+
+		if (ImGui::OkButton()) {
+			const int nodeId = _sceneGraphPanel._resizeNodeId;
+			voxel::Region newRegion(mins, maxs);
+			_sceneMgr->nodeResize(nodeId, newRegion);
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::SameLine();
+		if (ImGui::CancelButton()) {
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::EndPopup();
+	}
 }
 
 void MainWindow::popupNodeRename() {

--- a/src/tools/voxedit/modules/voxedit-ui/MainWindow.h
+++ b/src/tools/voxedit/modules/voxedit-ui/MainWindow.h
@@ -139,6 +139,7 @@ private:
 	void popupWelcome();
 	void popupMinecraftMapping();
 	void popupNodeRename();
+	void popupNodeResize();
 	void popupTipOfTheDay();
 	void popupFailedSave();
 	void popupUnsavedChanges();

--- a/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.cpp
@@ -62,6 +62,13 @@ void SceneGraphPanel::contextMenu(video::Camera& camera, const scenegraph::Scene
 			ImGui::CommandIconMenuItem(ICON_LC_GROUP, _("Merge locked"), "modelmergelocked", validModels > 1, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_SHRINK, _("Center origin"), "center_origin", true, &listener);
 			ImGui::CommandIconMenuItem(ICON_LC_SHRINK, _("Center reference"), "center_referenceposition", true, &listener);
+			if (ImGui::IconMenuItem(ICON_LC_EXPAND, _("Resize"))) {
+				const voxel::Region &region = node.region();
+				_resizeNodeId = nodeId;
+				_resizeMins = region.getLowerCorner();
+				_resizeMaxs = region.getUpperCorner();
+				_popupResizeNode = true;
+			}
 			commandNodeMenu(ICON_LC_SAVE, _("Save"), "modelsave", nodeId, true, &listener);
 		} else if (nodeType == scenegraph::SceneGraphNodeType::ModelReference) {
 			ImGui::CommandIconMenuItem(ICON_LC_CODESANDBOX, _("Convert to model"), "modelunref", true, &listener);

--- a/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.h
@@ -70,6 +70,10 @@ public:
 	}
 
 	bool _popupNewModelNode = false;
+	bool _popupResizeNode = false;
+	int _resizeNodeId = InvalidNodeId;
+	glm::ivec3 _resizeMins {0};
+	glm::ivec3 _resizeMaxs {0};
 	bool init();
 	void update(video::Camera &camera, const char *id, ModelNodeSettings *modelNodeSettings,
 				command::CommandExecutionListener &listener);

--- a/src/tools/voxedit/modules/voxedit-ui/WindowTitles.h
+++ b/src/tools/voxedit/modules/voxedit-ui/WindowTitles.h
@@ -46,3 +46,4 @@
 #define POPUP_TITLE_MODEL_UNREFERENCE "###unreferencedmodelpopup"
 #define POPUP_TITLE_LOAD_PALETTE "###selectpalettepopup"
 #define POPUP_TITLE_UV_EDITOR "###uveditorpopup"
+#define POPUP_TITLE_RESIZE_NODE "###resizenodepopup"


### PR DESCRIPTION
## Summary
- Right-clicking a model node in the scene graph panel now shows a "Resize" option
- Opens a modal popup with lower and upper bound inputs, allowing the region to be extended or shrunk from any side
- Existing voxels are preserved during resize, operation supports undo

## Test plan
- [ ] Right-click a model node in the scene graph, select "Resize"
- [ ] Extend the region in the negative direction (decrease lower bounds) and verify voxels are preserved
- [ ] Extend in the positive direction (increase upper bounds) and verify voxels are preserved
- [ ] Shrink the region and verify it clips correctly
- [ ] Undo the resize and verify original region is restored
- [ ] Save/reload and verify resized region persists