### PR TITLE
Fix int32 overflow in volume indexing for large models

### DIFF
--- a/src/modules/core/collection/Array3DView.h
+++ b/src/modules/core/collection/Array3DView.h
@@ -21,8 +21,8 @@ private:
 	const int _height;
 	const int _depth;
 
-	constexpr int index(int x, int y, int z) const {
-		return x + _width * (y + _height * z);
+	constexpr int64_t index(int x, int y, int z) const {
+		return (int64_t)x + (int64_t)_width * (y + (int64_t)_height * z);
 	}
 
 public:
@@ -46,32 +46,32 @@ public:
 	}
 
 	constexpr const T &get(int x, int y, int z) const {
-		const int idx = index(x, y, z);
+		const int64_t idx = index(x, y, z);
 		return _data[idx];
 	}
 
 	constexpr T &get(int x, int y, int z) {
-		const int idx = index(x, y, z);
+		const int64_t idx = index(x, y, z);
 		return _data[idx];
 	}
 
 	constexpr void set(int x, int y, int z, const T &t) {
-		const int idx = index(x, y, z);
+		const int64_t idx = index(x, y, z);
 		_data[idx] = t;
 	}
 
 	constexpr const T &get(const glm::ivec3& v) const {
-		const int idx = index(v.x, v.y, v.z);
+		const int64_t idx = index(v.x, v.y, v.z);
 		return _data[idx];
 	}
 
 	constexpr T &get(const glm::ivec3& v) {
-		const int idx = index(v.x, v.y, v.z);
+		const int64_t idx = index(v.x, v.y, v.z);
 		return _data[idx];
 	}
 
 	constexpr void set(const glm::ivec3& v, const T &t) {
-		const int idx = index(v.x, v.y, v.z);
+		const int64_t idx = index(v.x, v.y, v.z);
 		_data[idx] = t;
 	}
 

--- a/src/modules/memento/MementoHandler.cpp
+++ b/src/modules/memento/MementoHandler.cpp
@@ -224,8 +224,8 @@ MementoData MementoData::fromVolume(const voxel::RawVolume *volume, const voxel:
 		// Use the RawVolume copy-with-region constructor which will handle regions
 		// that extend outside the source by filling with air or cropping as needed.
 		voxel::RawVolume v(*volume, region);
-		const int actualVoxels = v.region().voxels();
-		io::BufferedReadWriteStream outStream((int64_t)actualVoxels * sizeof(voxel::Voxel));
+		const int64_t actualVoxels = v.region().voxels();
+		io::BufferedReadWriteStream outStream(actualVoxels * (int64_t)sizeof(voxel::Voxel));
 		io::ZipWriteStream stream(outStream);
 		if (stream.write(v.data(), actualVoxels * sizeof(voxel::Voxel)) == -1) {
 			Log::error("Failed to compress memento volume data");
@@ -244,8 +244,8 @@ MementoData MementoData::fromVolume(const voxel::RawVolume *volume, const voxel:
 		}
 		return data;
 	}
-	const int allVoxels = volume->region().voxels();
-	io::BufferedReadWriteStream outStream((int64_t)allVoxels * sizeof(voxel::Voxel));
+	const int64_t allVoxels = volume->region().voxels();
+	io::BufferedReadWriteStream outStream(allVoxels * (int64_t)sizeof(voxel::Voxel));
 	io::ZipWriteStream stream(outStream);
 	if (stream.write(volume->data(), allVoxels * sizeof(voxel::Voxel)) == -1) {
 		Log::error("Failed to compress memento volume data");

--- a/src/modules/scenegraph/SceneGraph.cpp
+++ b/src/modules/scenegraph/SceneGraph.cpp
@@ -633,7 +633,7 @@ void SceneGraph::updateTransforms(bool updateChildren) {
 }
 
 voxel::Region SceneGraph::maxRegion() const {
-	int maxVoxels = 0;
+	int64_t maxVoxels = 0;
 	voxel::Region r;
 	for (const auto &n : nodes()) {
 		const SceneGraphNode &node = n->second;
@@ -1271,7 +1271,16 @@ SceneGraph::MergeResult SceneGraph::merge(bool skipHidden) const {
 		}
 		bakeIntoSparse(frameIdx, merged, node, mergedPalette);
 	});
-	voxel::RawVolume *mergedVolume = new voxel::RawVolume(merged.calculateRegion());
+	const voxel::Region mergedRegion = merged.calculateRegion();
+	if (!mergedRegion.isValid()) {
+		return MergeResult{};
+	}
+	voxel::RawVolume *mergedVolume = new voxel::RawVolume(mergedRegion);
+	if (mergedVolume->voxels() == nullptr) {
+		Log::error("Failed to allocate merged volume (%zu bytes)", voxel::RawVolume::size(mergedRegion));
+		delete mergedVolume;
+		return MergeResult{};
+	}
 	merged.copyTo(*mergedVolume);
 	return MergeResult{mergedVolume, mergedPalette, normalPalette};
 }

--- a/src/modules/scenegraph/SceneGraphUtil.cpp
+++ b/src/modules/scenegraph/SceneGraphUtil.cpp
@@ -237,9 +237,9 @@ static int copySceneGraphNodeResolveRef_r(SceneGraph &target, const SceneGraph &
 	SceneGraphNode newNode(type);
 	copy(sourceNode, newNode);
 	if (type == SceneGraphNodeType::Model) {
-		const voxel::RawVolume *vol = source.resolveVolume(sourceNode);
-		if (vol) {
-			newNode.setVolume(new voxel::RawVolume(*vol), true);
+		const voxel::RawVolume *srcVol = source.resolveVolume(sourceNode);
+		if (srcVol) {
+			newNode.setVolume(new voxel::RawVolume(*srcVol), true);
 		}
 	}
 	const int newNodeId = addToGraph(target, core::move(newNode), parent);

--- a/src/modules/voxel/RawVolume.cpp
+++ b/src/modules/voxel/RawVolume.cpp
@@ -6,6 +6,7 @@
 #include "app/ForParallel.h"
 #include "core/Algorithm.h"
 #include "core/Assert.h"
+#include "core/Log.h"
 #include "core/StandardLib.h"
 #include "core/Trace.h"
 #include <glm/common.hpp>
@@ -32,6 +33,10 @@ RawVolume::RawVolume(const RawVolume *copy) : _region(copy->region()) {
 	setBorderValue(copy->borderValue());
 	const size_t size = RawVolume::size(_region);
 	_data = (Voxel *)core_malloc(size);
+	if (_data == nullptr) {
+		Log::error("Failed to allocate %zu bytes for volume copy", size);
+		return;
+	}
 	_borderVoxel = copy->_borderVoxel;
 	core_memcpy((void*)_data, (const void*)copy->_data, size);
 }
@@ -40,6 +45,10 @@ RawVolume::RawVolume(const RawVolume &copy) : _region(copy.region()) {
 	setBorderValue(copy.borderValue());
 	const size_t size = RawVolume::size(_region);
 	_data = (Voxel *)core_malloc(size);
+	if (_data == nullptr) {
+		Log::error("Failed to allocate %zu bytes for volume copy", size);
+		return;
+	}
 	_borderVoxel = copy._borderVoxel;
 	core_memcpy((void*)_data, (const void*)copy._data, size);
 }
@@ -77,10 +86,18 @@ RawVolume::RawVolume(const RawVolume& src, const Region& region, bool *onlyAir) 
 		}
 		const size_t size = RawVolume::size(_region);
 		_data = (Voxel *)core_malloc(size);
+		if (_data == nullptr) {
+			Log::error("Failed to allocate %zu bytes for volume copy", size);
+			return;
+		}
 		core_memset((void *)_data, 0, size);
 	} else if (src.region() == _region) {
 		const size_t size = RawVolume::size(_region);
 		_data = (Voxel *)core_malloc(size);
+		if (_data == nullptr) {
+			Log::error("Failed to allocate %zu bytes for volume copy", size);
+			return;
+		}
 		core_memcpy((void *)_data, (const void *)src._data, size);
 		if (onlyAir) {
 			*onlyAir = false;
@@ -94,33 +111,37 @@ RawVolume::RawVolume(const RawVolume& src, const Region& region, bool *onlyAir) 
 		}
 		const size_t size = RawVolume::size(_region);
 		_data = (Voxel *)core_malloc(size);
+		if (_data == nullptr) {
+			Log::error("Failed to allocate %zu bytes for volume copy", size);
+			return;
+		}
 		const glm::ivec3 &tgtMins = _region.getLowerCorner();
 		const glm::ivec3 &tgtMaxs = _region.getUpperCorner();
 		const glm::ivec3 &srcMins = src._region.getLowerCorner();
 
-		const int tgtWidth = _region.getWidthInVoxels();
-		const int tgtHeight = _region.getHeightInVoxels();
-		const int tgtYStride = tgtWidth;
-		const int tgtZStride = tgtWidth * tgtHeight;
+		const int64_t tgtWidth = _region.getWidthInVoxels();
+		const int64_t tgtHeight = _region.getHeightInVoxels();
+		const int64_t tgtYStride = tgtWidth;
+		const int64_t tgtZStride = tgtWidth * tgtHeight;
 
-		const int srcWidth = src._region.getWidthInVoxels();
-		const int srcHeight = src._region.getHeightInVoxels();
-		const int srcYStride = srcWidth;
-		const int srcZStride = srcWidth * srcHeight;
+		const int64_t srcWidth = src._region.getWidthInVoxels();
+		const int64_t srcHeight = src._region.getHeightInVoxels();
+		const int64_t srcYStride = srcWidth;
+		const int64_t srcZStride = srcWidth * srcHeight;
 
 		const int lineLength = tgtMaxs.x - tgtMins.x + 1;
 		const size_t lineSize = sizeof(voxel::Voxel) * lineLength;
 
 		for (int z = tgtMins.z; z <= tgtMaxs.z; ++z) {
-			const int32_t tgtZPos = z - tgtMins.z;
-			const int32_t srcZPos = z - srcMins.z;
+			const int64_t tgtZPos = z - tgtMins.z;
+			const int64_t srcZPos = z - srcMins.z;
 
 			for (int y = tgtMins.y; y <= tgtMaxs.y; ++y) {
-				const int32_t tgtYPos = y - tgtMins.y;
-				const int32_t srcYPos = y - srcMins.y;
+				const int64_t tgtYPos = y - tgtMins.y;
+				const int64_t srcYPos = y - srcMins.y;
 
-				const int tgtBaseIndex = tgtZPos * tgtZStride + tgtYPos * tgtYStride + (tgtMins.x - _region.getLowerX());
-				const int srcBaseIndex = srcZPos * srcZStride + srcYPos * srcYStride + (tgtMins.x - srcMins.x);
+				const int64_t tgtBaseIndex = tgtZPos * tgtZStride + tgtYPos * tgtYStride + (tgtMins.x - _region.getLowerX());
+				const int64_t srcBaseIndex = srcZPos * srcZStride + srcYPos * srcYStride + (tgtMins.x - srcMins.x);
 
 				voxel::Voxel* tgtLine = &_data[tgtBaseIndex];
 				const voxel::Voxel* srcLine = &src._data[srcBaseIndex];
@@ -157,20 +178,20 @@ bool RawVolume::hasFlags(const Region &region, uint8_t flags) const {
 
 	const glm::ivec3 &mins = r.getLowerCorner();
 	const glm::ivec3 &maxs = r.getUpperCorner();
-	const int width = _region.getWidthInVoxels();
-	const int height = _region.getHeightInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t width = _region.getWidthInVoxels();
+	const int64_t height = _region.getHeightInVoxels();
+	const int64_t yStride = width;
+	const int64_t zStride = width * height;
 
-	const int xStart = mins.x - _region.getLowerX();
+	const int64_t xStart = mins.x - _region.getLowerX();
 	const int lineLength = maxs.x - mins.x + 1;
 
 	for (int z = mins.z; z <= maxs.z; ++z) {
-		const int zPos = z - _region.getLowerZ();
-		const int zBase = zPos * zStride + xStart;
+		const int64_t zPos = z - _region.getLowerZ();
+		const int64_t zBase = zPos * zStride + xStart;
 		for (int y = mins.y; y <= maxs.y; ++y) {
-			const int yPos = y - _region.getLowerY();
-			const int baseIndex = zBase + (yPos * yStride);
+			const int64_t yPos = y - _region.getLowerY();
+			const int64_t baseIndex = zBase + (yPos * yStride);
 
 			int offset = 0;
 			int remaining = lineLength;
@@ -227,20 +248,20 @@ void RawVolume::removeFlags(const Region &region, uint8_t flags) {
 
 	const glm::ivec3 &mins = r.getLowerCorner();
 	const glm::ivec3 &maxs = r.getUpperCorner();
-	const int width = _region.getWidthInVoxels();
-	const int height = _region.getHeightInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t width = _region.getWidthInVoxels();
+	const int64_t height = _region.getHeightInVoxels();
+	const int64_t yStride = width;
+	const int64_t zStride = width * height;
 
-	const int xStart = mins.x - _region.getLowerX();
+	const int64_t xStart = mins.x - _region.getLowerX();
 	const int lineLength = maxs.x - mins.x + 1;
 
 	for (int z = mins.z; z <= maxs.z; ++z) {
-		const int zPos = z - _region.getLowerZ();
-		const int zBase = zPos * zStride + xStart;
+		const int64_t zPos = z - _region.getLowerZ();
+		const int64_t zBase = zPos * zStride + xStart;
 		for (int y = mins.y; y <= maxs.y; ++y) {
-			const int yPos = y - _region.getLowerY();
-			const int baseIndex = zBase + (yPos * yStride);
+			const int64_t yPos = y - _region.getLowerY();
+			const int64_t baseIndex = zBase + (yPos * yStride);
 
 			int offset = 0;
 			int remaining = lineLength;
@@ -287,20 +308,20 @@ void RawVolume::toggleFlags(const Region &region, uint8_t flags) {
 
 	const glm::ivec3 &mins = r.getLowerCorner();
 	const glm::ivec3 &maxs = r.getUpperCorner();
-	const int width = _region.getWidthInVoxels();
-	const int height = _region.getHeightInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t width = _region.getWidthInVoxels();
+	const int64_t height = _region.getHeightInVoxels();
+	const int64_t yStride = width;
+	const int64_t zStride = width * height;
 
-	const int xStart = mins.x - _region.getLowerX();
+	const int64_t xStart = mins.x - _region.getLowerX();
 	const int lineLength = maxs.x - mins.x + 1;
 
 	for (int z = mins.z; z <= maxs.z; ++z) {
-		const int zPos = z - _region.getLowerZ();
-		const int zBase = zPos * zStride + xStart;
+		const int64_t zPos = z - _region.getLowerZ();
+		const int64_t zBase = zPos * zStride + xStart;
 		for (int y = mins.y; y <= maxs.y; ++y) {
-			const int yPos = y - _region.getLowerY();
-			const int baseIndex = zBase + (yPos * yStride);
+			const int64_t yPos = y - _region.getLowerY();
+			const int64_t baseIndex = zBase + (yPos * yStride);
 
 			int offset = 0;
 			int remaining = lineLength;
@@ -347,20 +368,20 @@ void RawVolume::setFlags(const Region &region, uint8_t flags) {
 
 	const glm::ivec3 &mins = r.getLowerCorner();
 	const glm::ivec3 &maxs = r.getUpperCorner();
-	const int width = _region.getWidthInVoxels();
-	const int height = _region.getHeightInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t width = _region.getWidthInVoxels();
+	const int64_t height = _region.getHeightInVoxels();
+	const int64_t yStride = width;
+	const int64_t zStride = width * height;
 
-	const int xStart = mins.x - _region.getLowerX();
+	const int64_t xStart = mins.x - _region.getLowerX();
 	const int lineLength = maxs.x - mins.x + 1;
 
 	for (int z = mins.z; z <= maxs.z; ++z) {
-		const int zPos = z - _region.getLowerZ();
-		const int zBase = zPos * zStride + xStart;
+		const int64_t zPos = z - _region.getLowerZ();
+		const int64_t zBase = zPos * zStride + xStart;
 		for (int y = mins.y; y <= maxs.y; ++y) {
-			const int yPos = y - _region.getLowerY();
-			const int baseIndex = zBase + (yPos * yStride);
+			const int64_t yPos = y - _region.getLowerY();
+			const int64_t baseIndex = zBase + (yPos * yStride);
 
 			int offset = 0;
 			int remaining = lineLength;
@@ -402,20 +423,20 @@ bool RawVolume::isEmpty(const Region &region) const {
 
 	const glm::ivec3 &mins = r.getLowerCorner();
 	const glm::ivec3 &maxs = r.getUpperCorner();
-	const int width = _region.getWidthInVoxels();
-	const int height = _region.getHeightInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t width = _region.getWidthInVoxels();
+	const int64_t height = _region.getHeightInVoxels();
+	const int64_t yStride = width;
+	const int64_t zStride = width * height;
 
 	const int lineLength = maxs.x - mins.x + 1;
 	const int voxelLineSize = sizeof(voxel::Voxel) * lineLength;
-	const int xStart = (mins.x - _region.getLowerX());
+	const int64_t xStart = (mins.x - _region.getLowerX());
 	for (int z = mins.z; z <= maxs.z; ++z) {
-		const int zPos = z - _region.getLowerZ();
-		const int zBase = zPos * zStride + xStart;
+		const int64_t zPos = z - _region.getLowerZ();
+		const int64_t zBase = zPos * zStride + xStart;
 		for (int y = mins.y; y <= maxs.y; ++y) {
-			const int yPos = y - _region.getLowerY();
-			const int baseIndex = zBase + (yPos * yStride);
+			const int64_t yPos = y - _region.getLowerY();
+			const int64_t baseIndex = zBase + (yPos * yStride);
 			const voxel::Voxel* dataLine = &_data[baseIndex];
 
 			if (core::memchr_not(dataLine, 0, voxelLineSize) != nullptr) {
@@ -453,35 +474,35 @@ bool RawVolume::copyInto(const RawVolume &src, const voxel::Region &region) {
 		const glm::ivec3 &mins = srcRegion.getLowerCorner();
 		const glm::ivec3 &maxs = srcRegion.getUpperCorner();
 		const voxel::Region &fullSrcRegion = src.region();
-		const int width = _region.getWidthInVoxels();
-		const int height = _region.getHeightInVoxels();
+		const int64_t width = _region.getWidthInVoxels();
+		const int64_t height = _region.getHeightInVoxels();
 
-		const int tgtYStride = width;
-		const int tgtZStride = width * height;
+		const int64_t tgtYStride = width;
+		const int64_t tgtZStride = width * height;
 
-		const int srcWidth = fullSrcRegion.getWidthInVoxels();
-		const int srcHeight = fullSrcRegion.getHeightInVoxels();
-		const int srcXOffset = mins.x - fullSrcRegion.getLowerX();
-		const int srcYOffset = mins.y - fullSrcRegion.getLowerY();
-		const int srcZOffset = mins.z - fullSrcRegion.getLowerZ();
-		const int srcYStride = srcWidth;
-		const int srcZStride = srcWidth * srcHeight;
-		const int tgtXOffset = mins.x - _region.getLowerX();
+		const int64_t srcWidth = fullSrcRegion.getWidthInVoxels();
+		const int64_t srcHeight = fullSrcRegion.getHeightInVoxels();
+		const int64_t srcXOffset = mins.x - fullSrcRegion.getLowerX();
+		const int64_t srcYOffset = mins.y - fullSrcRegion.getLowerY();
+		const int64_t srcZOffset = mins.z - fullSrcRegion.getLowerZ();
+		const int64_t srcYStride = srcWidth;
+		const int64_t srcZStride = srcWidth * srcHeight;
+		const int64_t tgtXOffset = mins.x - _region.getLowerX();
 
 		const int lineLength = maxs.x - mins.x + 1;
 		const size_t lineSize = sizeof(voxel::Voxel) * lineLength;
 		for (int z = start; z < end; ++z) {
-			const int tgtZPos = z - _region.getLowerZ();
-			const int srcZPos = srcZOffset + z - mins.z;
-			const int srcXZBaseIndex = srcXOffset + srcZPos * srcZStride;
-			const int tgtXZBaseIndex = tgtZPos * tgtZStride + tgtXOffset;
+			const int64_t tgtZPos = z - _region.getLowerZ();
+			const int64_t srcZPos = srcZOffset + z - mins.z;
+			const int64_t srcXZBaseIndex = srcXOffset + srcZPos * srcZStride;
+			const int64_t tgtXZBaseIndex = tgtZPos * tgtZStride + tgtXOffset;
 
 			for (int y = mins.y; y <= maxs.y; ++y) {
-				const int tgtYPos = y - _region.getLowerY();
-				const int srcYPos = srcYOffset + y - mins.y;
+				const int64_t tgtYPos = y - _region.getLowerY();
+				const int64_t srcYPos = srcYOffset + y - mins.y;
 
-				const int tgtBaseIndex = tgtXZBaseIndex + tgtYPos * tgtYStride;
-				const int srcBaseIndex = srcXZBaseIndex + srcYPos * srcYStride;
+				const int64_t tgtBaseIndex = tgtXZBaseIndex + tgtYPos * tgtYStride;
+				const int64_t srcBaseIndex = srcXZBaseIndex + srcYPos * srcYStride;
 
 				const voxel::Voxel* srcLine = &src._data[srcBaseIndex];
 				voxel::Voxel* tgtLine = &_data[tgtBaseIndex];
@@ -527,21 +548,21 @@ bool RawVolume::move(const glm::ivec3 &shift) {
 	t.y = (t.y % h + h) % h;
 	t.z = (t.z % d + d) % d;
 
-	const int hwstride = h * w;
+	const int64_t hwstride = (int64_t)h * w;
 	for (int z = 0; z < d; ++z) {
-		const int zhwstride = z * hwstride;
+		const int64_t zhwstride = (int64_t)z * hwstride;
 		for (int y = 0; y < h; ++y) {
-			const int begin = zhwstride + y * w;
-			core::rotate(_data + begin, _data + begin + t.x, _data + zhwstride + (y + 1) * w);
+			const int64_t begin = zhwstride + (int64_t)y * w;
+			core::rotate(_data + begin, _data + begin + t.x, _data + zhwstride + (int64_t)(y + 1) * w);
 		}
 	}
 
-	const int yoffset = t.y * w;
+	const int64_t yoffset = (int64_t)t.y * w;
 	for (int z = 0; z < d; ++z) {
-		core::rotate(_data + z * hwstride, _data + z * hwstride + yoffset, _data + (z + 1) * hwstride);
+		core::rotate(_data + (int64_t)z * hwstride, _data + (int64_t)z * hwstride + yoffset, _data + (int64_t)(z + 1) * hwstride);
 	}
 
-	core::rotate(_data, _data + t.z * hwstride, _data + d * hwstride);
+	core::rotate(_data, _data + (int64_t)t.z * hwstride, _data + (int64_t)d * hwstride);
 
 	return true;
 }
@@ -567,7 +588,7 @@ const Voxel &RawVolume::voxel(int32_t x, int32_t y, int32_t z) const {
 		const int32_t iLocalYPos = y - _region.getLowerY();
 		const int32_t iLocalZPos = z - _region.getLowerZ();
 
-		return _data[iLocalXPos + iLocalYPos * width() + iLocalZPos * _region.stride()];
+		return _data[(int64_t)iLocalXPos + (int64_t)iLocalYPos * width() + (int64_t)iLocalZPos * _region.stride()];
 	}
 	return _borderVoxel;
 }
@@ -590,7 +611,7 @@ bool RawVolume::setVoxel(int32_t x, int32_t y, int32_t z, const Voxel &voxel) {
 	return setVoxel(glm::ivec3(x, y, z), voxel);
 }
 
-bool RawVolume::setVoxel(int idx, const Voxel &voxel) {
+bool RawVolume::setVoxel(int64_t idx, const Voxel &voxel) {
 	if (idx < 0 || idx >= _region.stride() * depth()) {
 		return false; // Index out of bounds
 	}
@@ -616,7 +637,7 @@ bool RawVolume::setVoxel(const glm::ivec3 &pos, const Voxel &voxel) {
 	}
 	const glm::ivec3 &lowerCorner = _region.getLowerCorner();
 	const glm::ivec3 localPos = pos - lowerCorner;
-	const int index = localPos.x + localPos.y * width() + localPos.z * _region.stride();
+	const int64_t index = (int64_t)localPos.x + (int64_t)localPos.y * width() + (int64_t)localPos.z * _region.stride();
 	if (_data[index] == voxel) {
 		return false;
 	}
@@ -627,7 +648,7 @@ bool RawVolume::setVoxel(const glm::ivec3 &pos, const Voxel &voxel) {
 void RawVolume::setVoxelUnsafe(const glm::ivec3 &pos, const Voxel &voxel) {
 	const glm::ivec3 &lowerCorner = _region.getLowerCorner();
 	const glm::ivec3 localPos = pos - lowerCorner;
-	const int index = localPos.x + localPos.y * width() + localPos.z * _region.stride();
+	const int64_t index = (int64_t)localPos.x + (int64_t)localPos.y * width() + (int64_t)localPos.z * _region.stride();
 	_data[index] = voxel;
 }
 
@@ -644,8 +665,11 @@ void RawVolume::initialise(const Region &regValidRegion) {
 	// Create the data
 	const size_t size = RawVolume::size(_region);
 	_data = (Voxel *)core_malloc(size);
-	core_assert_msg_always(_data != nullptr, "Failed to allocate the memory for a volume with the dimensions %i:%i:%i",
-						   width(), height(), depth());
+	if (_data == nullptr) {
+		Log::error("Failed to allocate %zu bytes for a volume with the dimensions %i:%i:%i",
+				   size, width(), height(), depth());
+		return;
+	}
 
 	// Clear to zeros
 	clear();

--- a/src/modules/voxel/RawVolume.h
+++ b/src/modules/voxel/RawVolume.h
@@ -149,7 +149,7 @@ public:
 	 */
 	CORE_NO_SANITIZE_ADDRESS bool setVoxel(const glm::ivec3 &pos, const Voxel &voxel);
 	CORE_NO_SANITIZE_ADDRESS void setVoxelUnsafe(const glm::ivec3 &pos, const Voxel &voxel);
-	CORE_NO_SANITIZE_ADDRESS bool setVoxel(int idx, const Voxel &voxel);
+	CORE_NO_SANITIZE_ADDRESS bool setVoxel(int64_t idx, const Voxel &voxel);
 
 	void clear();
 	void fill(const voxel::Voxel &voxel);

--- a/src/modules/voxel/RawVolumeView.h
+++ b/src/modules/voxel/RawVolumeView.h
@@ -49,12 +49,12 @@ public:
 	}
 
 	inline glm::ivec3 viewPosFromIndex(size_t idx) const {
-		const int width = _region.getWidthInVoxels();
-		const int height = _region.getHeightInVoxels();
-		const int dim = width * height;
-		const int z = idx / dim;
-		const int y = (idx % dim) / width;
-		const int x = idx % width;
+		const int64_t width = _region.getWidthInVoxels();
+		const int64_t height = _region.getHeightInVoxels();
+		const int64_t dim = width * height;
+		const int z = (int)(idx / dim);
+		const int y = (int)((idx % dim) / width);
+		const int x = (int)(idx % width);
 		return {x, y, z};
 	}
 
@@ -63,7 +63,7 @@ public:
 	 * @see viewPosFromIndex()
 	 */
 	inline const Voxel &operator[](size_t idx) const {
-		if ((int)idx >= _region.voxels()) {
+		if ((int64_t)idx >= _region.voxels()) {
 			return _volume->borderValue();
 		}
 		return _volume->voxel(viewPosFromIndex(idx) + _region.getLowerCorner());

--- a/src/modules/voxel/Region.cpp
+++ b/src/modules/voxel/Region.cpp
@@ -97,7 +97,7 @@ void Region::update() {
 	_width = _maxs - _mins;
 	_center = _mins + _width / 2;
 	_voxels = _width + 1;
-	_stride = _voxels.x * _voxels.y;
+	_stride = (int64_t)_voxels.x * (int64_t)_voxels.y;
 }
 
 core::String Region::toString(bool center) const {
@@ -135,11 +135,11 @@ void logRegion(const char *ctx, const voxel::Region& region) {
 	Log::debug("%s: region[mins(%i,%i,%i), maxs(%i,%i,%i)]", ctx, mins.x, mins.y, mins.z, maxs.x, maxs.y, maxs.z);
 }
 
-int Region::voxels() const {
+int64_t Region::voxels() const {
 	if (!isValid()) {
 		return 0;
 	}
-	return getWidthInVoxels() * getHeightInVoxels() * getDepthInVoxels();
+	return (int64_t)getWidthInVoxels() * (int64_t)getHeightInVoxels() * (int64_t)getDepthInVoxels();
 }
 
 /**

--- a/src/modules/voxel/Region.h
+++ b/src/modules/voxel/Region.h
@@ -130,24 +130,24 @@ public:
 		return subtract(a, result);
 	}
 
-	glm::ivec3 fromIndex(uint32_t idx) const {
-		return glm::ivec3(_mins.x + (idx % getWidthInVoxels()),
-						  _mins.y + ((idx / getWidthInVoxels()) % getHeightInVoxels()),
-						  _mins.z + (idx / (_stride)));
+	glm::ivec3 fromIndex(int64_t idx) const {
+		return glm::ivec3(_mins.x + (int)(idx % getWidthInVoxels()),
+						  _mins.y + (int)((idx / getWidthInVoxels()) % getHeightInVoxels()),
+						  _mins.z + (int)(idx / _stride));
 	}
 
 	/**
 	 * @brief Calculates the linear index for the given coordinates within this region.
 	 */
-	inline int index(const glm::ivec3 &pos) const {
+	inline int64_t index(const glm::ivec3 &pos) const {
 		return index(pos.x, pos.y, pos.z);
 	}
 
 	/**
 	 * @brief Calculates the linear index for the given coordinates within this region.
 	 */
-	inline int index(int x, int y, int z) const {
-		return (x - _mins.x) + (y - _mins.y) * getWidthInVoxels() + (z - _mins.z) * _stride;
+	inline int64_t index(int x, int y, int z) const {
+		return (int64_t)(x - _mins.x) + (int64_t)(y - _mins.y) * getWidthInVoxels() + (int64_t)(z - _mins.z) * _stride;
 	}
 
 	/**
@@ -210,8 +210,8 @@ public:
 	/**
 	 * @return The amount of possible voxels in this region.
 	 */
-	int voxels() const;
-	int stride() const;
+	int64_t voxels() const;
+	int64_t stride() const;
 
 	/** Moves the Region by the amount specified. */
 	void shift(int32_t amountX, int32_t amountY, int32_t amountZ);
@@ -245,7 +245,7 @@ private:
 	glm::aligned_ivec4 _width;
 	glm::aligned_ivec4 _voxels;
 	glm::aligned_ivec4 _center;
-	int _stride;
+	int64_t _stride;
 };
 
 inline const glm::aligned_ivec4& Region::getLowerCorner4() const {
@@ -342,7 +342,7 @@ inline int32_t Region::getDepthInCells() const {
 	return _width.z;
 }
 
-inline int Region::stride() const {
+inline int64_t Region::stride() const {
 	return _stride;
 }
 

--- a/src/modules/voxel/VolumeData.h
+++ b/src/modules/voxel/VolumeData.h
@@ -14,19 +14,19 @@ private:
 	T *_data;
 	const voxel::Region _region;
 
-	inline int index(int x, int y, int z) const {
-		const int32_t iLocalXPos = x - _region.getLowerX();
-		const int32_t iLocalYPos = y - _region.getLowerY();
-		const int32_t iLocalZPos = z - _region.getLowerZ();
+	inline int64_t index(int x, int y, int z) const {
+		const int64_t iLocalXPos = x - _region.getLowerX();
+		const int64_t iLocalYPos = y - _region.getLowerY();
+		const int64_t iLocalZPos = z - _region.getLowerZ();
 		return iLocalXPos + (iLocalYPos * _region.getWidthInVoxels()) +
-			   (iLocalZPos * _region.getWidthInVoxels() * _region.getHeightInVoxels());
+			   (iLocalZPos * _region.stride());
 	}
 
 public:
 	using value_type = T;
 
 	VolumeData(const voxel::Region &region, T defaultVal) : _region(region) {
-		const int size = _region.voxels();
+		const int64_t size = _region.voxels();
 		_data = (T *)core_malloc(size * sizeof(T));
 		core_memset(_data, defaultVal, size * sizeof(T));
 	}
@@ -40,7 +40,7 @@ public:
 	}
 
 	void setValue(int x, int y, int z, const T &value) {
-		const int idx = index(x, y, z);
+		const int64_t idx = index(x, y, z);
 		if (idx < 0 || idx >= _region.voxels()) {
 			return;
 		}
@@ -55,7 +55,7 @@ public:
 		if (!_region.containsPoint(x, y, z)) {
 			return 0u;
 		}
-		const int idx = index(x, y, z);
+		const int64_t idx = index(x, y, z);
 		if (idx < 0 || idx >= _region.voxels()) {
 			return 0u;
 		}

--- a/src/modules/voxel/VolumeSampler.h
+++ b/src/modules/voxel/VolumeSampler.h
@@ -348,8 +348,8 @@ public:
 		// Then we update the voxel pointer
 		if (currentPositionValid()) {
 			const glm::aligned_ivec4 localPos = _posInVolume - region.getLowerCorner4();
-			const int32_t uVoxelIndex =
-				localPos.x + localPos.y * _volume->width() + localPos.z * _volume->width() * _volume->height();
+			const int64_t uVoxelIndex =
+				(int64_t)localPos.x + (int64_t)localPos.y * _volume->width() + (int64_t)localPos.z * region.stride();
 
 			_currentVoxel = _volume->voxels() + uVoxelIndex;
 			return true;
@@ -410,7 +410,7 @@ public:
 		if (core_unlikely(!bIsOldPositionValid)) {
 			setPosition(_posInVolume);
 		} else if (core_likely(currentPositionValid())) {
-			_currentVoxel += (intptr_t)(_volume->width() * offset);
+			_currentVoxel += (int64_t)_volume->width() * offset;
 		} else {
 			_currentVoxel = nullptr;
 		}
@@ -431,7 +431,7 @@ public:
 		if (core_unlikely(!bIsOldPositionValid)) {
 			setPosition(_posInVolume);
 		} else if (core_likely(currentPositionValid())) {
-			_currentVoxel += (intptr_t)(_volume->width() * _volume->height() * offset);
+			_currentVoxel += region().stride() * offset;
 		} else {
 			_currentVoxel = nullptr;
 		}
@@ -489,7 +489,7 @@ public:
 		if (core_unlikely(!bIsOldPositionValid)) {
 			setPosition(_posInVolume);
 		} else if (core_likely(currentPositionValid())) {
-			_currentVoxel -= (intptr_t)(_volume->width() * offset);
+			_currentVoxel -= (int64_t)_volume->width() * offset;
 		} else {
 			_currentVoxel = nullptr;
 		}
@@ -510,7 +510,7 @@ public:
 		if (core_unlikely(!bIsOldPositionValid)) {
 			setPosition(_posInVolume);
 		} else if (core_likely(currentPositionValid())) {
-			_currentVoxel -= (intptr_t)(_volume->width() * _volume->height() * offset);
+			_currentVoxel -= region().stride() * offset;
 		} else {
 			_currentVoxel = nullptr;
 		}

--- a/src/modules/voxel/private/CubicSurfaceExtractor.cpp
+++ b/src/modules/voxel/private/CubicSurfaceExtractor.cpp
@@ -65,7 +65,7 @@ private:
 public:
 	Array(uint32_t width, uint32_t height, uint32_t depth) :
 			_width(width), _height(height), _depth(depth) {
-		_elements = (VertexData*)core_malloc(width * height * depth * sizeof(VertexData));
+		_elements = (VertexData*)core_malloc((size_t)width * height * depth * sizeof(VertexData));
 		clear();
 	}
 
@@ -74,12 +74,12 @@ public:
 	}
 
 	void clear() {
-		core_memset((void*)_elements, 0x0, _width * _height * _depth * sizeof(VertexData));
+		core_memset((void*)_elements, 0x0, (size_t)_width * _height * _depth * sizeof(VertexData));
 	}
 
 	inline VertexData& operator()(uint32_t x, uint32_t y, uint32_t z) {
 		core_assert_msg(x < _width && y < _height && z < _depth, "Array access is out-of-range.");
-		return _elements[z * _width * _height + y * _width + x];
+		return _elements[(size_t)z * _width * _height + (size_t)y * _width + x];
 	}
 
 	void swap(Array& other) {

--- a/src/modules/voxel/private/TextureSurfaceExtractor.cpp
+++ b/src/modules/voxel/private/TextureSurfaceExtractor.cpp
@@ -172,16 +172,16 @@ static void collectFacePair(SurfaceExtractionContext &ctx, core::Buffer<PendingQ
 	// Direct volume access with precomputed strides
 	const Voxel *volData = volume->voxels();
 	const Region &volRegion = volume->region();
-	const int volW = volume->width();
-	const int volStride = volRegion.stride();
+	const int64_t volW = volume->width();
+	const int64_t volStride = volRegion.stride();
 
-	const int dimStrides[3] = {1, volW, volStride};
-	const int uVolStride = dimStrides[axes.x];
-	const int vVolStride = dimStrides[axes.y];
-	const int sVolStride = dimStrides[axes.z];
+	const int64_t dimStrides[3] = {1, volW, volStride};
+	const int64_t uVolStride = dimStrides[axes.x];
+	const int64_t vVolStride = dimStrides[axes.y];
+	const int64_t sVolStride = dimStrides[axes.z];
 
-	const int volBase =
-		(rx - volRegion.getLowerX()) + (ry - volRegion.getLowerY()) * volW + (rz - volRegion.getLowerZ()) * volStride;
+	const int64_t volBase =
+		(rx - volRegion.getLowerX()) + (int64_t)(ry - volRegion.getLowerY()) * volW + (int64_t)(rz - volRegion.getLowerZ()) * volStride;
 
 	const int rOrigin[3] = {rx, ry, rz};
 	const int sAbsBase = rOrigin[axes.z];
@@ -211,11 +211,11 @@ static void collectFacePair(SurfaceExtractionContext &ctx, core::Buffer<PendingQ
 		const bool posNeighborInVolume = (neighborSPos >= sVolLower && neighborSPos <= sVolUpper);
 		const bool negNeighborInVolume = (neighborSNeg >= sVolLower && neighborSNeg <= sVolUpper);
 
-		const int sliceBase = volBase + s * sVolStride;
+		const int64_t sliceBase = volBase + s * sVolStride;
 
 		int maskCountPos = 0, maskCountNeg = 0;
 		for (int u = 0; u < uIterMax; ++u) {
-			int volIdx = sliceBase + u * uVolStride;
+			int64_t volIdx = sliceBase + u * uVolStride;
 			const int maskColBase = u * vDim;
 			for (int v = 0; v < vIterMax; ++v) {
 				const Voxel &vox = volData[volIdx];

--- a/src/modules/voxel/tests/RegionTest.cpp
+++ b/src/modules/voxel/tests/RegionTest.cpp
@@ -244,7 +244,7 @@ TEST_F(RegionTest, testIndexBackAndForth) {
 	const int size = region.voxels();
 	for (int i = 0; i < size; ++i) {
 		const glm::ivec3 pos = region.fromIndex(i);
-		const int idx = region.index(pos);
+		const int64_t idx = region.index(pos);
 		EXPECT_EQ(i, idx);
 	}
 }

--- a/src/modules/voxelformat/Format.cpp
+++ b/src/modules/voxelformat/Format.cpp
@@ -194,6 +194,10 @@ bool Format::save(const scenegraph::SceneGraph &sceneGraph, const core::String &
 	if (singleVolume() && sceneGraph.size(scenegraph::SceneGraphNodeType::AllModels) > 1) {
 		Log::debug("Merge volumes before saving as the target format only supports one volume");
 		scenegraph::SceneGraph::MergeResult merged = sceneGraph.merge(saveVisibleOnly);
+		if (!merged.hasVolume()) {
+			Log::error("Failed to merge volumes for saving");
+			return false;
+		}
 		scenegraph::SceneGraph mergedSceneGraph;
 		scenegraph::SceneGraphNode mergedNode(scenegraph::SceneGraphNodeType::Model);
 		mergedNode.setVolume(merged.volume(), true);

--- a/src/modules/voxelformat/private/binvox/BinVoxFormat.cpp
+++ b/src/modules/voxelformat/private/binvox/BinVoxFormat.cpp
@@ -6,6 +6,7 @@
 #include "BinVoxFormat.h"
 #include "color/Color.h"
 #include "core/Log.h"
+#include <inttypes.h>
 #include "core/ScopedPtr.h"
 #include "core/StringUtil.h"
 #include "core/Var.h"
@@ -208,15 +209,15 @@ bool BinVoxFormat::saveGroups(const scenegraph::SceneGraph &sceneGraph, const co
 	uint8_t count = 0u;
 	uint8_t value = 0u;
 	uint32_t voxels = 0u;
-	const int maxIndex = width * height * depth;
+	const int64_t maxIndex = (int64_t)width * height * depth;
 	glm::ivec3 pos = mins;
 	const uint8_t emptyColorReplacement = node->palette().findReplacement(0);
 	Log::debug("found replacement for %s at index %u: %s at index %u",
 			   color::print(node->palette().color(0)).c_str(), 0,
 			   color::print(node->palette().color(emptyColorReplacement)).c_str(), emptyColorReplacement);
-	for (int idx = 0; idx < maxIndex; ++idx) {
+	for (int64_t idx = 0; idx < maxIndex; ++idx) {
 		if (!sampler.setPosition(pos)) {
-			Log::error("Failed to set position for index %i (%i:%i:%i) (w:%i,h:%i,d:%i)", idx, pos.x, pos.y, pos.z,
+			Log::error("Failed to set position for index %" PRId64 " (%i:%i:%i) (w:%i,h:%i,d:%i)", idx, pos.x, pos.y, pos.z,
 					   width, height, depth);
 			return false;
 		}
@@ -267,9 +268,9 @@ bool BinVoxFormat::saveGroups(const scenegraph::SceneGraph &sceneGraph, const co
 	wrapBool(writeValue(stream, value, binvoxVersion))
 	wrapBool(stream->writeUInt8(count))
 	voxels += count;
-	const uint32_t expectedVoxels = width * height * depth;
+	const uint64_t expectedVoxels = (uint64_t)width * height * depth;
 	if (voxels != expectedVoxels) {
-		Log::error("Not enough data was written: %u vs %u (w: %u, h: %u, d: %u)", voxels, expectedVoxels, width, height,
+		Log::error("Not enough data was written: %u vs %" PRIu64 " (w: %u, h: %u, d: %u)", voxels, expectedVoxels, width, height,
 				   depth);
 		return false;
 	}

--- a/src/modules/voxelformat/private/cubzh/CubzhFormat.cpp
+++ b/src/modules/voxelformat/private/cubzh/CubzhFormat.cpp
@@ -282,7 +282,7 @@ bool CubzhFormat::loadShape5(const core::String &filename, const Header &header,
 				voxel::RawVolume *volume = new voxel::RawVolume(region);
 				node.setVolume(volume, true);
 				int i = 0;
-				if (width * height * depth > (int)volumeBuffer.size()) {
+				if ((int64_t)width * height * depth > (int64_t)volumeBuffer.size()) {
 					Log::error("invalid blocks chunk");
 					return false;
 				}
@@ -559,7 +559,7 @@ bool CubzhFormat::loadShape6(const core::String &filename, const Header &header,
 				voxel::RawVolume *volume = new voxel::RawVolume(region);
 				node.setVolume(volume, true);
 				int i = 0;
-				if (width * height * depth > (int)volumeBuffer.size()) {
+				if ((int64_t)width * height * depth > (int64_t)volumeBuffer.size()) {
 					Log::error("invalid blocks chunk");
 					return false;
 				}

--- a/src/modules/voxelformat/private/magicavoxel/VoxFormat.cpp
+++ b/src/modules/voxelformat/private/magicavoxel/VoxFormat.cpp
@@ -16,6 +16,7 @@
 #include "voxel/RawVolume.h"
 #include "voxelformat/external/ogt_vox.h"
 #include "voxelutil/VolumeVisitor.h"
+#include <climits>
 #include <glm/gtc/quaternion.hpp>
 #include "MagicaVoxel.h"
 #include "palette/Palette.h"
@@ -98,11 +99,26 @@ bool VoxFormat::loadInstance(const ogt_vox_scene *scene, uint32_t ogt_instanceId
 	}
 	return false;
 #else
-	const glm::ivec3 &ogtMins = calcTransform(ogtMat, glm::vec3(0));
-	const glm::ivec3 &ogtMaxs = calcTransform(ogtMat, ogtVolumeSize(ogtModel));
-	const glm::ivec3 mins(-(ogtMins.x + 1), ogtMins.z, ogtMins.y);
-	const glm::ivec3 maxs(-(ogtMaxs.x + 1), ogtMaxs.z, ogtMaxs.y);
-	voxel::Region region(glm::min(mins, maxs), glm::max(mins, maxs));
+	const glm::vec3 volSize = ogtVolumeSize(ogtModel);
+	const glm::vec3 corners[8] = {
+		glm::vec3(0),
+		glm::vec3(volSize.x, 0, 0),
+		glm::vec3(0, volSize.y, 0),
+		glm::vec3(volSize.x, volSize.y, 0),
+		glm::vec3(0, 0, volSize.z),
+		glm::vec3(volSize.x, 0, volSize.z),
+		glm::vec3(0, volSize.y, volSize.z),
+		volSize
+	};
+	glm::ivec3 mins(INT_MAX);
+	glm::ivec3 maxs(INT_MIN);
+	for (int c = 0; c < 8; ++c) {
+		const glm::ivec3 ogtCorner = calcTransform(ogtMat, corners[c]);
+		const glm::ivec3 pos(-(ogtCorner.x + 1), ogtCorner.z, ogtCorner.y);
+		mins = glm::min(mins, pos);
+		maxs = glm::max(maxs, pos);
+	}
+	voxel::Region region(mins, maxs);
 	const glm::ivec3 shift = region.getLowerCorner();
 	region.shift(-shift);
 	voxel::RawVolume *v = new voxel::RawVolume(region);

--- a/src/modules/voxelformat/private/magicavoxel/XRawFormat.cpp
+++ b/src/modules/voxelformat/private/magicavoxel/XRawFormat.cpp
@@ -145,7 +145,7 @@ size_t XRawFormat::loadPalette(const core::String &filename, const io::ArchivePt
 		return 0;
 	}
 
-	if (stream->skip(width * height * depth * bitsPerIndex / 8u) == -1) {
+	if (stream->skip((int64_t)width * height * depth * bitsPerIndex / 8u) == -1) {
 		Log::error("Could not load xraw file: Not enough data in stream");
 		return 0;
 	}

--- a/src/modules/voxelformat/private/minecraft/MTSFormat.cpp
+++ b/src/modules/voxelformat/private/minecraft/MTSFormat.cpp
@@ -208,11 +208,11 @@ bool MTSFormat::saveGroups(const scenegraph::SceneGraph &sceneGraph, const core:
 		}
 	}
 	// probability values (param1)
-	for (int32_t n = 0; n < region.voxels(); ++n) {
+	for (int64_t n = 0; n < region.voxels(); ++n) {
 		wrapBool(zipStream.writeUInt8(0x7f))
 	}
 	// param2
-	for (int32_t n = 0; n < region.voxels(); ++n) {
+	for (int64_t n = 0; n < region.voxels(); ++n) {
 		wrapBool(zipStream.writeUInt8(0x00))
 	}
 	zipStream.flush();

--- a/src/modules/voxelformat/private/minecraft/SchematicFormat.cpp
+++ b/src/modules/voxelformat/private/minecraft/SchematicFormat.cpp
@@ -132,9 +132,9 @@ bool SchematicFormat::saveGroups(const scenegraph::SceneGraph &sceneGraph, const
 			voxel::RawVolume::Sampler sampler2 = sampler;
 			for (int y = 0; y < size.y; ++y) {
 				voxel::RawVolume::Sampler sampler3 = sampler2;
-				const int stride = (y * size.z + z) * size.x;
+				const int64_t stride = ((int64_t)y * size.z + z) * size.x;
 				for (int x = 0; x < size.x; ++x) {
-					const int idx = stride + x;
+					const int64_t idx = stride + x;
 					const voxel::Voxel &voxel = sampler3.voxel();
 					if (voxel::isAir(voxel.getMaterial())) {
 						blocks[idx] = 0;

--- a/src/modules/voxelformat/private/minecraft/schematic/Sponge.cpp
+++ b/src/modules/voxelformat/private/minecraft/schematic/Sponge.cpp
@@ -282,9 +282,9 @@ static bool parseBlocks(const priv::NamedBinaryTag &schematic, scenegraph::Scene
 			voxel::RawVolume::Sampler sampler2 = sampler;
 			for (int y = 0; y < height; ++y) {
 				voxel::RawVolume::Sampler sampler3 = sampler2;
-				const int stride = (y * depth + z) * width;
+				const int64_t stride = ((int64_t)y * depth + z) * width;
 				for (int x = 0; x < width; ++x) {
-					const int idx = stride + x;
+					const int64_t idx = stride + x;
 					const uint8_t palIdx = (*blocks.byteArray())[idx];
 					if (palIdx != 0u) {
 						uint8_t currentPalIdx;

--- a/src/modules/voxelformat/private/veloren/VelorenTerrainFormat.cpp
+++ b/src/modules/voxelformat/private/veloren/VelorenTerrainFormat.cpp
@@ -180,11 +180,11 @@ bool VelorenTerrainFormat::saveGroups(const scenegraph::SceneGraph &sceneGraph, 
 		return false;
 	}
 	const palette::Palette &palette = node->palette();
-	const uint32_t count = region.voxels();
+	const int64_t count = region.voxels();
 	wrapBool(stream->writeUInt64(versionMagic(3)))
 	wrapBool(stream->writeUInt64(count))
 
-	for (uint32_t i = 0; i < count; ++i) {
+	for (int64_t i = 0; i < count; ++i) {
 		const glm::ivec3 pos = region.fromIndex(i);
 		const voxel::Voxel voxel = volume->voxel(pos);
 		const color::RGBA color = palette.color(voxel.getColor());

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -585,7 +585,7 @@ void RawVolumeRenderer::renderNormals(const voxel::MeshStatePtr &meshState, cons
 			_shapeBuilder.setColor(color::Red());
 			if (const voxel::RawVolume *v = meshState->volume(idx)) {
 				if (v->region().voxels() < 128 * 128 * 128) {
-					const int n = v->region().stride();
+					const int64_t n = v->region().stride();
 					_shapeBuilder.reserve(2 * n, 2 * n);
 					voxelutil::visitSurfaceVolume(
 						*v, [this, &normalPalette](int x, int y, int z, const voxel::Voxel &voxel) {

--- a/src/modules/voxelutil/FillHollow.h
+++ b/src/modules/voxelutil/FillHollow.h
@@ -27,7 +27,7 @@ void fillHollow(VOLUME &volume, const voxel::Voxel &voxel) {
 	const int width = region.getWidthInVoxels();
 	const int height = region.getHeightInVoxels();
 	const int depth = region.getDepthInVoxels();
-	const int size = width * height * depth;
+	const int64_t size = (int64_t)width * height * depth;
 	const glm::ivec3 mins = volume.region().getLowerCorner();
 	core::Buffer<bool> visitedData(size);
 	core::Array3DView<bool> visited(visitedData.data(), width, height, depth);

--- a/src/modules/voxelutil/VolumeCropper.cpp
+++ b/src/modules/voxelutil/VolumeCropper.cpp
@@ -35,8 +35,8 @@ namespace voxelutil {
 	const int width = region.getWidthInVoxels();
 	const int height = region.getHeightInVoxels();
 	const int depth = region.getDepthInVoxels();
-	const int yStride = width;
-	const int zStride = width * height;
+	const int64_t yStride = width;
+	const int64_t zStride = (int64_t)width * height;
 	const voxel::Voxel *data = volume->voxels();
 	const size_t lineSize = sizeof(voxel::Voxel) * width;
 
@@ -49,9 +49,9 @@ namespace voxelutil {
 
 	// Scan through all Z-Y planes to find bounds
 	for (int z = 0; z < depth; ++z) {
-		const int zBase = z * zStride;
+		const int64_t zBase = z * zStride;
 		for (int y = 0; y < height; ++y) {
-			const int baseIndex = zBase + y * yStride;
+			const int64_t baseIndex = zBase + y * yStride;
 			const voxel::Voxel *lineStart = &data[baseIndex];
 
 			// Check if this line has any non-air voxels

--- a/src/modules/voxelutil/VolumeSplitter.cpp
+++ b/src/modules/voxelutil/VolumeSplitter.cpp
@@ -113,6 +113,12 @@ core::Buffer<voxel::RawVolume *> splitVolume(const voxel::RawVolume *volume, con
 					const voxel::Region innerRegion(innerMins, innerMaxs);
 					bool onlyAir = true;
 					voxel::RawVolume *copy = new voxel::RawVolume(*volume, innerRegion, createEmpty ? nullptr : &onlyAir);
+					if (copy->voxels() == nullptr) {
+						Log::error("Failed to allocate split volume for region %s", innerRegion.toString().c_str());
+						delete copy;
+						++idx;
+						continue;
+					}
 					if (onlyAir && !createEmpty) {
 						Log::debug("- skip empty %s", innerRegion.toString().c_str());
 						delete copy;


### PR DESCRIPTION
## Summary
- Fix int32 overflow in `Region::_stride`, `Region::voxels()`, and all volume 
  index/stride calculations across the codebase (27 files). Volumes where 
  `width * height > INT_MAX` (~46341^2) caused negative indices and SIGSEGV crashes.
- Add null checks after volume allocations in scene graph copy (`copySceneGraph`, 
  `splitVolumes`) and save paths to handle OOM gracefully instead of crashing.
- Fix VoxFormat 8-corner bounding box computation for rotated instances.

## Details
The int32 overflow affected:
- **RawVolume**: copy constructors, `hasFlags`/`removeFlags`/`toggleFlags`/`setFlags`, 
  `isEmpty`, `copyInto`, `move`
- **VolumeSampler**: `setPosition()`, `movePositiveY/Z`, `moveNegativeY/Z`
- **Region**: `_stride` field, `voxels()` return type, `index()`, `fromIndex()`
- **Supporting classes**: `VolumeData`, `Array3DView`, `RawVolumeView`
- **Surface extractors**: `TextureSurfaceExtractor`, `CubicSurfaceExtractor`
- **Format code**: BinVox, Cubzh, XRaw, MTS, Schematic, Sponge, Veloren
- **Utilities**: `VolumeCropper`, `FillHollow`, `MementoHandler`

## Test plan
- [ ] Load and save large .vox models (total bounding box > 46341 in any two dimensions)
- [ ] Verify existing unit tests pass
- [ ] Test .vengi and .vox save/load round-trip with multi-node scenes