### PR TITLE
VOXEDIT: QoL improvements - session restore, import merge, sprint config

### DIFF
--- a/src/tools/voxedit/VoxEdit.cpp
+++ b/src/tools/voxedit/VoxEdit.cpp
@@ -8,6 +8,7 @@
 #include "command/CommandCompleter.h"
 #include "core/BindingContext.h"
 #include "color/Color.h"
+#include "core/ConfigVar.h"
 #include "core/Log.h"
 #include "ui/IMGUIEx.h"
 #include "voxedit-util/Config.h"
@@ -548,6 +549,15 @@ app::AppState VoxEdit::onInit() {
 			if (filePtr->exists()) {
 				const core::String &filePath = filesystem()->sysAbsolutePath(filePtr->name());
 				_mainWindow->load(filePath, nullptr);
+			}
+		} else if (core::getVar(cfg::VoxEditContinueSession)->boolVal()) {
+			const core::String &lastFile = core::getVar(cfg::UIFileDialogLastFile)->strVal();
+			if (!lastFile.empty()) {
+				const io::FilePtr &filePtr = filesystem()->open(lastFile);
+				if (filePtr->exists()) {
+					const core::String &filePath = filesystem()->sysAbsolutePath(filePtr->name());
+					_mainWindow->load(filePath, nullptr);
+				}
 			}
 		}
 	}

--- a/src/tools/voxedit/VoxEdit.cpp
+++ b/src/tools/voxedit/VoxEdit.cpp
@@ -9,6 +9,8 @@
 #include "core/BindingContext.h"
 #include "color/Color.h"
 #include "core/Log.h"
+#include "ui/IMGUIEx.h"
+#include "voxedit-util/Config.h"
 #include "core/StringUtil.h"
 #include "core/TimeProvider.h"
 #include "core/Var.h"
@@ -205,7 +207,13 @@ app::AppState VoxEdit::onConstruct() {
 		.setHandler([this](const command::CommandArgs &args) {
 			const core::String &file = args.str("file");
 			if (file.empty()) {
-				openDialog([this](const core::String &f, const io::FormatDescription *desc) { _sceneMgr->import(f); }, voxelui::FileDialogOptions::build(_paletteCache, false), voxelformat::voxelLoad());
+				auto baseOptions = voxelui::FileDialogOptions::build(_paletteCache, false);
+				auto importOptions = [baseOptions](video::OpenFileMode mode, const io::FormatDescription *desc, const io::FilesystemEntry &entry) mutable {
+					bool hasOptions = baseOptions(mode, desc, entry);
+					ImGui::CheckboxVar(cfg::VoxEditImportSingleNode);
+					return true;
+				};
+				openDialog([this](const core::String &f, const io::FormatDescription *desc) { _sceneMgr->import(f); }, importOptions, voxelformat::voxelLoad());
 				return;
 			}
 			_sceneMgr->import(file);

--- a/src/tools/voxedit/modules/voxedit-ui/MainWindow.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/MainWindow.cpp
@@ -255,7 +255,49 @@ void MainWindow::stopViewportRecordings() {
 	}
 }
 
+void MainWindow::saveCameraState() {
+	if (_viewports.empty()) {
+		return;
+	}
+	const video::Camera &cam = _viewports[0]->camera();
+	const glm::vec3 &target = cam.target();
+	const glm::quat &q = cam.quaternion();
+	core::getVar(cfg::VoxEditLastCameraTarget)->setVal(core::String::format("%f %f %f", target.x, target.y, target.z));
+	core::getVar(cfg::VoxEditLastCameraAngles)->setVal(core::String::format("%f %f %f %f", q.w, q.x, q.y, q.z));
+	core::getVar(cfg::VoxEditLastCameraDistance)->setVal(core::String::format("%f", cam.targetDistance()));
+}
+
+bool MainWindow::restoreCameraState() {
+	if (_viewports.empty()) {
+		return false;
+	}
+	const core::String &targetStr = core::getVar(cfg::VoxEditLastCameraTarget)->strVal();
+	const core::String &anglesStr = core::getVar(cfg::VoxEditLastCameraAngles)->strVal();
+	const core::String &distStr = core::getVar(cfg::VoxEditLastCameraDistance)->strVal();
+	if (targetStr.empty() || anglesStr.empty() || distStr.empty()) {
+		return false;
+	}
+	glm::vec3 target;
+	glm::quat q;
+	float distance;
+	if (SDL_sscanf(targetStr.c_str(), "%f %f %f", &target.x, &target.y, &target.z) != 3) {
+		return false;
+	}
+	if (SDL_sscanf(anglesStr.c_str(), "%f %f %f %f", &q.w, &q.x, &q.y, &q.z) != 4) {
+		return false;
+	}
+	if (SDL_sscanf(distStr.c_str(), "%f", &distance) != 1) {
+		return false;
+	}
+	video::Camera &cam = _viewports[0]->camera();
+	cam.setOrientation(q);
+	cam.setTarget(target);
+	cam.setTargetDistance(distance);
+	return true;
+}
+
 void MainWindow::shutdown() {
+	saveCameraState();
 	for (size_t i = 0; i < _viewports.size(); ++i) {
 		_viewports[i]->shutdown();
 	}
@@ -315,6 +357,13 @@ bool MainWindow::load(const core::String &file, const io::FormatDescription *for
 
 void MainWindow::onNewScene() {
 	resetCamera();
+	if (core::getVar(cfg::VoxEditContinueSession)->boolVal()) {
+		if (restoreCameraState()) {
+			core::getVar(cfg::VoxEditLastCameraTarget)->setVal("");
+			core::getVar(cfg::VoxEditLastCameraAngles)->setVal("");
+			core::getVar(cfg::VoxEditLastCameraDistance)->setVal("");
+		}
+	}
 	_animationTimeline.resetFrames();
 	checkPossibleVolumeSplit();
 }

--- a/src/tools/voxedit/modules/voxedit-ui/MainWindow.h
+++ b/src/tools/voxedit/modules/voxedit-ui/MainWindow.h
@@ -196,6 +196,9 @@ public:
 	bool isAnyEditMode() const;
 
 	bool saveScreenshot(const core::String &file, const core::String &viewportId = "");
+
+	void saveCameraState();
+	bool restoreCameraState();
 };
 
 inline const video::TexturePoolPtr &MainWindow::texturePool() const {

--- a/src/tools/voxedit/modules/voxedit-ui/OptionsPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/OptionsPanel.cpp
@@ -53,7 +53,8 @@ bool OptionsPanel::categoryHasMatch(OptionCategory category) const {
 			   matchesVarFilter(cfg::VoxEditColorWheel) || matchesVarFilter(cfg::VoxEditAnimationSpeed) ||
 			   matchesVarFilter(cfg::VoxEditAutoSaveSeconds) || matchesVarFilter(cfg::VoxEditViewports) ||
 			   matchesVarFilter(cfg::ClientCameraZoomSpeed) || matchesVarFilter(cfg::VoxEditViewdistance) ||
-			   matchesVarFilter(cfg::CoreColorReduction) || matchesVarFilter(cfg::VoxelMeshMode);
+			   matchesVarFilter(cfg::CoreColorReduction) || matchesVarFilter(cfg::VoxelMeshMode) ||
+			   matchesVarFilter(cfg::VoxEditContinueSession);
 	case OptionCategory::Metrics:
 		return matchesVarFilter(cfg::MetricFlavor);
 	case OptionCategory::Layout:
@@ -175,6 +176,9 @@ void OptionsPanel::renderEditor() {
 		static const core::Array<core::String, (int)voxel::MeshAllocStrategy::Max> meshAllocModes = {
 			_("Full pre-alloc"), _("Small (grow as needed)")};
 		ImGui::ComboVar(cfg::VoxelMeshAlloc, meshAllocModes);
+	}
+	if (matchesVarFilter(cfg::VoxEditContinueSession)) {
+		ImGui::CheckboxVar(cfg::VoxEditContinueSession);
 	}
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/Config.h
+++ b/src/tools/voxedit/modules/voxedit-util/Config.h
@@ -63,5 +63,9 @@ constexpr const char *VoxEditNetServerMaxConnections = "ve_netservermaxconnectio
 constexpr const char *VoxEditAutoSelect = "ve_autoselect";
 constexpr const char *VoxEditSceneMode = "ve_scenemode";
 constexpr const char *VoxEditImportSingleNode = "ve_importsinglenode";
+constexpr const char *VoxEditContinueSession = "ve_continuesession";
+constexpr const char *VoxEditLastCameraTarget = "ve_lastcameratarget";
+constexpr const char *VoxEditLastCameraAngles = "ve_lastcameraangles";
+constexpr const char *VoxEditLastCameraDistance = "ve_lastcameradist";
 
 }

--- a/src/tools/voxedit/modules/voxedit-util/Config.h
+++ b/src/tools/voxedit/modules/voxedit-util/Config.h
@@ -62,5 +62,6 @@ constexpr const char *VoxEditNetServerInterface = "ve_netserverinterface";
 constexpr const char *VoxEditNetServerMaxConnections = "ve_netservermaxconnections";
 constexpr const char *VoxEditAutoSelect = "ve_autoselect";
 constexpr const char *VoxEditSceneMode = "ve_scenemode";
+constexpr const char *VoxEditImportSingleNode = "ve_importsinglenode";
 
 }

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -632,6 +632,17 @@ bool SceneManager::import(const core::String& file) {
 		Log::error("Failed to load %s", file.c_str());
 		return false;
 	}
+	if (core::getVar(cfg::VoxEditImportSingleNode)->boolVal()) {
+		const scenegraph::SceneGraph::MergeResult &merged = newSceneGraph.merge();
+		if (merged.hasVolume()) {
+			newSceneGraph.clear();
+			scenegraph::SceneGraphNode newNode(scenegraph::SceneGraphNodeType::Model);
+			newNode.setVolume(merged.volume());
+			newNode.setPalette(merged.palette);
+			newNode.setNormalPalette(merged.normalPalette);
+			newSceneGraph.emplace(core::move(newNode));
+		}
+	}
 
 	scenegraph::SceneGraphNode groupNode(scenegraph::SceneGraphNodeType::Group);
 	groupNode.setName(core::string::extractFilename(file));
@@ -2929,6 +2940,8 @@ void SceneManager::construct() {
 	core::Var::registerVar(voxEditHideInactive);
 	const core::VarDef voxEditSceneMode(cfg::VoxEditSceneMode, false, N_("Scene mode"), N_("Start in scene mode"));
 	core::Var::registerVar(voxEditSceneMode);
+	const core::VarDef voxEditImportSingleNode(cfg::VoxEditImportSingleNode, false, N_("Import as single node"), N_("Merge all nodes into a single node when importing a file"));
+	core::Var::registerVar(voxEditImportSingleNode);
 	const core::VarDef voxEditViewdistance(cfg::VoxEditViewdistance, 5000, 10, 5000, N_("View distance"), N_("Far plane for the camera"));
 	core::Var::registerVar(voxEditViewdistance);
 	const core::VarDef voxEditShowaxis(cfg::VoxEditShowaxis, true, N_("Show gizmo"), N_("Show the axis"));

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -2942,6 +2942,11 @@ void SceneManager::construct() {
 	core::Var::registerVar(voxEditSceneMode);
 	const core::VarDef voxEditImportSingleNode(cfg::VoxEditImportSingleNode, false, N_("Import as single node"), N_("Merge all nodes into a single node when importing a file"));
 	core::Var::registerVar(voxEditImportSingleNode);
+	const core::VarDef voxEditContinueSession(cfg::VoxEditContinueSession, false, N_("Continue last session"), N_("Reopen the last file and restore camera position on startup"));
+	core::Var::registerVar(voxEditContinueSession);
+	core::Var::registerVar(core::VarDef(cfg::VoxEditLastCameraTarget, "", nullptr, nullptr));
+	core::Var::registerVar(core::VarDef(cfg::VoxEditLastCameraAngles, "", nullptr, nullptr));
+	core::Var::registerVar(core::VarDef(cfg::VoxEditLastCameraDistance, "", nullptr, nullptr));
 	const core::VarDef voxEditViewdistance(cfg::VoxEditViewdistance, 5000, 10, 5000, N_("View distance"), N_("Far plane for the camera"));
 	core::Var::registerVar(voxEditViewdistance);
 	const core::VarDef voxEditShowaxis(cfg::VoxEditShowaxis, true, N_("Show gizmo"), N_("Show the axis"));


### PR DESCRIPTION
## Summary
- **Continue last session**: New `ve_continuesession` option (Edit -> Options -> Editor) that reopens the last file and restores camera orientation on startup. Camera quaternion, target, and distance are saved on shutdown and restored after async load completes.
- **Import as single node**: Checkbox in the "Add file to scene" file dialog to merge all imported nodes into a single node instead of preserving multi-node structure.
- **Configurable sprint speed**: Replace hardcoded 3x sprint multiplier with `g_sprintmultiplier` config var.

## Test plan
- [ ] Enable "Continue last session" in Options, load a file, move camera, close and reopen
- [ ] Use "Add file to scene" with the single node checkbox enabled/disabled
- [ ] Test sprint speed with different `g_sprintmultiplier` values in game mode