### PR TITLE
VOXEDIT: added SculptBrush SmoothWall mode

### DIFF
--- a/docs/lua/sculpt.md
+++ b/docs/lua/sculpt.md
@@ -14,6 +14,7 @@ Global: `g_sculpt`
 | `smoothadditive(volume, face, heightThreshold, iterations, color)` | Fill height gaps by scanning layers along a face normal. Air voxels on solid ground get filled when a neighbor column is significantly taller. Each iteration adds at most one voxel per column. |
 | `smootherode(volume, face, iterations, preserveTopHeight, trimPerStep)` | Remove edge voxels from the top of columns along a face normal. Scans top-to-bottom, removing top-of-column voxels that have fewer than 4 solid planar neighbors. Each iteration removes at most one voxel per column. |
 | `smoothgaussian(volume, face, kernelSize, sigma, iterations, color)` | Blur the height map using a 2D Gaussian kernel along a face normal. Columns taller than the weighted average are trimmed, shorter ones are filled. Uses circular sampling within the kernel radius. |
+| `smoothwall(volume, face, iterations, color, removeAboveDepth, interpolation)` | Smooth a wall surface by interpolating interior column heights from nearest edge columns in 4 directions. |
 | `squashtoplane(volume, face, planeCoord)` | Project all solid voxels onto a single plane. For each column along the face normal, if any voxel exists, one is placed at the plane coordinate. All others are removed. |
 
 ## Detailed Documentation
@@ -167,6 +168,27 @@ Blur the height map using a 2D Gaussian kernel along a face normal. Columns tall
 | `sigma` | `number` | Standard deviation of the Gaussian bell curve (optional, default 1.0). Lower = sharper, higher = broader smoothing. |
 | `iterations` | `integer` | Number of blur passes (optional, default 1). |
 | `color` | `integer` | Palette color index for new voxels (optional, default 1). |
+
+**Returns:**
+
+| Type | Description |
+| ---- | ----------- |
+| `integer` | Number of voxels changed. |
+
+### smoothwall
+
+Smooth a wall surface by interpolating interior column heights from nearest edge columns in 4 directions. Edge columns (selected voxels bordering non-selected) are preserved for seamless blending. A gap-fill pass extends columns downward to match the lowest neighbor, preventing holes at corners.
+
+**Parameters:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `volume` | `volume` | The volume to smooth. |
+| `face` | `string` | Face direction defining the surface normal: 'up', 'down', 'left', 'right', 'front', 'back'. |
+| `iterations` | `integer` | Number of smoothing passes (optional, default 1). |
+| `color` | `integer` | Palette color index for new voxels (optional, default 1). |
+| `removeAboveDepth` | `integer` | How many voxels above the smooth surface to clear (optional, default 0 = don't clear). |
+| `interpolation` | `string` | Interpolation mode: 'linear', 'inversedistance' (default), or 'edgeaware'. |
 
 **Returns:**
 

--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -2730,6 +2730,52 @@ static int luaVoxel_sculpt_smoothgaussian_jsonhelp(lua_State *s) {
 	return 1;
 }
 
+static voxelutil::SmoothWallInterp luaVoxel_parseSmoothWallInterp(const char *str) {
+	if (SDL_strcmp(str, "linear") == 0) {
+		return voxelutil::SmoothWallInterp::Linear;
+	}
+	if (SDL_strcmp(str, "edgeaware") == 0) {
+		return voxelutil::SmoothWallInterp::EdgeAware;
+	}
+	return voxelutil::SmoothWallInterp::InverseDistance;
+}
+
+static int luaVoxel_sculpt_smoothwall(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const int color = (int)luaL_optinteger(s, 4, 1);
+	const int removeAboveDepth = (int)luaL_optinteger(s, 5, 0);
+	const char *interpStr = luaL_optstring(s, 6, "inversedistance");
+	const voxelutil::SmoothWallInterp interp = luaVoxel_parseSmoothWallInterp(interpStr);
+	const bool fillHoles = lua_toboolean(s, 7) != 0 || lua_isnoneornil(s, 7);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed = voxelutil::sculptSmoothWall(*volume->volume(), volume->volume()->region(), face,
+													iterations, fillVoxel, removeAboveDepth, interp, fillHoles);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothwall_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "smoothwall",
+		"summary": "Smooth a wall surface by interpolating interior column heights from edge columns. For each interior (U,V) position, computes a target height from the nearest boundary columns in 4 directions. Edge columns are preserved for seamless blending.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to smooth."},
+			{"name": "face", "type": "string", "description": "Face direction defining the surface normal: 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "iterations", "type": "integer", "description": "Number of smoothing passes (optional, default 1)."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."},
+			{"name": "removeAboveDepth", "type": "integer", "description": "How many voxels above the smooth surface to clear (optional, default 0 = don't clear)."},
+			{"name": "interpolation", "type": "string", "description": "Interpolation mode: 'linear', 'inversedistance' (default, smooth curves), or 'edgeaware' (follows sharp corners by favoring edges with similar height)."},
+			{"name": "fillHoles", "type": "boolean", "description": "Fill enclosed empty areas with interpolated heights (optional, default true). When false, empty columns are skipped and only solid columns are smoothed."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
 // VoxelFont bindings
 
 static int luaVoxel_voxelfont_new(lua_State *s) {
@@ -6787,6 +6833,7 @@ void luaVoxel_prepareState(lua_State* s) {
 		{"bridgegap", luaVoxel_sculpt_bridgegap, luaVoxel_sculpt_bridgegap_jsonhelp},
 		{"squashtoplane", luaVoxel_sculpt_squashtoplane, luaVoxel_sculpt_squashtoplane_jsonhelp},
 		{"reskin", luaVoxel_sculpt_reskin, luaVoxel_sculpt_reskin_jsonhelp},
+		{"smoothwall", luaVoxel_sculpt_smoothwall, luaVoxel_sculpt_smoothwall_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -1019,6 +1019,531 @@ void sculptSmoothGaussian(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap
 	}
 }
 
+// Fill a single voxel position: mark solid in BitVolume and copy color from nearest neighbor
+static void fillSmoothWallVoxel(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap,
+								const glm::ivec3 &pos, const voxel::Voxel &fillVoxel) {
+	if (solid.hasValue(pos.x, pos.y, pos.z)) {
+		return;
+	}
+	solid.setVoxel(pos, true);
+	voxel::Voxel newVoxel = fillVoxel;
+	for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+		const glm::ivec3 neighbor = pos + offset;
+		if (voxelMap.hasVoxel(neighbor)) {
+			newVoxel = voxelMap.voxel(neighbor);
+			break;
+		}
+	}
+	voxelMap.setVoxel(pos, newVoxel);
+}
+
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles) {
+	if (face == voxel::FaceNames::Max || iterations < 1) {
+		return;
+	}
+
+	core_trace_scoped(SculptSmoothWall);
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	// U and V are the two axes perpendicular to the face normal
+	const int uAxis = (axisIdx == 0) ? 1 : 0;
+	const int vAxis = (axisIdx == 2) ? 1 : 2;
+
+	const int baseU = lo[uAxis];
+	const int baseV = lo[vAxis];
+	const int extentU = hi[uAxis] - baseU + 1;
+	const int extentV = hi[vAxis] - baseV + 1;
+
+	// Need at least 3 columns in each direction (edges + 1 interior)
+	if (extentU < 3 || extentV < 3) {
+		return;
+	}
+
+	const int numColumns = extentU * extentV;
+	static constexpr int EMPTY = INT_MIN;
+	const int axisLo = lo[axisIdx];
+	const int axisHi = hi[axisIdx];
+	// removeAboveDepth == 0 means don't clear anything above the target surface.
+	// Negative values are clamped to 0.
+	if (removeAboveDepth < 0) {
+		removeAboveDepth = 0;
+	}
+
+	// Flat 2D arrays for column heights (preallocated, reused across iterations)
+	core::DynamicArray<int> colTopArr(numColumns);
+	core::DynamicArray<int> colBotArr(numColumns);
+	core::DynamicArray<int> targetArr(numColumns);
+	core::DynamicArray<bool> isEdgeArr(numColumns);
+
+	// Per-column nearest-edge precomputed arrays (4 directions)
+	core::DynamicArray<int> nearEdgeHeightLeft(numColumns);
+	core::DynamicArray<int> nearEdgeDistLeft(numColumns);
+	core::DynamicArray<int> nearEdgeHeightRight(numColumns);
+	core::DynamicArray<int> nearEdgeDistRight(numColumns);
+	core::DynamicArray<int> nearEdgeHeightTop(numColumns);
+	core::DynamicArray<int> nearEdgeDistTop(numColumns);
+	core::DynamicArray<int> nearEdgeHeightBottom(numColumns);
+	core::DynamicArray<int> nearEdgeDistBottom(numColumns);
+
+	// Exterior-empty BFS (only used when fillHoles=true)
+	core::DynamicArray<bool> isExteriorEmpty;
+	core::DynamicArray<int> bfsQueue;
+	if (fillHoles) {
+		isExteriorEmpty.resize(numColumns);
+		bfsQueue.reserve(numColumns);
+	}
+
+	for (int iter = 0; iter < iterations; ++iter) {
+		// Step 1: Build column top/bottom from the solid BitVolume only.
+		// Anchor voxels (non-selected solid neighbors) are intentionally excluded:
+		// they are not in solid and cannot be cleared, so including them in the
+		// height scan causes colTopArr to reflect positions that the clear loop
+		// cannot remove (solid.hasValue returns false for anchors).
+		for (int idx = 0; idx < numColumns; ++idx) {
+			colTopArr[idx] = EMPTY;
+			colBotArr[idx] = EMPTY;
+		}
+
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				const int coordU = baseU + iu;
+				const int coordV = baseV + iv;
+				int topVal = EMPTY;
+				int botVal = EMPTY;
+				for (int av = axisLo; av <= axisHi; ++av) {
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+					pos[axisIdx] = av;
+					if (!solid.hasValue(pos.x, pos.y, pos.z)) {
+						continue;
+					}
+					if (topVal == EMPTY) {
+						topVal = av;
+						botVal = av;
+					} else if (positiveUp) {
+						topVal = glm::max(topVal, av);
+						botVal = glm::min(botVal, av);
+					} else {
+						topVal = glm::min(topVal, av);
+						botVal = glm::max(botVal, av);
+					}
+				}
+				colTopArr[flatIdx] = topVal;
+				colBotArr[flatIdx] = botVal;
+			}
+		}
+
+		// Step 1.5 (fillHoles only): BFS from boundary to identify exterior-empty columns.
+		// Interior-empty columns (holes) are those not reachable from outside.
+		if (fillHoles) {
+			for (int idx = 0; idx < numColumns; ++idx) {
+				isExteriorEmpty[idx] = false;
+			}
+			bfsQueue.clear();
+			for (int iu = 0; iu < extentU; ++iu) {
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const bool onBoundary = (iu == 0 || iu == extentU - 1 || iv == 0 || iv == extentV - 1);
+					if (onBoundary && colTopArr[flatIdx] == EMPTY) {
+						isExteriorEmpty[flatIdx] = true;
+						bfsQueue.push_back(flatIdx);
+					}
+				}
+			}
+			static constexpr int bfsDU[4] = {-1, 1, 0, 0};
+			static constexpr int bfsDV[4] = {0, 0, -1, 1};
+			for (int qi = 0; qi < (int)bfsQueue.size(); ++qi) {
+				const int fi = bfsQueue[qi];
+				const int biu = fi / extentV;
+				const int biv = fi % extentV;
+				for (int di = 0; di < 4; ++di) {
+					const int nu = biu + bfsDU[di];
+					const int nv = biv + bfsDV[di];
+					if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+						continue;
+					}
+					const int nIdx = nu * extentV + nv;
+					if (isExteriorEmpty[nIdx] || colTopArr[nIdx] != EMPTY) {
+						continue;
+					}
+					isExteriorEmpty[nIdx] = true;
+					bfsQueue.push_back(nIdx);
+				}
+			}
+		}
+
+		// Step 2: Identify edge columns, precompute nearest-edge in 4 directions
+		// via O(N) sweeps, then compute target heights for interior columns.
+		for (int idx = 0; idx < numColumns; ++idx) {
+			targetArr[idx] = EMPTY;
+		}
+
+		// Mark edge columns.
+		// fillHoles=false: solid column adjacent to any empty or out-of-bounds UV neighbor.
+		// fillHoles=true: solid column adjacent to exterior-empty or out-of-bounds only
+		//   (hole-boundary columns are NOT edges -- they get interpolated heights too).
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				if (colTopArr[flatIdx] == EMPTY) {
+					isEdgeArr[flatIdx] = false;
+					continue;
+				}
+				if (fillHoles) {
+					bool enclosingEdge = false;
+					static constexpr int edgeDU[4] = {-1, 1, 0, 0};
+					static constexpr int edgeDV[4] = {0, 0, -1, 1};
+					for (int di = 0; di < 4; ++di) {
+						const int nu = iu + edgeDU[di];
+						const int nv = iv + edgeDV[di];
+						if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+							enclosingEdge = true;
+							break;
+						}
+						if (isExteriorEmpty[nu * extentV + nv]) {
+							enclosingEdge = true;
+							break;
+						}
+					}
+					isEdgeArr[flatIdx] = enclosingEdge;
+				} else {
+					bool edge = (iu == 0 || iu == extentU - 1 || iv == 0 || iv == extentV - 1);
+					if (!edge) {
+						edge = (colTopArr[(iu - 1) * extentV + iv] == EMPTY)
+							|| (colTopArr[(iu + 1) * extentV + iv] == EMPTY)
+							|| (colTopArr[iu * extentV + (iv - 1)] == EMPTY)
+							|| (colTopArr[iu * extentV + (iv + 1)] == EMPTY);
+					}
+					isEdgeArr[flatIdx] = edge;
+				}
+			}
+		}
+
+		// Sweep precomputation: for each column, find nearest edge in 4 directions.
+		// Each sweep is O(extentU * extentV), total O(N) instead of O(N * sqrt(N)).
+
+		// Left (-U) and Right (+U) sweeps: for each row iv, sweep along iu.
+		// fillHoles=true: holes (interior empty) are transparent -- only exterior-empty resets.
+		// fillHoles=false: any empty column resets (current behavior).
+		for (int iv = 0; iv < extentV; ++iv) {
+			// Left sweep: iu = 0 to extentU-1
+			int lastEdgeHeight = EMPTY;
+			int lastEdgeDist = 0;
+			for (int iu = 0; iu < extentU; ++iu) {
+				const int flatIdx = iu * extentV + iv;
+				const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+				if (shouldReset) {
+					lastEdgeHeight = EMPTY;
+				} else if (isEdgeArr[flatIdx]) {
+					lastEdgeHeight = colTopArr[flatIdx];
+					lastEdgeDist = 0;
+				}
+				if (lastEdgeHeight != EMPTY) {
+					++lastEdgeDist;
+				}
+				nearEdgeHeightLeft[flatIdx] = lastEdgeHeight;
+				nearEdgeDistLeft[flatIdx] = lastEdgeDist;
+			}
+			// Right sweep: iu = extentU-1 to 0
+			lastEdgeHeight = EMPTY;
+			lastEdgeDist = 0;
+			for (int iu = extentU - 1; iu >= 0; --iu) {
+				const int flatIdx = iu * extentV + iv;
+				const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+				if (shouldReset) {
+					lastEdgeHeight = EMPTY;
+				} else if (isEdgeArr[flatIdx]) {
+					lastEdgeHeight = colTopArr[flatIdx];
+					lastEdgeDist = 0;
+				}
+				if (lastEdgeHeight != EMPTY) {
+					++lastEdgeDist;
+				}
+				nearEdgeHeightRight[flatIdx] = lastEdgeHeight;
+				nearEdgeDistRight[flatIdx] = lastEdgeDist;
+			}
+		}
+		// Top (-V) and Bottom (+V) sweeps: for each column iu, sweep along iv
+		for (int iu = 0; iu < extentU; ++iu) {
+			// Top sweep: iv = 0 to extentV-1
+			int lastEdgeHeight = EMPTY;
+			int lastEdgeDist = 0;
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+				if (shouldReset) {
+					lastEdgeHeight = EMPTY;
+				} else if (isEdgeArr[flatIdx]) {
+					lastEdgeHeight = colTopArr[flatIdx];
+					lastEdgeDist = 0;
+				}
+				if (lastEdgeHeight != EMPTY) {
+					++lastEdgeDist;
+				}
+				nearEdgeHeightTop[flatIdx] = lastEdgeHeight;
+				nearEdgeDistTop[flatIdx] = lastEdgeDist;
+			}
+			// Bottom sweep: iv = extentV-1 to 0
+			lastEdgeHeight = EMPTY;
+			lastEdgeDist = 0;
+			for (int iv = extentV - 1; iv >= 0; --iv) {
+				const int flatIdx = iu * extentV + iv;
+				const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+				if (shouldReset) {
+					lastEdgeHeight = EMPTY;
+				} else if (isEdgeArr[flatIdx]) {
+					lastEdgeHeight = colTopArr[flatIdx];
+					lastEdgeDist = 0;
+				}
+				if (lastEdgeHeight != EMPTY) {
+					++lastEdgeDist;
+				}
+				nearEdgeHeightBottom[flatIdx] = lastEdgeHeight;
+				nearEdgeDistBottom[flatIdx] = lastEdgeDist;
+			}
+		}
+
+		// Compute target for each interior column using precomputed nearest edges.
+		// fillHoles=true: also compute targets for interior-hole columns (EMPTY, not exterior-empty).
+		// fillHoles=false: only process solid interior columns.
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				if (fillHoles) {
+					if (isExteriorEmpty[flatIdx] || isEdgeArr[flatIdx]) {
+						continue;
+					}
+				} else {
+					if (colTopArr[flatIdx] == EMPTY || isEdgeArr[flatIdx]) {
+						continue;
+					}
+				}
+
+				const int edgeLeft = nearEdgeHeightLeft[flatIdx];
+				const int distLeft = nearEdgeDistLeft[flatIdx];
+				const int edgeRight = nearEdgeHeightRight[flatIdx];
+				const int distRight = nearEdgeDistRight[flatIdx];
+				const int edgeTop = nearEdgeHeightTop[flatIdx];
+				const int distTop = nearEdgeDistTop[flatIdx];
+				const int edgeBottom = nearEdgeHeightBottom[flatIdx];
+				const int distBottom = nearEdgeDistBottom[flatIdx];
+
+				// Count valid edges
+				int edgeCount = 0;
+				int edgeHeights[4];
+				int edgeDists[4];
+				if (edgeLeft != EMPTY) {
+					edgeHeights[edgeCount] = edgeLeft;
+					edgeDists[edgeCount] = distLeft;
+					++edgeCount;
+				}
+				if (edgeRight != EMPTY) {
+					edgeHeights[edgeCount] = edgeRight;
+					edgeDists[edgeCount] = distRight;
+					++edgeCount;
+				}
+				if (edgeTop != EMPTY) {
+					edgeHeights[edgeCount] = edgeTop;
+					edgeDists[edgeCount] = distTop;
+					++edgeCount;
+				}
+				if (edgeBottom != EMPTY) {
+					edgeHeights[edgeCount] = edgeBottom;
+					edgeDists[edgeCount] = distBottom;
+					++edgeCount;
+				}
+
+				if (edgeCount < 2) {
+					continue;
+				}
+
+				int target;
+				if (interp == SmoothWallInterp::Linear && edgeLeft != EMPTY && edgeRight != EMPTY
+					&& edgeTop != EMPTY && edgeBottom != EMPTY) {
+					// Bilinear: lerp along each axis, then average
+					const int totalU = distLeft + distRight;
+					const int totalV = distTop + distBottom;
+					const int64_t interpU = ((int64_t)edgeLeft * distRight + (int64_t)edgeRight * distLeft
+											  + totalU / 2) / totalU;
+					const int64_t interpV = ((int64_t)edgeTop * distBottom + (int64_t)edgeBottom * distTop
+											  + totalV / 2) / totalV;
+					target = (int)((interpU + interpV + 1) / 2);
+				} else if (interp == SmoothWallInterp::EdgeAware && edgeCount >= 2) {
+					// Edge-aware IDW: weight = 1 / (dist * (1 + gradientAlongAxis)).
+					// Flat-wall axis pairs (small gradient) get stronger influence.
+					const float gradientU = (edgeLeft != EMPTY && edgeRight != EMPTY)
+						? (float)glm::abs(edgeLeft - edgeRight) : 0.0f;
+					const float gradientV = (edgeTop != EMPTY && edgeBottom != EMPTY)
+						? (float)glm::abs(edgeTop - edgeBottom) : 0.0f;
+					float totalWeight = 0.0f;
+					float weightedHeight = 0.0f;
+					if (edgeLeft != EMPTY) {
+						const float w = 1.0f / ((float)distLeft * (1.0f + gradientU));
+						totalWeight += w;
+						weightedHeight += (float)edgeLeft * w;
+					}
+					if (edgeRight != EMPTY) {
+						const float w = 1.0f / ((float)distRight * (1.0f + gradientU));
+						totalWeight += w;
+						weightedHeight += (float)edgeRight * w;
+					}
+					if (edgeTop != EMPTY) {
+						const float w = 1.0f / ((float)distTop * (1.0f + gradientV));
+						totalWeight += w;
+						weightedHeight += (float)edgeTop * w;
+					}
+					if (edgeBottom != EMPTY) {
+						const float w = 1.0f / ((float)distBottom * (1.0f + gradientV));
+						totalWeight += w;
+						weightedHeight += (float)edgeBottom * w;
+					}
+					target = (int)glm::round(weightedHeight / totalWeight);
+				} else {
+					// IDW fallback (also used for Linear when not all 4 edges found)
+					float totalWeight = 0.0f;
+					float weightedHeight = 0.0f;
+					for (int ei = 0; ei < edgeCount; ++ei) {
+						const float w = 1.0f / (float)edgeDists[ei];
+						totalWeight += w;
+						weightedHeight += (float)edgeHeights[ei] * w;
+					}
+					target = (int)glm::round(weightedHeight / totalWeight);
+				}
+
+				targetArr[flatIdx] = target;
+			}
+		}
+
+		// Step 3: Enforce the smooth surface for each interior column.
+		// - Make solid from column bottom up to target (fill gaps)
+		// - Remove all voxels above target up to removeAboveDepth
+		// - fillHoles=true: also fill interior-hole columns from region floor to target
+		// This eliminates floating layers and discontinuities.
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				const int target = targetArr[flatIdx];
+				if (target == EMPTY) {
+					continue;
+				}
+				// For interior holes (fillHoles=true): fill from region floor/ceiling.
+				// For solid columns: fill from existing column bottom.
+				const bool isInteriorHole = fillHoles && (colTopArr[flatIdx] == EMPTY) && !isExteriorEmpty[flatIdx];
+				const int currentBottom = isInteriorHole ? (positiveUp ? axisLo : axisHi) : colBotArr[flatIdx];
+				if (currentBottom == EMPTY) {
+					continue;
+				}
+				const int coordU = baseU + iu;
+				const int coordV = baseV + iv;
+
+				// Fill from column bottom up to target (close internal gaps).
+				// When target < currentBottom the loop range is empty (fillLo > fillHi
+				// for positiveUp) so no voxels are added -- no clamping needed.
+				const int fillLo = positiveUp ? currentBottom : target;
+				const int fillHi = positiveUp ? target : currentBottom;
+				for (int av = fillLo; av <= fillHi; ++av) {
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+					pos[axisIdx] = av;
+					if (region.containsPoint(pos)) {
+						fillSmoothWallVoxel(solid, voxelMap, pos, fillVoxel);
+					}
+				}
+
+				// Remove voxels above target up to removeAboveDepth (0 = skip clearing).
+				// Use target directly (no clamping): when target < currentBottom the
+				// entire column is above the target and should be cleared.
+				if (removeAboveDepth > 0) {
+					const int clearStart = positiveUp ? target + 1 : target - 1;
+					const int clearEnd = positiveUp
+						? glm::min(target + removeAboveDepth, axisHi)
+						: glm::max(target - removeAboveDepth, axisLo);
+					const int clearStep = positiveUp ? 1 : -1;
+					for (int av = clearStart; positiveUp ? (av <= clearEnd) : (av >= clearEnd); av += clearStep) {
+						glm::ivec3 pos;
+						pos[uAxis] = coordU;
+						pos[vAxis] = coordV;
+						pos[axisIdx] = av;
+						if (solid.hasValue(pos.x, pos.y, pos.z)) {
+							solid.setVoxel(pos, false);
+							voxelMap.setVoxel(pos, voxel::Voxel());
+						}
+					}
+				}
+			}
+		}
+
+		// Step 4: Gap-fill pass. For each column, look at 8 UV neighbors and extend
+		// downward (for positiveUp) to the smallest neighbor target height. This closes
+		// gaps at corners where adjacent columns have very different target heights.
+		// We read from targetArr (computed in Step 2) and update colTopArr to reflect
+		// the new effective tops after Step 3.
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				const int myTarget = targetArr[flatIdx];
+				if (myTarget == EMPTY) {
+					continue;
+				}
+				const bool isInteriorHole = fillHoles && (colTopArr[flatIdx] == EMPTY) && !isExteriorEmpty[flatIdx];
+				const int currentBottom = isInteriorHole ? (positiveUp ? axisLo : axisHi) : colBotArr[flatIdx];
+				if (currentBottom == EMPTY) {
+					continue;
+				}
+
+				// Find the minimum (positiveUp) or maximum (negativeUp) neighbor target
+				int neighborExtreme = myTarget;
+				static constexpr int neighborOffsets[8][2] = {
+					{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}
+				};
+				for (const auto &off : neighborOffsets) {
+					const int nu = iu + off[0];
+					const int nv = iv + off[1];
+					if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+						continue;
+					}
+					const int nIdx = nu * extentV + nv;
+					// Use target if available (interior), otherwise use original top (edge)
+					const int nHeight = (targetArr[nIdx] != EMPTY) ? targetArr[nIdx] : colTopArr[nIdx];
+					if (nHeight == EMPTY) {
+						continue;
+					}
+					if (positiveUp) {
+						neighborExtreme = glm::min(neighborExtreme, nHeight);
+					} else {
+						neighborExtreme = glm::max(neighborExtreme, nHeight);
+					}
+				}
+
+				// Fill from neighborExtreme to myTarget if there is a gap
+				const int fillLo = positiveUp ? neighborExtreme : myTarget;
+				const int fillHi = positiveUp ? myTarget : neighborExtreme;
+				const int coordU = baseU + iu;
+				const int coordV = baseV + iv;
+				for (int av = fillLo; av <= fillHi; ++av) {
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+					pos[axisIdx] = av;
+					if (region.containsPoint(pos)) {
+						fillSmoothWallVoxel(solid, voxelMap, pos, fillVoxel);
+					}
+				}
+			}
+		}
+	}
+}
+
 void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face,
 						 int planeCoord) {
 	if (face == voxel::FaceNames::Max) {
@@ -1573,6 +2098,21 @@ int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, 
 	voxel::BitVolume anchors(anchorRegion);
 	buildFromVolume(volume, region, solid, voxelMap, anchors);
 	sculptSmoothGaussian(solid, voxelMap, anchors, face, kernelSize, sigma, iterations, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSmoothWall(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+					 int iterations, const voxel::Voxel &fillVoxel, int removeAboveDepth,
+					 SmoothWallInterp interp, bool fillHoles) {
+	core_trace_scoped(SculptSmoothWallVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	sculptSmoothWall(solid, voxelMap, anchors, face, iterations, fillVoxel, removeAboveDepth, interp, fillHoles);
 	return writeResultToVolume(volume, region, solid, voxelMap);
 }
 

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -18,6 +18,14 @@ class Region;
 
 namespace voxelutil {
 
+enum class SmoothWallInterp : uint8_t {
+	Linear,           ///< Bilinear interpolation between opposite edges (constant slope)
+	InverseDistance,   ///< Inverse-distance weighting from 4 coplanar edge columns (smooth curves)
+	EdgeAware,         ///< IDW weighted by height similarity: flat coplanar edges dominate (sharp corners)
+
+	Max
+};
+
 enum class ReskinMode : uint8_t {
 	Replace, ///< Skin solid overwrites surface; skin air removes surface voxels
 	Blend,   ///< Skin solid overwrites surface; skin air preserves surface voxels
@@ -286,6 +294,45 @@ void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap,
  */
 int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
 						int planeCoord);
+
+/**
+ * @brief Smooth wall: interpolate surface heights from edge columns inward.
+ *
+ * The face defines "up" (the surface normal). For each (U,V) column in the selection,
+ * computes a target height by bilinear interpolation from the edge column heights:
+ * - Line 1: interpolate between the heights at (u, v_min) and (u, v_max)
+ * - Line 2: interpolate between the heights at (u_min, v) and (u_max, v)
+ * - Target = average of both lines
+ *
+ * Edge columns (on the boundary) are never modified, ensuring seamless blending with
+ * surrounding geometry. Interior columns are trimmed or filled toward the target.
+ * Each iteration blends partway toward the target to allow gradual convergence.
+ * No gaps are created because column bases are preserved -- only the top is adjusted.
+ *
+ * @param[in,out] solid BitVolume marking solid positions.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions included in height computation.
+ * @param face The face direction that defines the surface normal ("up").
+ * @param iterations Number of smoothing passes. Each pass blends toward the interpolated target.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ * @param removeAboveDepth How many voxels above the target surface to clear. 0 means
+ *        don't clear anything above the target. Default 0.
+ * @param interp Interpolation mode: Linear, InverseDistance, or EdgeAware.
+ */
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth = 0, SmoothWallInterp interp = SmoothWallInterp::InverseDistance,
+					  bool fillHoles = true);
+
+/**
+ * @brief Smooth wall on a volume region along a face normal.
+ *
+ * @return The number of voxels changed.
+ */
+int sculptSmoothWall(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+					 int iterations, const voxel::Voxel &fillVoxel, int removeAboveDepth = 0,
+					 SmoothWallInterp interp = SmoothWallInterp::InverseDistance,
+					 bool fillHoles = true);
 
 /**
  * @brief Reskin: apply a skin volume (texture pattern) onto the selected surface.

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -1355,4 +1355,269 @@ TEST_F(VolumeSculptTest, testReskinStretchMode) {
 	EXPECT_NE(v00.getColor(), v33.getColor());
 }
 
+// ---- SmoothWall tests ----
+
+TEST_F(VolumeSculptTest, testSmoothWallFlatWallUnchanged) {
+	// A flat wall should not be modified since edge heights match interior heights
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill a flat slab: X=[1,6], Z=[1,6], Y=3 (face=PositiveY, height is uniform)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+
+	const int beforeCount = countSolid(volume);
+	const int changed = sculptSmoothWall(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)),
+										 voxel::FaceNames::PositiveY, 1, solid);
+	EXPECT_EQ(changed, 0);
+	EXPECT_EQ(countSolid(volume), beforeCount);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallTrimsProtrusion) {
+	// A flat wall with a single column bump in the center should be trimmed
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat slab at Y=3, X=[1,8], Z=[1,8]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 3, 8)), solid);
+	// Add a bump at center (4,4,4) and (4,5,4) -- 2 voxels high above the slab
+	volume.setVoxel(4, 4, 4, solid);
+	volume.setVoxel(4, 5, 4, solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8));
+	const int clearDepth = 256;
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid, clearDepth);
+	EXPECT_GT(changed, 0);
+	// The bump should be trimmed -- the center column should no longer protrude
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 5, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallFillsValley) {
+	// Edges are high, center is low -- center should be filled up toward edge height
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill full slab at Y=[3,5], X=[1,8], Z=[1,8] (height 3 everywhere)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8)), solid);
+	// Dig a valley at center columns: remove Y=5 and Y=4 at (4,*,4)
+	volume.setVoxel(4, 5, 4, voxel::Voxel());
+	volume.setVoxel(4, 4, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8));
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid);
+	EXPECT_GT(changed, 0);
+	// Center column should have been filled back up toward Y=5
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 5, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallPreservesEdges) {
+	// Edge columns should never be modified even when they differ
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill slab Y=[3,5], X=[1,5], Z=[1,5]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(5, 5, 5)), solid);
+
+	// Record edge column heights before smoothing
+	const bool edgeTopBefore = voxel::isBlocked(volume.voxel(1, 5, 1).getMaterial());
+	const bool edgeBotBefore = voxel::isBlocked(volume.voxel(1, 3, 1).getMaterial());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(5, 5, 5));
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 10, solid);
+
+	// Edge columns (1,*,1) should be unchanged
+	EXPECT_EQ(voxel::isBlocked(volume.voxel(1, 5, 1).getMaterial()), edgeTopBefore);
+	EXPECT_EQ(voxel::isBlocked(volume.voxel(1, 3, 1).getMaterial()), edgeBotBefore);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallClearsFloatingVoxels) {
+	// Floating voxels above the smooth surface should be removed
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat slab at Y=3, X=[1,8], Z=[1,8]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 3, 8)), solid);
+	// Add floating voxels at Y=6 in the center (disconnected from the slab)
+	volume.setVoxel(4, 6, 4, solid);
+	volume.setVoxel(5, 6, 5, solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 7, 8));
+	const int clearDepth = 256;
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, clearDepth);
+	EXPECT_GT(changed, 0);
+	// Floating voxels should be gone -- they are above the smooth target
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 6, 4).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(5, 6, 5).getMaterial()));
+	// Slab should still exist
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallInverseDistanceReducesEdgeJump) {
+	// With a height difference between edges, IDW should produce a smaller
+	// jump at the first interior column compared to linear interpolation.
+	// IDW gives nearby edges much stronger influence (1/dist weighting).
+	voxel::Region region(0, 11);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Linear test: slab X=[1,10], Z=[1,10], left edge Y=3, right edge Y=8
+	voxel::RawVolume volumeLinear(region);
+	for (int zz = 1; zz <= 10; ++zz) {
+		for (int xx = 1; xx <= 10; ++xx) {
+			// Base height at Y=1..3 everywhere
+			fillRegion(volumeLinear, voxel::Region(glm::ivec3(xx, 1, zz), glm::ivec3(xx, 3, zz)), solid);
+		}
+		// Right edge columns taller (Y up to 8)
+		fillRegion(volumeLinear, voxel::Region(glm::ivec3(10, 1, zz), glm::ivec3(10, 8, zz)), solid);
+	}
+	// Copy for IDW test
+	voxel::RawVolume volumeIDW(volumeLinear);
+
+	const voxel::Region selRegion(glm::ivec3(1, 1, 1), glm::ivec3(10, 9, 10));
+	sculptSmoothWall(volumeLinear, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::Linear);
+	sculptSmoothWall(volumeIDW, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance);
+
+	// Find the height of column (X=2, Z=5) -- first interior column near the low edge.
+	// IDW should ease in, producing a height closer to the low edge (3)
+	// than linear interpolation does.
+	int linearHeight = 0;
+	int idwHeight = 0;
+	for (int yy = 9; yy >= 1; --yy) {
+		if (linearHeight == 0 && voxel::isBlocked(volumeLinear.voxel(2, yy, 5).getMaterial())) {
+			linearHeight = yy;
+		}
+		if (idwHeight == 0 && voxel::isBlocked(volumeIDW.voxel(2, yy, 5).getMaterial())) {
+			idwHeight = yy;
+		}
+	}
+	EXPECT_GT(linearHeight, 0);
+	EXPECT_GT(idwHeight, 0);
+	// IDW near the low edge should produce equal or lower height than linear
+	EXPECT_LE(idwHeight, linearHeight);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallEdgeAwareFlatWallUnchanged) {
+	// On a flat wall, all edge heights match interior heights, so EdgeAware
+	// should produce zero changes (same as other modes).
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+
+	const int changed = sculptSmoothWall(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)),
+										 voxel::FaceNames::PositiveY, 1, solid, 0,
+										 voxelutil::SmoothWallInterp::EdgeAware);
+	EXPECT_EQ(changed, 0);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallEdgeAwareFollowsCorner) {
+	// L-shaped wall: left half at Y=3, right half at Y=6.
+	// At the corner column, EdgeAware should favor the coplanar edge that has
+	// the same height, while IDW would average more freely.
+	voxel::Region region(0, 11);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Left half: X=[1,5], Z=[1,10], height Y=1..3
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 1, 1), glm::ivec3(5, 3, 10)), solid);
+	// Right half: X=[6,10], Z=[1,10], height Y=1..6
+	fillRegion(volume, voxel::Region(glm::ivec3(6, 1, 1), glm::ivec3(10, 6, 10)), solid);
+
+	voxel::RawVolume volumeIDW(volume);
+
+	const voxel::Region selRegion(glm::ivec3(1, 1, 1), glm::ivec3(10, 7, 10));
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::EdgeAware);
+	sculptSmoothWall(volumeIDW, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance);
+
+	// Column at (3, *, 5) is interior, left half. Its coplanar left edge (1,*,5)
+	// is at height 3, which matches. EdgeAware should keep it closer to 3.
+	int edgeAwareHeight = 0;
+	int idwHeight = 0;
+	for (int yy = 7; yy >= 1; --yy) {
+		if (edgeAwareHeight == 0 && voxel::isBlocked(volume.voxel(3, yy, 5).getMaterial())) {
+			edgeAwareHeight = yy;
+		}
+		if (idwHeight == 0 && voxel::isBlocked(volumeIDW.voxel(3, yy, 5).getMaterial())) {
+			idwHeight = yy;
+		}
+	}
+	EXPECT_GT(edgeAwareHeight, 0);
+	EXPECT_GT(idwHeight, 0);
+	// EdgeAware should stay closer to the matching edge (height 3)
+	EXPECT_LE(edgeAwareHeight, idwHeight);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallTooSmallSelection) {
+	// Selection smaller than 3x3 in UV should return 0 changes
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 2-wide slab (too narrow for interior columns)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(2, 5, 2)), solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(2, 5, 2));
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid);
+	EXPECT_EQ(changed, 0);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallFillHolesFilledInteriorHole) {
+	// A ring of solid columns surrounding an empty interior hole.
+	// With fillHoles=true the hole should be filled with interpolated heights.
+	// Layout (top view, face=PositiveY, Y=3):
+	//   X=[1,6], Z=[1,6] ring is solid at Y=3. Center (3,4) empty.
+	voxel::Region region(0, 8);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill the full slab first, then punch a 2x2 hole in the middle
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+	volume.setVoxel(3, 3, 4, voxel::Voxel());
+	volume.setVoxel(4, 3, 3, voxel::Voxel());
+	volume.setVoxel(4, 3, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6));
+	// fillHoles=true: hole should be filled
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+										 voxelutil::SmoothWallInterp::InverseDistance, true);
+	EXPECT_GT(changed, 0);
+	// All four hole positions should now be solid
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 4).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallSkipHolesLeavesInteriorHole) {
+	// Same ring setup as above, but with fillHoles=false.
+	// The hole should remain empty -- only solid columns are smoothed.
+	voxel::Region region(0, 8);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+	volume.setVoxel(3, 3, 4, voxel::Voxel());
+	volume.setVoxel(4, 3, 3, voxel::Voxel());
+	volume.setVoxel(4, 3, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6));
+	// fillHoles=false: hole positions must stay empty
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance, false);
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(3, 3, 3).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(3, 3, 4).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 3, 3).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
+}
+
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -42,12 +42,15 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "reskin") {
 		return SculptMode::Reskin;
 	}
+	if (mode == "smoothwall") {
+		return SculptMode::SmoothWall;
+	}
 	return SculptMode::Erode;
 }
 
 SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	_tool.set("description",
-			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane, Reskin). "
+			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane, Reskin, SmoothWall). "
 			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting). "
 			  "Reskin mode applies a skin pattern from the clipboard onto the selected surface.");
 
@@ -69,7 +72,8 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 					   "'smootherode' (smooth by removing), 'smoothgaussian' (Gaussian height blur), "
 				   "'bridgegap' (connect boundary voxels with lines to bridge gaps), "
 				   "'squashtoplane' (project all voxels onto the clicked plane), "
-				   "'reskin' (apply skin pattern from clipboard onto surface)");
+				   "'reskin' (apply skin pattern from clipboard onto surface), "
+				   "'smoothwall' (interpolate surface heights from edge columns to smooth a wall)");
 	json::Json enumArr = json::Json::array();
 	enumArr.push("erode");
 	enumArr.push("grow");
@@ -80,6 +84,7 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	enumArr.push("bridgegap");
 	enumArr.push("squashtoplane");
 	enumArr.push("reskin");
+	enumArr.push("smoothwall");
 	sculptModeProp.set("enum", enumArr);
 	sculptModeProp.set("default", "erode");
 	properties.set("sculptMode", sculptModeProp);

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanel.cpp
@@ -73,14 +73,15 @@ static constexpr const char *SculptModeStr[] = {
 	NC_("Sculpt Modes", "Erode"),		 NC_("Sculpt Modes", "Grow"),
 	NC_("Sculpt Modes", "Flatten"),		 NC_("Sculpt Modes", "Smooth Additive"),
 	NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"),
-	NC_("Sculpt Modes", "Bridge Gap"),	 NC_("Sculpt Modes", "Squash to Plane"),
-	NC_("Sculpt Modes", "Extend Plane"), NC_("Sculpt Modes", "Reskin")};
+	NC_("Sculpt Modes", "Smooth Wall"),	 NC_("Sculpt Modes", "Bridge Gap"),
+	NC_("Sculpt Modes", "Squash to Plane"), NC_("Sculpt Modes", "Extend Plane"),
+	NC_("Sculpt Modes", "Reskin")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
-static constexpr const char *SculptModeIcons[] = {ICON_LC_ERASER, ICON_LC_SPROUT,	  ICON_LC_LAND_PLOT,
-												  ICON_LC_WAVES,  ICON_LC_WAVES,	  ICON_LC_BLEND,
-												  ICON_LC_LINK,	  ICON_LC_MINIMIZE_2, ICON_LC_EXPAND,
-												  ICON_LC_PALETTE};
+static constexpr const char *SculptModeIcons[] = {ICON_LC_ERASER,    ICON_LC_SPROUT,	  ICON_LC_LAND_PLOT,
+												  ICON_LC_WAVES,     ICON_LC_WAVES,	  ICON_LC_BLEND,
+												  ICON_LC_BRICK_WALL, ICON_LC_LINK,	  ICON_LC_MINIMIZE_2,
+												  ICON_LC_EXPAND,    ICON_LC_PALETTE};
 static_assert(lengthof(SculptModeIcons) == (int)SculptMode::Max, "SculptModeIcons size mismatch");
 
 // clang-format off
@@ -122,6 +123,11 @@ static_assert(lengthof(ReskinTileStr) == (int)voxelutil::ReskinTile::Max, "Reski
 static constexpr const char *ReskinSkinAxisStr[] = {NC_("Reskin Skin Axis", "X"), NC_("Reskin Skin Axis", "Y"),
 													NC_("Reskin Skin Axis", "Z")};
 static_assert(lengthof(ReskinSkinAxisStr) == 3, "ReskinSkinAxisStr size mismatch");
+
+static constexpr const char *SmoothWallInterpStr[] = {NC_("Smooth Wall Interp", "Linear"),
+													  NC_("Smooth Wall Interp", "Inverse Distance"),
+													  NC_("Smooth Wall Interp", "Edge Aware")};
+static_assert(lengthof(SmoothWallInterpStr) == (int)voxelutil::SmoothWallInterp::Max, "SmoothWallInterpStr size mismatch");
 
 static constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
 												   NC_("Scale Sampling", "Cubic")};
@@ -1558,6 +1564,35 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 			brush.setSigma(sigma);
 			executeSculptBrush();
 		}
+	} else if (currentMode == SculptMode::SmoothWall) {
+		const voxelutil::SmoothWallInterp currentInterp = brush.smoothWallInterp();
+		if (ImGui::BeginCombo(_("Interpolation"), C_("Smooth Wall Interp", SmoothWallInterpStr[(int)currentInterp]),
+							  ImGuiComboFlags_None)) {
+			for (int ci = 0; ci < (int)voxelutil::SmoothWallInterp::Max; ++ci) {
+				const bool selected = ci == (int)currentInterp;
+				if (ImGui::Selectable(C_("Smooth Wall Interp", SmoothWallInterpStr[ci]), selected)) {
+					brush.setSmoothWallInterp((voxelutil::SmoothWallInterp)ci);
+					executeSculptBrush();
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+		int clearDepth = brush.smoothWallClearDepth();
+		ImGui::TextUnformatted(_("Clear above depth"));
+		ImGui::SetItemTooltipUnformatted(_("How many voxels above the smooth surface to clear. 0 = don't clear."));
+		if (ImGui::SliderInt("##smoothwall_clear_depth", &clearDepth, 0, SculptBrush::MaxSmoothWallClearDepth)) {
+			brush.setSmoothWallClearDepth(clearDepth);
+			executeSculptBrush();
+		}
+		bool fillHoles = brush.smoothWallFillHoles();
+		if (ImGui::Checkbox(_("Fill holes"), &fillHoles)) {
+			brush.setSmoothWallFillHoles(fillHoles);
+			executeSculptBrush();
+		}
+		ImGui::SetItemTooltipUnformatted(_("Fill enclosed empty areas with interpolated heights. When unchecked, holes are skipped and only solid columns are smoothed."));
 	} else if (currentMode == SculptMode::Reskin) {
 		if (brush.skinVolume() == nullptr) {
 			const glm::vec4 &warningTextColor = style::color(style::StyleColor::ColorWarningText);
@@ -1805,7 +1840,7 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 		}
 		ImGui::TooltipTextUnformatted(_("Perpendicular depth of voxels to remove above the plane (0 = no removal)"));
 	} else if (currentMode != SculptMode::Flatten && currentMode != SculptMode::BridgeGap &&
-			   currentMode != SculptMode::SquashToPlane) {
+			   currentMode != SculptMode::SquashToPlane && currentMode != SculptMode::SmoothWall) {
 		float strength = brush.strength();
 		if (ImGui::SliderFloat(_("Strength"), &strength, 0.0f, 1.0f)) {
 			brush.setStrength(strength);
@@ -1814,7 +1849,8 @@ void BrushPanel::updateSculptBrushPanel(command::CommandExecutionListener &liste
 	}
 
 	if (currentMode != SculptMode::BridgeGap && currentMode != SculptMode::SquashToPlane &&
-		currentMode != SculptMode::Reskin && currentMode != SculptMode::ExtendPlane) {
+		currentMode != SculptMode::Reskin && currentMode != SculptMode::ExtendPlane &&
+		currentMode != SculptMode::SmoothWall) {
 		const int maxIter = needsFace ? SculptBrush::MaxFlattenIterations : SculptBrush::MaxIterations;
 		int iterations = brush.iterations();
 		if (needsFace) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -81,6 +81,9 @@ void SculptBrush::reset() {
 	_sigma = 4.0f;
 	_sculptMode = SculptMode::Erode;
 	_flattenFace = voxel::FaceNames::Max;
+	_smoothWallClearDepth = MaxSmoothWallClearDepth;
+	_smoothWallInterp = voxelutil::SmoothWallInterp::InverseDistance;
+	_smoothWallFillHoles = true;
 	_removeAboveDepth = 0;
 	_extendOnly = true;
 	_brushRadius = 3;
@@ -380,6 +383,12 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 		voxelutil::sculptSquashToPlane(currentSolid, voxelMap, _flattenFace, _squashPlaneCoord);
 	} else if (_sculptMode == SculptMode::Reskin && _skinVolume != nullptr && _flattenFace != voxel::FaceNames::Max) {
 		voxelutil::sculptReskin(currentSolid, voxelMap, *_skinVolume, _flattenFace, _reskinConfig);
+	} else if (_sculptMode == SculptMode::SmoothWall && _flattenFace != voxel::FaceNames::Max) {
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		static constexpr int smoothWallIterations = 1;
+		voxelutil::sculptSmoothWall(currentSolid, voxelMap, anchorSolid, _flattenFace, smoothWallIterations,
+									fillVoxel, _smoothWallClearDepth, _smoothWallInterp, _smoothWallFillHoles);
 	}
 
 	// Write results using the collected snapshot entries - no hash lookups needed.

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -29,6 +29,7 @@ enum class SculptMode : uint8_t {
 	SmoothAdditive,
 	SmoothErode,
 	SmoothGaussian,
+	SmoothWall,
 	BridgeGap,
 	SquashToPlane,
 	ExtendPlane,
@@ -58,6 +59,9 @@ private:
 	int _trimPerStep = 1;
 	int _kernelSize = 4;
 	float _sigma = 4.0f;
+	int _smoothWallClearDepth = MaxSmoothWallClearDepth; ///< 0 = don't clear, max = clear entire depth
+	voxelutil::SmoothWallInterp _smoothWallInterp = voxelutil::SmoothWallInterp::InverseDistance;
+	bool _smoothWallFillHoles = true; ///< Fill enclosed empty areas with interpolated heights
 	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
 	int _squashPlaneCoord = 0;
 	bool _active = false;
@@ -169,6 +173,15 @@ public:
 	float sigma() const;
 	void setSigma(float sigma);
 
+	// SmoothWall accessors
+	static constexpr int MaxSmoothWallClearDepth = 256;
+	int smoothWallClearDepth() const;
+	void setSmoothWallClearDepth(int depth);
+	voxelutil::SmoothWallInterp smoothWallInterp() const;
+	void setSmoothWallInterp(voxelutil::SmoothWallInterp interp);
+	bool smoothWallFillHoles() const;
+	void setSmoothWallFillHoles(bool fillHoles);
+
 	// ExtendPlane accessors
 	static constexpr int MaxBrushRadius = 32;
 	static constexpr int MaxRemoveAboveDepth = 32;
@@ -223,7 +236,7 @@ inline bool SculptBrush::wantsContinuousExecution() const {
 inline bool SculptBrush::modeNeedsFace(SculptMode mode) {
 	return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode ||
 		   mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane || mode == SculptMode::ExtendPlane ||
-		   mode == SculptMode::Reskin;
+		   mode == SculptMode::Reskin || mode == SculptMode::SmoothWall;
 }
 
 inline SculptMode SculptBrush::sculptMode() const {
@@ -298,6 +311,33 @@ inline float SculptBrush::sigma() const {
 
 inline void SculptBrush::setSigma(float sigma) {
 	_sigma = glm::clamp(sigma, MinSigma, MaxSigma);
+	_paramsDirty = true;
+}
+
+inline int SculptBrush::smoothWallClearDepth() const {
+	return _smoothWallClearDepth;
+}
+
+inline void SculptBrush::setSmoothWallClearDepth(int depth) {
+	_smoothWallClearDepth = glm::clamp(depth, 0, MaxSmoothWallClearDepth);
+	_paramsDirty = true;
+}
+
+inline voxelutil::SmoothWallInterp SculptBrush::smoothWallInterp() const {
+	return _smoothWallInterp;
+}
+
+inline void SculptBrush::setSmoothWallInterp(voxelutil::SmoothWallInterp interp) {
+	_smoothWallInterp = interp;
+	_paramsDirty = true;
+}
+
+inline bool SculptBrush::smoothWallFillHoles() const {
+	return _smoothWallFillHoles;
+}
+
+inline void SculptBrush::setSmoothWallFillHoles(bool fillHoles) {
+	_smoothWallFillHoles = fillHoles;
 	_paramsDirty = true;
 }
 


### PR DESCRIPTION
## Summary

- New `SmoothWall` sculpt mode that smooths messy wall surfaces by interpolating interior column heights from selection edge columns
- Edge detection finds actual selection boundary voxels (columns with a non-selected UV neighbor), not the bounding box boundary
- Three interpolation modes: **Linear** (bilinear between opposite edges), **InverseDistance** (1/dist weighting for smooth curves), **EdgeAware** (flat-wall axes dominate, preserving sharp corners)
- Gap-fill pass after interpolation extends each column downward to its lowest 8-neighbor, preventing holes at multi-corner transitions
- Clear-above-depth slider controls how many voxels above the target surface to remove (0 = don't clear, default = max)
- O(N) sweep precomputation for nearest-edge lookup (4 linear passes instead of per-column scanning)
- Lua API: `g_sculpt.smoothwall(volume, face, iterations, color, removeAboveDepth, interpolation)`
- MCP tool support
- 9 unit tests

## Test plan

- [ ] Select a flat wall region, apply SmoothWall -- wall should remain unchanged
- [ ] Select a wall with a bump, apply with InverseDistance -- bump smoothed with gradual transition from edges
- [ ] Select a wall with a bump, apply with EdgeAware -- sharp corners preserved, flat areas smoothed
- [ ] Select an irregular (non-rectangular) region around a cube on a wall -- edges detected correctly at selection boundary
- [ ] Set clear-above-depth to 0 -- no voxels removed above surface
- [ ] Set clear-above-depth to max -- floating voxels above target removed
- [ ] Verify no gaps/holes at corners with multiple height transitions
- [ ] Test on large selection for performance