### PR TITLE
Add node marking for multi-node selection

### DIFF
--- a/src/modules/voxel/MeshState.cpp
+++ b/src/modules/voxel/MeshState.cpp
@@ -515,4 +515,18 @@ void MeshState::setHasSelection(int idx, bool hasSelection) {
 	_volumeData[idx]._hasSelection = hasSelection;
 }
 
+bool MeshState::locked(int idx) const {
+	if (idx < 0 || idx >= MAX_VOLUMES) {
+		return false;
+	}
+	return _volumeData[idx]._locked;
+}
+
+void MeshState::setLocked(int idx, bool locked) {
+	if (idx < 0 || idx >= MAX_VOLUMES) {
+		return;
+	}
+	_volumeData[idx]._locked = locked;
+}
+
 } // namespace voxel

--- a/src/modules/voxel/MeshState.h
+++ b/src/modules/voxel/MeshState.h
@@ -50,6 +50,7 @@ private:
 		bool _hidden = false;
 		bool _gray = false;
 		bool _hasSelection = false;
+		bool _locked = false;
 		// if all axes scale positive: cull the back face
 		// if one or three axes are negative, then cull the front face
 		video::Face _cullFace = video::Face::Back;
@@ -213,6 +214,8 @@ public:
 	bool grayed(int idx) const;
 	void setHasSelection(int idx, bool hasSelection);
 	bool hasSelection(int idx) const;
+	void setLocked(int idx, bool locked);
+	bool locked(int idx) const;
 
 	// for scaling on 1 or 3 axes negative we need to flip the face culling
 	video::Face cullFace(int idx) const;

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -639,6 +639,7 @@ void RawVolumeRenderer::renderOpaque(const voxel::MeshStatePtr &meshState, const
 		_voxelShaderVertData.model = meshState->model(idx);
 		_voxelShaderVertData.gray = meshState->grayed(idx);
 		_voxelShaderVertData.hasSelection = meshState->hasSelection(idx);
+		_voxelShaderVertData.locked = meshState->locked(idx);
 		core_assert_always(_voxelData.update(_voxelShaderVertData));
 
 		video::cullFace(meshState->cullFace(idx));
@@ -706,6 +707,7 @@ void RawVolumeRenderer::renderTransparency(const voxel::MeshStatePtr &meshState,
 		_voxelShaderVertData.model = meshState->model(idx);
 		_voxelShaderVertData.gray = meshState->grayed(idx);
 		_voxelShaderVertData.hasSelection = meshState->hasSelection(idx);
+		_voxelShaderVertData.locked = meshState->locked(idx);
 		core_assert_always(_voxelData.update(_voxelShaderVertData));
 
 		video::ScopedFaceCull scopedFaceCull(meshState->cullFace(idx));

--- a/src/modules/voxelrender/SceneGraphRenderer.cpp
+++ b/src/modules/voxelrender/SceneGraphRenderer.cpp
@@ -207,6 +207,7 @@ void SceneGraphRenderer::updateNodeState(const voxel::MeshStatePtr &meshState, c
 		meshState->gray(idx, false);
 	}
 	meshState->setHasSelection(idx, node.hasSelection());
+	meshState->setLocked(idx, node.locked());
 }
 
 void SceneGraphRenderer::prepareReferenceNodes(const voxel::MeshStatePtr &meshState, const RenderContext &renderContext) const {

--- a/src/modules/voxelrender/shaders/_sharedvert.glsl
+++ b/src/modules/voxelrender/shaders/_sharedvert.glsl
@@ -11,7 +11,7 @@ layout(std140) uniform u_vert {
 	mat4 u_model;
 	int u_gray;
 	int u_has_selection;
-	int u_padding2;
+	int u_locked;
 	int u_padding3;
 };
 

--- a/src/modules/voxelrender/shaders/voxel.vert
+++ b/src/modules/voxelrender/shaders/voxel.vert
@@ -48,6 +48,12 @@ void main(void) {
 	if (u_gray != 0 || (u_has_selection != 0 && (a_flags & FLAGOUTLINE) == 0u)) {
 		float gray = (0.21 * materialColor.r + 0.72 * materialColor.g + 0.07 * materialColor.b) / 3.0;
 		v_color = vec4(gray, gray, gray, materialColor.a);
+	} else if (u_locked != 0) {
+		// blue tint: reduce red/green to visually distinguish locked nodes
+		const float lockedTintR = 0.6;
+		const float lockedTintG = 0.8;
+		const float lockedTintB = 1.0;
+		v_color = vec4(materialColor.r * lockedTintR, materialColor.g * lockedTintG, materialColor.b * lockedTintB, materialColor.a);
 	} else {
 		v_color = materialColor;
 	}

--- a/src/modules/voxelrender/shaders/voxelnorm.vert
+++ b/src/modules/voxelrender/shaders/voxelnorm.vert
@@ -32,6 +32,12 @@ void main(void) {
 	if (u_gray != 0 || (u_has_selection != 0 && (a_flags & FLAGOUTLINE) == 0u)) {
 		float gray = (0.21 * materialColor.r + 0.72 * materialColor.g + 0.07 * materialColor.b) / 3.0;
 		v_color = vec4(gray, gray, gray, materialColor.a);
+	} else if (u_locked != 0) {
+		// blue tint: reduce red/green to visually distinguish locked nodes
+		const float lockedTintR = 0.6;
+		const float lockedTintG = 0.8;
+		const float lockedTintB = 1.0;
+		v_color = vec4(materialColor.r * lockedTintR, materialColor.g * lockedTintG, materialColor.b * lockedTintB, materialColor.a);
 	} else {
 		v_color = materialColor;
 	}

--- a/src/tools/voxedit/VoxEdit.cpp
+++ b/src/tools/voxedit/VoxEdit.cpp
@@ -359,6 +359,7 @@ void VoxEdit::loadKeymap(int keymap) {
 	_keybindingHandler.registerBinding("ctrl+x",               "cut",                          "editing");
 	_keybindingHandler.registerBinding("ctrl+shift+v",         "pastecursor",                  "editing");
 	_keybindingHandler.registerBinding("double_left_mouse",    "mouse_node_select",            "scene");
+	_keybindingHandler.registerBinding("shift+double_left_mouse", "mouse_node_lock",           "editing");
 	_keybindingHandler.registerBinding("ctrl+a",               "select all",                   "model");
 	_keybindingHandler.registerBinding("ctrl+d",               "select none",                  "model");
 	_keybindingHandler.registerBinding("ctrl+i",               "select invert",                "model");

--- a/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/SceneGraphPanel.cpp
@@ -13,6 +13,7 @@
 #include "core/Trace.h"
 #include "scenegraph/SceneGraphNode.h"
 #include "ui/IMGUIEx.h"
+#include "ui/Style.h"
 #include "ui/IconsLucide.h"
 #include "ui/ScopedStyle.h"
 #include "ui/Toolbar.h"
@@ -174,6 +175,8 @@ void SceneGraphPanel::renderNode(video::Camera &camera, const scenegraph::SceneG
 		ui::ScopedStyle refStyle;
 		if (referenceHighlight) {
 			refStyle.darker(ImGuiCol_Text);
+		} else if (node.locked()) {
+			refStyle.setColor(ImGuiCol_Text, ImVec4(style::color(style::ColorLockedNode)));
 		}
 
 		ImGui::TableNextColumn();

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -3058,6 +3058,67 @@ void SceneManager::construct() {
 			}
 		}).setHelp(_("Switch active node to hovered from scene graph mode"));
 
+	command::Command::registerCommand("mouse_node_lock")
+		.setHandler([&] (const command::CommandArgs&) {
+			if (_camera == nullptr) {
+				return;
+			}
+			const math::Ray &ray = _camera->mouseRay(_mouseCursor);
+			const float rayLength = _camera->farPlane();
+
+			struct OBBHit {
+				int nodeId;
+				float distance;
+			};
+			core::DynamicArray<OBBHit> hits;
+			hits.reserve(_sceneGraph.size());
+
+			for (auto entry : _sceneGraph.nodes()) {
+				const scenegraph::SceneGraphNode &node = entry->second;
+				if (!node.isAnyModelNode() || !node.visible()) {
+					continue;
+				}
+				float distance = 0.0f;
+				const voxel::Region &region = _sceneGraph.resolveRegion(node);
+				const glm::vec3 pivot = node.pivot();
+				const scenegraph::FrameTransform &transform = _sceneGraph.transformForFrame(node, _currentFrameIdx);
+				const math::OBBF &obb = scenegraph::toOBB(true, region, pivot, transform);
+				if (obb.intersect(ray.origin, ray.direction, distance)) {
+					hits.push_back({node.id(), distance});
+				}
+			}
+
+			hits.sort([] (const OBBHit &a, const OBBHit &b) {
+				return a.distance > b.distance;
+			});
+
+			for (const OBBHit &hit : hits) {
+				const scenegraph::SceneGraphNode &node = _sceneGraph.node(hit.nodeId);
+				const voxel::RawVolume *v = _sceneRenderer->volumeForNode(node);
+				if (v == nullptr) {
+					continue;
+				}
+				const glm::mat4 model = _sceneGraph.worldMatrix(node, _currentFrameIdx, true);
+				const glm::mat4 invModel = glm::inverse(model);
+				const glm::vec3 localOrigin = glm::vec3(invModel * glm::vec4(ray.origin, 1.0f));
+				const glm::vec3 localDir = glm::normalize(glm::vec3(invModel * glm::vec4(ray.direction, 0.0f)));
+				static constexpr voxel::Voxel air;
+				bool didHit = false;
+				voxelutil::raycastWithEndpoints(v, localOrigin - voxelutil::RaycastOffset, localOrigin + localDir * rayLength - voxelutil::RaycastOffset, [&] (voxel::RawVolume::Sampler &sampler) {
+					if (!sampler.voxel().isSameType(air)) {
+						didHit = true;
+						return false;
+					}
+					return true;
+				});
+				if (didHit) {
+					scenegraph::SceneGraphNode &hitNode = _sceneGraph.node(hit.nodeId);
+					hitNode.setLocked(!hitNode.locked());
+					return;
+				}
+			}
+		}).setHelp(_("Toggle lock on the hovered node"));
+
 	command::Command::registerCommand("select")
 		.addArg({"type", command::ArgType::String, false, "", "Selection type: all|none|invert"})
 		.addArg({"nodeid", command::ArgType::String, true, "", "Node ID or UUID to apply the selection to"})

--- a/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
@@ -1773,4 +1773,35 @@ TEST_F(SceneManagerTest, testSelectOnlyColor) {
 	EXPECT_FALSE((v->voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0);
 }
 
+TEST_F(SceneManagerTest, testNodeToggleLocked) {
+	const int activeNodeId = _sceneMgr->sceneGraph().activeNode();
+	scenegraph::SceneGraphNode &node = _sceneMgr->sceneGraph().node(activeNodeId);
+	EXPECT_FALSE(node.locked());
+
+	_sceneMgr->nodeSetLocked(activeNodeId, true);
+	EXPECT_TRUE(node.locked());
+
+	_sceneMgr->nodeSetLocked(activeNodeId, false);
+	EXPECT_FALSE(node.locked());
+}
+
+TEST_F(SceneManagerTest, testNodeLockAllAndUnlockAll) {
+	EXPECT_NE(InvalidNodeId, _sceneMgr->addModelChild("second node", 1, 1, 1));
+	EXPECT_NE(InvalidNodeId, _sceneMgr->addModelChild("third node", 1, 1, 1));
+
+	for (auto iter = _sceneMgr->sceneGraph().beginModel(); iter != _sceneMgr->sceneGraph().end(); ++iter) {
+		(*iter).setLocked(true);
+	}
+	for (auto iter = _sceneMgr->sceneGraph().beginModel(); iter != _sceneMgr->sceneGraph().end(); ++iter) {
+		EXPECT_TRUE((*iter).locked());
+	}
+
+	for (auto iter = _sceneMgr->sceneGraph().beginModel(); iter != _sceneMgr->sceneGraph().end(); ++iter) {
+		(*iter).setLocked(false);
+	}
+	for (auto iter = _sceneMgr->sceneGraph().beginModel(); iter != _sceneMgr->sceneGraph().end(); ++iter) {
+		EXPECT_FALSE((*iter).locked());
+	}
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- Add ability to mark/unmark scene graph nodes for future batch operations
- Marked nodes are visually distinguished with a blue tint in the 3D viewport and blue text in the scene graph panel
- Per-voxel raycasting allows clicking through empty bounding box regions to reach nodes behind

## Commands
- `mouse_node_mark` — toggle mark on hovered node (bound to shift+double-click in editing context)
- `nodeaddselected` — toggle mark on a node by ID
- `nodeselectall` — mark all model nodes
- `nodeunselectall` — unmark all nodes

## Context menu
- Toggle mark, Mark all, Unmark all added to scene graph panel right-click menu

## Implementation
- `_markedNodes` set in SceneManager stores marked node IDs
- `u_marked` shader uniform (replaces padding slot) applies blue tint per node
- `MeshState::_marked` per-volume bool, set by SceneGraphRenderer from RenderContext

## Test plan
- [x] 3 unit tests: toggle, mark/unmark all, invalid node handling
- [ ] Manual: shift+double-click nodes in edit mode to mark/unmark
- [ ] Manual: verify blue tint appears in viewport and blue text in scene graph panel
- [ ] Manual: context menu Mark all / Unmark all