### PR TITLE
Fix brush preview trailing stale visuals on cursor move

### DIFF
--- a/src/tools/voxedit/modules/voxedit-util/modifier/IModifierRenderer.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/IModifierRenderer.h
@@ -83,6 +83,17 @@ public:
 	}
 
 	/**
+	 * @brief Clear the renderer's brush volume pointers to nullptr.
+	 *
+	 * Must be called before freeing preview volumes to prevent dangling pointer
+	 * comparisons in MeshState::setVolume(). Without this, the allocator may reuse
+	 * the same address for a new volume, causing setVolume() to skip the update
+	 * (old == new pointer) and leaving stale mesh data in GPU buffers.
+	 */
+	virtual void clearBrushVolumes() {
+	}
+
+	/**
 	 * @brief Wait for any pending mesh extractions to complete.
 	 *
 	 * This must be called before freeing preview volumes to avoid race conditions

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -586,7 +586,13 @@ static void createOrClearPreviewVolume(voxel::RawVolume *existingVolume, core::S
 		}
 		volume->clear();
 	} else {
+		// Keep the old volume alive during allocation so the heap allocator
+		// cannot reuse the same address. MeshState::setVolume() compares raw
+		// pointers (old == new) and skips the update when they match, which
+		// would leave stale mesh data in GPU buffers.
+		voxel::RawVolume *old = volume.release();
 		volume = new voxel::RawVolume(*existingVolume, region);
+		delete old;
 	}
 }
 
@@ -639,6 +645,11 @@ bool Modifier::isSimplePreview(const Brush *brush, const voxel::Region &region) 
 }
 
 void Modifier::resetPreview() {
+	// Clear renderer volume pointers before freeing the volumes.
+	// The allocator may reuse the same heap address for the next preview volume,
+	// which would cause MeshState::setVolume() to see old == new and skip the
+	// update, leaving stale mesh data in GPU buffers.
+	_modifierRenderer->clearBrushVolumes();
 	_previewVolume = nullptr;
 	_previewMirrorVolume = nullptr;
 	_brushPreview = BrushPreview();
@@ -758,11 +769,10 @@ void Modifier::render(const video::Camera &camera, palette::Palette &activePalet
 
 	if (ctx.brushActive) {
 		if (brush->dirty()) {
-			if (_nextPreviewUpdateSeconds > 0.0) {
-				_nextPreviewUpdateSeconds -= 0.02;
-			} else {
-				_nextPreviewUpdateSeconds = _nowSeconds + 0.1;
-			}
+			// Clear stale preview so the old position does not keep
+			// rendering, then regenerate immediately at the new position.
+			resetPreview();
+			_nextPreviewUpdateSeconds = _nowSeconds;
 			brush->markClean();
 		}
 		if (_nextPreviewUpdateSeconds > 0.0) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ModifierRenderer.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ModifierRenderer.cpp
@@ -121,6 +121,11 @@ void ModifierRenderer::updateCursor(const voxel::Voxel& voxel, voxel::FaceNames 
 	_shapeRenderer.createOrUpdate(_voxelCursorMesh, _shapeBuilder);
 }
 
+void ModifierRenderer::clearBrushVolumes() {
+	updateBrushVolume(0, nullptr, nullptr);
+	updateBrushVolume(1, nullptr, nullptr);
+}
+
 void ModifierRenderer::clear() {
 	_volumeRenderer.clear(_meshState);
 	for (int i = 0; i < lengthof(_aabbMeshes); ++i) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/ModifierRenderer.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/ModifierRenderer.h
@@ -47,6 +47,7 @@ public:
 	bool init() override;
 	void shutdown() override;
 
+	void clearBrushVolumes() override;
 	void update(const ModifierRendererContext &ctx) override;
 	void render(const video::Camera &camera, const glm::mat4 &modelMatrix) override;
 	void waitForPendingExtractions() override;


### PR DESCRIPTION
## Summary
- **Root cause**: `MeshState::setVolume()` compares raw pointers (`old == new`) and skips updates when they match. After `resetPreview()` freed the old preview volume, the heap allocator could reuse the same address for the new allocation, leaving stale mesh data in GPU buffers at the old cursor position.
- Clear the renderer's volume pointers before freeing via new `clearBrushVolumes()` virtual method on `IModifierRenderer`
- Keep old allocation alive during new allocation (`release`/`delete`) in `createOrClearPreviewVolume` as a second defense against address reuse
- Replace the debounce timer with immediate regeneration to eliminate the preview lag window

## Test plan
- [x] Existing 250 unit tests pass
- [ ] Open a model, select Paint select mode with radius, move mouse quickly over surface -- no stale preview trail at old cursor positions
- [ ] Verify no flickering when moving cursor slowly
- [ ] Test with other select modes (Circle, Lasso) to ensure no regression