### PR TITLE
VOXEDIT: add ExtendPlane sculpt mode

### DIFF
--- a/src/modules/voxelrender/shaders/voxel.vert
+++ b/src/modules/voxelrender/shaders/voxel.vert
@@ -32,6 +32,8 @@ void main(void) {
 #else
 		v_flags |= FLAGOUTLINE;
 #endif
+	} else if ((a_flags & FLAGOUTLINE) != 0u) {
+		v_flags |= FLAGOUTLINE;
 	}
 
 	if (normalIndex > 0) { // NO_NORMAL

--- a/src/modules/voxelrender/shaders/voxelnorm.vert
+++ b/src/modules/voxelrender/shaders/voxelnorm.vert
@@ -27,6 +27,8 @@ void main(void) {
 #else
 		v_flags |= FLAGOUTLINE;
 #endif
+	} else if ((a_flags & FLAGOUTLINE) != 0u) {
+		v_flags |= FLAGOUTLINE;
 	}
 
 	if (u_gray != 0 || (u_has_selection != 0 && (a_flags & FLAGOUTLINE) == 0u)) {

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -36,6 +36,9 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "squashtoplane") {
 		return SculptMode::SquashToPlane;
 	}
+	if (mode == "extendplane") {
+		return SculptMode::ExtendPlane;
+	}
 	if (mode == "reskin") {
 		return SculptMode::Reskin;
 	}

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -70,12 +70,13 @@ static constexpr const char *SculptModeStr[] = {
 	NC_("Sculpt Modes", "Flatten"),		 NC_("Sculpt Modes", "Smooth Additive"),
 	NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"),
 	NC_("Sculpt Modes", "Bridge Gap"),	 NC_("Sculpt Modes", "Squash to Plane"),
-	NC_("Sculpt Modes", "Reskin")};
+	NC_("Sculpt Modes", "Extend Plane"), NC_("Sculpt Modes", "Reskin")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
 static constexpr const char *SculptModeIcons[] = {ICON_LC_ERASER, ICON_LC_SPROUT,	  ICON_LC_LAND_PLOT,
 												  ICON_LC_WAVES,  ICON_LC_WAVES,	  ICON_LC_BLEND,
-												  ICON_LC_LINK,	  ICON_LC_MINIMIZE_2, ICON_LC_PALETTE};
+												  ICON_LC_LINK,	  ICON_LC_MINIMIZE_2, ICON_LC_EXPAND,
+												  ICON_LC_PALETTE};
 static_assert(lengthof(SculptModeIcons) == (int)SculptMode::Max, "SculptModeIcons size mismatch");
 
 // clang-format off
@@ -1803,6 +1804,38 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 			brush.setReskinInvertSkin(invertSkin);
 			executeSculptBrush();
 		}
+	} else if (currentMode == SculptMode::ExtendPlane) {
+		int radius = brush.brushRadius();
+		ImGui::TextUnformatted(_("Brush radius"));
+		if (ImGui::Button("-##extend_radius")) {
+			brush.setBrushRadius(radius - 1);
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##extend_radius_slider", &radius, 1, SculptBrush::MaxBrushRadius)) {
+			brush.setBrushRadius(radius);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##extend_radius")) {
+			brush.setBrushRadius(radius + 1);
+		}
+		bool extendOnly = brush.extendOnly();
+		if (ImGui::Checkbox(_("Extend only"), &extendOnly)) {
+			brush.setExtendOnly(extendOnly);
+		}
+		int removeDepth = brush.removeAboveDepth();
+		ImGui::TextUnformatted(_("Remove above"));
+		if (ImGui::Button("-##remove_depth")) {
+			brush.setRemoveAboveDepth(removeDepth - 1);
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##remove_depth_slider", &removeDepth, 0, SculptBrush::MaxRemoveAboveDepth)) {
+			brush.setRemoveAboveDepth(removeDepth);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##remove_depth")) {
+			brush.setRemoveAboveDepth(removeDepth + 1);
+		}
+		ImGui::TooltipTextUnformatted(_("Perpendicular depth of voxels to remove above the plane (0 = no removal)"));
 	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap &&
 			   currentMode != SculptMode::SquashToPlane) {
 		float strength = brush.strength();
@@ -1813,7 +1846,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 	}
 
 	if (currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane &&
-		currentMode != SculptMode::Reskin) {
+		currentMode != SculptMode::Reskin && currentMode != SculptMode::ExtendPlane) {
 		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
 		if (needsFace) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -178,6 +178,13 @@ void Modifier::update(double nowSeconds, const video::Camera *camera) {
 				_nextSingleExecution = nowSeconds + 0.1;
 			}
 		}
+	} else if (Brush *b = currentBrush()) {
+		if (b->wantsContinuousExecution()) {
+			if (_actionExecuteButton.pressed() && nowSeconds >= _nextSingleExecution) {
+				_actionExecuteButton.execute(true);
+				_nextSingleExecution = nowSeconds + 0.1;
+			}
+		}
 	}
 	if (Brush *brush = currentBrush()) {
 		brush->update(_brushContext, nowSeconds);
@@ -644,6 +651,12 @@ bool Modifier::isSimplePreview(const Brush *brush, const voxel::Region &region) 
 		const SelectMode mode = selectBrush->selectMode();
 		if (mode == SelectMode::All || mode == SelectMode::Surface || mode == SelectMode::Box3D ||
 			mode == SelectMode::SameColor || mode == SelectMode::FuzzyColor) {
+			return true;
+		}
+	}
+	if (brush->type() == BrushType::Sculpt) {
+		const SculptBrush *sculptBrush = (const SculptBrush *)brush;
+		if (sculptBrush->sculptMode() == SculptMode::ExtendPlane && sculptBrush->planeFitted()) {
 			return true;
 		}
 	}

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
@@ -370,6 +370,14 @@ public:
 	}
 
 	/**
+	 * @return true if this brush should execute on every frame while the mouse button is held,
+	 * rather than only on mouse-up. Used for paint-drag style brushes.
+	 */
+	virtual bool wantsContinuousExecution() const {
+		return false;
+	}
+
+	/**
 	 * @brief Calculate the region this brush will modify
 	 *
 	 * Each brush defines its own logic for determining the affected region.

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -6,6 +6,8 @@
 #include "core/GLM.h"
 #include "core/Trace.h"
 #include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicMap.h"
+#include "math/Axis.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxel/BitVolume.h"
 #include "voxel/Connectivity.h"
@@ -29,6 +31,8 @@ void SculptBrush::onSceneChange() {
 	_snapshotRegion = voxel::Region::InvalidRegion;
 	_cachedRegion = voxel::Region::InvalidRegion;
 	_cachedRegionValid = false;
+	_planeFitted = false;
+	_lastPaintPos = glm::ivec3(INT_MIN);
 }
 
 void SculptBrush::onActivated() {
@@ -77,6 +81,13 @@ void SculptBrush::reset() {
 	_sigma = 4.0f;
 	_sculptMode = SculptMode::Erode;
 	_flattenFace = voxel::FaceNames::Max;
+	_removeAboveDepth = 0;
+	_extendOnly = true;
+	_brushRadius = 3;
+	_planeFitted = false;
+	_planeGradU = 0.0f;
+	_planeGradV = 0.0f;
+	_lastPaintPos = glm::ivec3(INT_MIN);
 }
 
 bool SculptBrush::beginBrush(const BrushContext &ctx) {
@@ -98,6 +109,7 @@ bool SculptBrush::beginBrush(const BrushContext &ctx) {
 
 void SculptBrush::endBrush(BrushContext &) {
 	_active = false;
+	_lastPaintPos = glm::ivec3(INT_MIN);
 }
 
 bool SculptBrush::active() const {
@@ -113,12 +125,47 @@ void SculptBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *vo
 			adjustSnapshotForRegionShift(delta);
 		}
 	}
+	if (_hasSnapshot && _sculptMode == SculptMode::ExtendPlane && _planeFitted) {
+		if (_active && ctx.cursorPosition != _lastPaintPos) {
+			_paramsDirty = true;
+		}
+	}
 	if (_hasSnapshot) {
 		_cachedRegion = _snapshotRegion;
 		if (_sculptMode == SculptMode::Reskin) {
 			// Expand along face normal for z offset + skin layers growing outward
 			const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
 			_cachedRegion.grow(expand);
+		} else if (_sculptMode == SculptMode::ExtendPlane && _planeFitted) {
+			// Show brush preview around cursor position
+			const int r = _brushRadius;
+			glm::ivec3 lo = ctx.cursorPosition;
+			glm::ivec3 hi = ctx.cursorPosition;
+			lo[_planeUAxis] -= r;
+			lo[_planeVAxis] -= r;
+			hi[_planeUAxis] += r;
+			hi[_planeVAxis] += r;
+			// Predict height range across the brush corners
+			const float h00 = static_cast<float>(_planeSeedH) +
+							  _planeGradU * static_cast<float>(lo[_planeUAxis] - _planeSeedU) +
+							  _planeGradV * static_cast<float>(lo[_planeVAxis] - _planeSeedV);
+			const float h11 = static_cast<float>(_planeSeedH) +
+							  _planeGradU * static_cast<float>(hi[_planeUAxis] - _planeSeedU) +
+							  _planeGradV * static_cast<float>(hi[_planeVAxis] - _planeSeedV);
+			const float h01 = static_cast<float>(_planeSeedH) +
+							  _planeGradU * static_cast<float>(lo[_planeUAxis] - _planeSeedU) +
+							  _planeGradV * static_cast<float>(hi[_planeVAxis] - _planeSeedV);
+			const float h10 = static_cast<float>(_planeSeedH) +
+							  _planeGradU * static_cast<float>(hi[_planeUAxis] - _planeSeedU) +
+							  _planeGradV * static_cast<float>(lo[_planeVAxis] - _planeSeedV);
+			const float minH = glm::min(glm::min(h00, h11), glm::min(h01, h10));
+			const float maxH = glm::max(glm::max(h00, h11), glm::max(h01, h10));
+			lo[_planeHeightAxis] = static_cast<int>(glm::floor(minH)) - 1;
+			hi[_planeHeightAxis] = static_cast<int>(glm::ceil(maxH)) + 1;
+			_cachedRegion = voxel::Region(lo, hi);
+		} else if (_sculptMode == SculptMode::ExtendPlane) {
+			// Plane not yet fitted - show snapshot region
+			_cachedRegion.grow(_iterations);
 		} else {
 			// Expand by iterations since smoothing can grow surface by 1 voxel per iteration
 			_cachedRegion.grow(_iterations);
@@ -392,6 +439,19 @@ void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrap
 	}
 	_paramsDirty = false;
 
+	// ExtendPlane uses additive painting - no history restore between strokes
+	if (_sculptMode == SculptMode::ExtendPlane) {
+		if (!_planeFitted && _flattenFace != voxel::FaceNames::Max) {
+			fitPlaneFromSnapshot();
+		}
+		if (_planeFitted && _active) {
+			paintExtendPlane(wrapper, ctx);
+			_lastPaintPos = ctx.cursorPosition;
+			markDirty();
+		}
+		return;
+	}
+
 	voxel::RawVolume *vol = wrapper.volume();
 
 	// Restore previously modified state before re-applying
@@ -413,6 +473,262 @@ void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrap
 	markDirty();
 }
 
+void SculptBrush::fitPlaneFromSnapshot() {
+	core_trace_scoped(SculptBrushFitPlane);
+
+	_planeHeightAxis = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
+	_planeUAxis = (_planeHeightAxis + 1) % 3;
+	_planeVAxis = (_planeHeightAxis + 2) % 3;
+	const bool fromPositive = voxel::isPositiveFace(_flattenFace);
+
+	// Build height map from snapshot: surface height per (u,v) column
+	// Key is ivec3 with height axis zeroed out (no hash<ivec2> available)
+	using HeightMap = core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>>;
+	HeightMap heightMap;
+
+	struct HeightCollector {
+		HeightMap *map;
+		int uAxis;
+		int vAxis;
+		int heightAxis;
+		bool fromPositive;
+		bool setVoxel(int x, int y, int z, const voxel::Voxel &) {
+			const glm::ivec3 pos(x, y, z);
+			glm::ivec3 key(pos);
+			key[heightAxis] = 0;
+			auto it = map->find(key);
+			if (it == map->end()) {
+				map->put(key, pos[heightAxis]);
+			} else {
+				if (fromPositive) {
+					it->value = glm::max(it->value, pos[heightAxis]);
+				} else {
+					it->value = glm::min(it->value, pos[heightAxis]);
+				}
+			}
+			return true;
+		}
+	};
+	HeightCollector collector{&heightMap, _planeUAxis, _planeVAxis, _planeHeightAxis, fromPositive};
+	_snapshot.copyTo(collector);
+
+	if (heightMap.empty()) {
+		_planeFitted = false;
+		return;
+	}
+
+	// Pick seed from first entry
+	auto seedIt = heightMap.begin();
+	_planeSeedU = seedIt->key[_planeUAxis];
+	_planeSeedV = seedIt->key[_planeVAxis];
+	_planeSeedH = seedIt->value;
+
+	// 2D linear regression: h = seedH + gradU*(u-seedU) + gradV*(v-seedV)
+	double sumDU = 0.0, sumDV = 0.0, sumDH = 0.0;
+	double sumDU2 = 0.0, sumDV2 = 0.0, sumDUDV = 0.0;
+	double sumDUDH = 0.0, sumDVDH = 0.0;
+	int planeN = 0;
+
+	for (auto it = heightMap.begin(); it != heightMap.end(); ++it) {
+		const double du = static_cast<double>(it->key[_planeUAxis] - _planeSeedU);
+		const double dv = static_cast<double>(it->key[_planeVAxis] - _planeSeedV);
+		const double dh = static_cast<double>(it->value - _planeSeedH);
+		sumDU += du;
+		sumDV += dv;
+		sumDH += dh;
+		sumDU2 += du * du;
+		sumDV2 += dv * dv;
+		sumDUDV += du * dv;
+		sumDUDH += du * dh;
+		sumDVDH += dv * dh;
+		++planeN;
+	}
+
+	_planeGradU = 0.0f;
+	_planeGradV = 0.0f;
+
+	static constexpr int MinPlaneSamples = 3;
+	static constexpr double MinDeterminant = 0.001;
+
+	if (planeN >= MinPlaneSamples) {
+		const double n = static_cast<double>(planeN);
+		const double meanDU = sumDU / n;
+		const double meanDV = sumDV / n;
+		const double meanDH = sumDH / n;
+		const double suu = sumDU2 - n * meanDU * meanDU;
+		const double svv = sumDV2 - n * meanDV * meanDV;
+		const double suv = sumDUDV - n * meanDU * meanDV;
+		const double suh = sumDUDH - n * meanDU * meanDH;
+		const double svh = sumDVDH - n * meanDV * meanDH;
+		const double det = suu * svv - suv * suv;
+		if (glm::abs(det) > MinDeterminant) {
+			_planeGradU = static_cast<float>((svv * suh - suv * svh) / det);
+			_planeGradV = static_cast<float>((suu * svh - suv * suh) / det);
+		}
+	}
+
+	_planeFitted = true;
+}
+
+void SculptBrush::paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
+	core_trace_scoped(SculptBrushPaintExtendPlane);
+
+	voxel::RawVolume *vol = wrapper.volume();
+	const voxel::Region &volRegion = vol->region();
+	const bool fromPositive = voxel::isPositiveFace(_flattenFace);
+	const int step = fromPositive ? 1 : -1;
+
+	const int cursorU = ctx.cursorPosition[_planeUAxis];
+	const int cursorV = ctx.cursorPosition[_planeVAxis];
+
+	voxel::Voxel fillVoxel = ctx.cursorVoxel;
+	if (voxel::isAir(fillVoxel.getMaterial())) {
+		fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	}
+	fillVoxel.setFlags(voxel::FlagOutline);
+
+	// UV neighbor offsets for gap-filling span extension (du, dv)
+	static constexpr int uvNeighborDU[] = {-1, 1, 0, 0};
+	static constexpr int uvNeighborDV[] = {0, 0, -1, 1};
+	static constexpr int numUVNeighbors = 4;
+
+	// Precompute removal ray direction (perpendicular to fitted plane)
+	static constexpr float RayStep = 0.5f;
+	const voxel::Voxel air;
+	glm::vec3 removeNormal(0.0f);
+	const float removeLineLen = static_cast<float>(_removeAboveDepth);
+	if (_removeAboveDepth > 0) {
+		removeNormal[_planeUAxis] = -_planeGradU;
+		removeNormal[_planeVAxis] = -_planeGradV;
+		removeNormal[_planeHeightAxis] = 1.0f;
+		removeNormal *= static_cast<float>(step);
+		removeNormal = glm::normalize(removeNormal);
+	}
+
+	for (int u = cursorU - _brushRadius; u <= cursorU + _brushRadius; ++u) {
+		for (int v = cursorV - _brushRadius; v <= cursorV + _brushRadius; ++v) {
+			const float predictedHf = static_cast<float>(_planeSeedH) +
+									  _planeGradU * static_cast<float>(u - _planeSeedU) +
+									  _planeGradV * static_cast<float>(v - _planeSeedV);
+
+			// Fill vertical span from floor to ceil to cover sub-voxel plane position
+			int loH = static_cast<int>(glm::floor(predictedHf));
+			int hiH = static_cast<int>(glm::ceil(predictedHf));
+
+			// Extend span toward UV neighbors to bridge gaps on steep slopes
+			for (int ni = 0; ni < numUVNeighbors; ++ni) {
+				const float neighborH = static_cast<float>(_planeSeedH) +
+										_planeGradU * static_cast<float>(u + uvNeighborDU[ni] - _planeSeedU) +
+										_planeGradV * static_cast<float>(v + uvNeighborDV[ni] - _planeSeedV);
+				const int midH = static_cast<int>(glm::round((predictedHf + neighborH) * 0.5f));
+				loH = glm::min(loH, midH);
+				hiH = glm::max(hiH, midH);
+			}
+
+			// In extend-only mode, only place voxels adjacent to existing solid
+			bool canPlace = true;
+			if (_extendOnly) {
+				canPlace = false;
+				for (int h = loH; h <= hiH && !canPlace; ++h) {
+					glm::ivec3 pos;
+					pos[_planeUAxis] = u;
+					pos[_planeVAxis] = v;
+					pos[_planeHeightAxis] = h;
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+						const glm::ivec3 neighbor = pos + offset;
+						if (!volRegion.containsPoint(neighbor)) {
+							continue;
+						}
+						if (voxel::isBlocked(vol->voxel(neighbor).getMaterial())) {
+							canPlace = true;
+							break;
+						}
+					}
+				}
+			}
+
+			// Remove voxels along a thick 3D ray perpendicular to the plane.
+			// Only remove voxels that do NOT have FlagOutline (preserves selected
+			// and newly placed voxels).
+			if (_removeAboveDepth > 0) {
+				glm::vec3 origin;
+				origin[_planeUAxis] = static_cast<float>(u);
+				origin[_planeVAxis] = static_cast<float>(v);
+				origin[_planeHeightAxis] = static_cast<float>(hiH) + 0.5f * static_cast<float>(step);
+
+				glm::ivec3 prevPos(INT_MIN);
+				for (float t = 0.0f; t <= removeLineLen; t += RayStep) {
+					const glm::vec3 fp = origin + removeNormal * t;
+					const glm::ivec3 pos(static_cast<int>(glm::round(fp.x)),
+										 static_cast<int>(glm::round(fp.y)),
+										 static_cast<int>(glm::round(fp.z)));
+					if (pos == prevPos) {
+						continue;
+					}
+					prevPos = pos;
+					// Clear center + 18 face/edge neighbors, but skip outlined voxels
+					if (volRegion.containsPoint(pos)) {
+						const voxel::Voxel &vx = vol->voxel(pos);
+						if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
+							writeVoxel(wrapper, pos, air);
+						}
+					}
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+						const glm::ivec3 nPos = pos + offset;
+						if (volRegion.containsPoint(nPos)) {
+							const voxel::Voxel &vx = vol->voxel(nPos);
+							if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
+								writeVoxel(wrapper, nPos, air);
+							}
+						}
+					}
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderEdges) {
+						const glm::ivec3 nPos = pos + offset;
+						if (volRegion.containsPoint(nPos)) {
+							const voxel::Voxel &vx = vol->voxel(nPos);
+							if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
+								writeVoxel(wrapper, nPos, air);
+							}
+						}
+					}
+				}
+			}
+
+			// Place voxels at predicted plane height
+			if (canPlace) {
+				for (int h = loH; h <= hiH; ++h) {
+					glm::ivec3 pos;
+					pos[_planeUAxis] = u;
+					pos[_planeVAxis] = v;
+					pos[_planeHeightAxis] = h;
+
+					if (!volRegion.containsPoint(pos)) {
+						continue;
+					}
+
+					const voxel::Voxel &existing = vol->voxel(pos);
+					if (voxel::isAir(existing.getMaterial())) {
+						voxel::Voxel newVoxel = fillVoxel;
+						for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+							const glm::ivec3 neighbor = pos + offset;
+							if (!volRegion.containsPoint(neighbor)) {
+								continue;
+							}
+							const voxel::Voxel &nv = vol->voxel(neighbor);
+							if (voxel::isBlocked(nv.getMaterial())) {
+								newVoxel = voxel::createVoxel(nv.getMaterial(), nv.getColor(), nv.getNormal(),
+															  voxel::FlagOutline, nv.getBoneIdx());
+								break;
+							}
+						}
+						writeVoxel(wrapper, pos, newVoxel);
+					}
+				}
+			}
+		}
+	}
+}
+
 void SculptBrush::setSculptMode(SculptMode mode) {
 	const bool needsFace = modeNeedsFace(mode);
 	const bool hadFace = modeNeedsFace(_sculptMode);
@@ -421,6 +737,10 @@ void SculptBrush::setSculptMode(SculptMode mode) {
 	}
 	if (mode == SculptMode::SmoothGaussian && _sculptMode != SculptMode::SmoothGaussian) {
 		_iterations = 3;
+	}
+	if (mode == SculptMode::ExtendPlane && _sculptMode != SculptMode::ExtendPlane) {
+		_planeFitted = false;
+		_lastPaintPos = glm::ivec3(INT_MIN);
 	}
 	_sculptMode = mode;
 	_paramsDirty = true;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -13,6 +13,7 @@
 #include "voxel/Voxel.h"
 #include "voxelutil/VolumeSculpt.h"
 
+#include <climits>
 #include <glm/vec3.hpp>
 
 namespace voxel {
@@ -30,6 +31,7 @@ enum class SculptMode : uint8_t {
 	SmoothGaussian,
 	BridgeGap,
 	SquashToPlane,
+	ExtendPlane,
 	Reskin,
 
 	Max
@@ -62,6 +64,21 @@ private:
 	bool _hasSnapshot = false;
 	bool _paramsDirty = true;
 
+	// ExtendPlane parameters
+	int _removeAboveDepth = 0;
+	bool _extendOnly = true;
+	int _brushRadius = 3;
+	float _planeGradU = 0.0f;
+	float _planeGradV = 0.0f;
+	int _planeSeedU = 0;
+	int _planeSeedV = 0;
+	int _planeSeedH = 0;
+	int _planeUAxis = 0;
+	int _planeVAxis = 2;
+	int _planeHeightAxis = 1;
+	bool _planeFitted = false;
+	glm::ivec3 _lastPaintPos{INT_MIN};
+
 	// Reskin parameters
 	voxelutil::ReskinConfig _reskinConfig;
 	const voxel::RawVolume *_skinVolume = nullptr;
@@ -88,6 +105,8 @@ private:
 	void applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
 	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
 	void writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &voxel);
+	void fitPlaneFromSnapshot();
+	void paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
 
 protected:
 	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
@@ -113,6 +132,7 @@ public:
 	bool active() const override;
 	voxel::Region calcRegion(const BrushContext &ctx) const override;
 	bool managesOwnSelection() const override;
+	bool wantsContinuousExecution() const override;
 
 	static bool modeNeedsFace(SculptMode mode);
 
@@ -148,6 +168,17 @@ public:
 	static constexpr float MinSigma = 0.1f;
 	float sigma() const;
 	void setSigma(float sigma);
+
+	// ExtendPlane accessors
+	static constexpr int MaxBrushRadius = 32;
+	static constexpr int MaxRemoveAboveDepth = 32;
+	int removeAboveDepth() const;
+	void setRemoveAboveDepth(int depth);
+	bool extendOnly() const;
+	void setExtendOnly(bool extend);
+	int brushRadius() const;
+	void setBrushRadius(int radius);
+	bool planeFitted() const;
 
 	// Reskin accessors
 	static constexpr int MaxReskinDepth = 32;
@@ -185,9 +216,14 @@ inline bool SculptBrush::managesOwnSelection() const {
 	return true;
 }
 
+inline bool SculptBrush::wantsContinuousExecution() const {
+	return _sculptMode == SculptMode::ExtendPlane && _planeFitted;
+}
+
 inline bool SculptBrush::modeNeedsFace(SculptMode mode) {
 	return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode ||
-		   mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane || mode == SculptMode::Reskin;
+		   mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane || mode == SculptMode::ExtendPlane ||
+		   mode == SculptMode::Reskin;
 }
 
 inline SculptMode SculptBrush::sculptMode() const {
@@ -327,6 +363,35 @@ inline void SculptBrush::setReskinZOffset(int offset) {
 inline void SculptBrush::setReskinInvertSkin(bool invert) {
 	_reskinConfig.invertSkin = invert;
 	_paramsDirty = true;
+}
+
+inline int SculptBrush::removeAboveDepth() const {
+	return _removeAboveDepth;
+}
+
+inline void SculptBrush::setRemoveAboveDepth(int depth) {
+	_removeAboveDepth = glm::clamp(depth, 0, MaxRemoveAboveDepth);
+	_paramsDirty = true;
+}
+
+inline bool SculptBrush::extendOnly() const {
+	return _extendOnly;
+}
+
+inline void SculptBrush::setExtendOnly(bool extend) {
+	_extendOnly = extend;
+}
+
+inline int SculptBrush::brushRadius() const {
+	return _brushRadius;
+}
+
+inline void SculptBrush::setBrushRadius(int radius) {
+	_brushRadius = glm::clamp(radius, 1, MaxBrushRadius);
+}
+
+inline bool SculptBrush::planeFitted() const {
+	return _planeFitted;
 }
 
 inline const voxel::RawVolume *SculptBrush::skinVolume() const {

--- a/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
@@ -321,4 +321,235 @@ TEST_F(SculptBrushTest, testFlattenReversible) {
 	brush.shutdown();
 }
 
+TEST_F(SculptBrushTest, testExtendPlaneFlatSurface) {
+	// A flat 5x5 selected surface at y=0. Painting adjacent area should place voxels at y=0.
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	for (int x = -2; x <= 2; ++x) {
+		for (int z = -2; z <= 2; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	// First click: captures face and fits plane
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+	ASSERT_TRUE(brush.planeFitted());
+
+	// Second click: paint at x=5, z=0 to extend the flat surface
+	ctx.cursorPosition = glm::ivec3(5, 0, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Voxels should be placed at y=0 in the painted area
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(5, 0, 0).getMaterial()))
+		<< "Extended voxel at (5,0,0) should be placed at plane height y=0";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 0, 0).getMaterial()))
+		<< "Extended voxel at (4,0,0) should be placed at plane height y=0";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testExtendPlaneSlopedSurface) {
+	// A sloped surface: y increases with x. Painting beyond should follow the slope.
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	// Create slope: y = x (for x from -2 to 2, z from -1 to 1)
+	for (int x = -2; x <= 2; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, x, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(0);
+	brush.setExtendOnly(false);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	// First click: captures face and fits plane
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+	ASSERT_TRUE(brush.planeFitted());
+
+	// Paint at x=4, z=0 - should place voxel at y=4 (following slope y=x)
+	ctx.cursorPosition = glm::ivec3(4, 4, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 4, 0).getMaterial()))
+		<< "Sloped extension at (4,4,0) should follow y=x slope";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testExtendPlaneRemoveAbove) {
+	// Flat surface at y=0 with voxels stacked at y=1..5. Extend + remove depth=2
+	// should place the plane AND remove layers above. y=5 is well beyond the
+	// thick ray reach (depth + neighbor expansion) and should survive.
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	for (int x = -2; x <= 2; ++x) {
+		for (int z = -2; z <= 2; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+	// Stack above at x=0
+	volume.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+	volume.setVoxel(0, 2, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+	volume.setVoxel(0, 3, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+	volume.setVoxel(0, 5, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(1);
+	brush.setRemoveAboveDepth(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	// First click: captures face and fits plane
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+	ASSERT_TRUE(brush.planeFitted());
+
+	// Paint at (3,0,0) - extends plane AND removes above
+	ctx.cursorPosition = glm::ivec3(3, 0, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	// Plane extended at x=3
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Plane should be extended to (3,0,0)";
+	// Original plane remains
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()))
+		<< "Original plane voxel at (0,0,0) should remain";
+	// y=1 and y=2 removed (within depth=2 above hiH=0)
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 0).getMaterial()))
+		<< "Voxel at y=1 should be removed (within depth=2)";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 2, 0).getMaterial()))
+		<< "Voxel at y=2 should be removed (within depth=2)";
+	// y=5 well beyond remove depth + thick ray neighbor expansion
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 5, 0).getMaterial()))
+		<< "Voxel at y=5 should NOT be removed (beyond depth=2 + neighbor reach)";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testExtendPlaneNoPlaneFitted) {
+	// Without clicking a face, painting should be a no-op
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	for (int x = -1; x <= 1; ++x) {
+		for (int z = -1; z <= 1; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(2);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	// No cursorFace set (defaults to Max)
+
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	EXPECT_FALSE(brush.planeFitted())
+		<< "Plane should not be fitted without a face click";
+
+	// Area outside original selection should remain empty
+	EXPECT_TRUE(voxel::isAir(volume.voxel(5, 0, 0).getMaterial()))
+		<< "No voxels should be placed without a fitted plane";
+
+	brush.shutdown();
+}
+
+TEST_F(SculptBrushTest, testExtendPlaneExtendOnly) {
+	// With extend-only, painting far from existing voxels should be a no-op
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	for (int x = -2; x <= 2; ++x) {
+		for (int z = -2; z <= 2; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(0);
+	ASSERT_TRUE(brush.extendOnly());
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	// First click: captures face and fits plane
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+	ASSERT_TRUE(brush.planeFitted());
+
+	// Paint adjacent to existing surface - should place
+	ctx.cursorPosition = glm::ivec3(3, 0, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Adjacent column should be placed in extend-only mode";
+
+	// Paint far from existing surface - should NOT place
+	ctx.cursorPosition = glm::ivec3(8, 0, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(8, 0, 0).getMaterial()))
+		<< "Disconnected column should NOT be placed in extend-only mode";
+
+	brush.shutdown();
+}
+
 } // namespace voxedit


### PR DESCRIPTION
## Summary
- New **Extend Plane** sculpt mode: fits a plane via 2D linear regression on the selected surface, then allows paint-drag to extend it in any direction following the slope
- **Brush radius** slider (1-32) controls paint area, with wireframe preview box at cursor
- **Extend only** checkbox (default on) prevents floating disconnected voxel chunks by requiring face-adjacency to existing solid
- **Remove above** slider (0-32) clears voxels perpendicular to the fitted plane above the brush, using a thick 3D ray (18 face+edge neighbors) for gap-free removal on slopes. Skips voxels with FlagOutline to protect selected/placed voxels
- **Continuous paint-drag**: `wantsContinuousExecution()` virtual on Brush base class enables frame-by-frame execution while mouse is held
- **Selection tint fix**: vertex shaders (voxel.vert, voxelnorm.vert) now pass FLAGOUTLINE through when `u_has_selection != 0`
- MCP tool updated with `"extendplane"` mode string
- 5 unit tests covering flat surface, sloped surface, remove-above, no-plane-fitted, and extend-only

## Known issues
- Small gap can appear between existing surface and newly painted plane on some slopes (cosmetic, to be investigated separately)

## Test plan
- [ ] Build: `cmake --build build --target voxedit -j$(nproc)`
- [ ] Tests: `cmake --build build --target tests-voxedit-util -j$(nproc) && ./build/tests-voxedit-util/vengi-tests-voxedit-util --gtest_filter="*ExtendPlane*"`
- [ ] Manual: Select a surface, switch to Sculpt > Extend Plane, click a face to fit the plane, paint-drag to extend
- [ ] Verify brush preview box follows cursor after plane is fitted
- [ ] Verify extend-only prevents floating chunks when painting in air
- [ ] Verify remove-above clears voxels above the plane without gaps
- [ ] Verify selection tint (blue overlay) shows on selected voxels