### PR TITLE
Fix Box3D additive select, rewrite mergeActiveToBackground, add position step UI

### DIFF
--- a/src/modules/ui/IMGUIEx.cpp
+++ b/src/modules/ui/IMGUIEx.cpp
@@ -135,8 +135,7 @@ static bool InputXYZImpl(const char *label, glm::vec<3, ValueType> &vec, const c
 		if constexpr (isFloat) {
 			modified |= ImGui::InputFloat("", &vec.z, step, step_fast, format, flags);
 		} else {
-			ImGui::InputInt("", &vec.z, step, step_fast, flags);
-			modified |= ImGui::IsItemDeactivatedAfterEdit();
+			modified |= ImGui::InputInt("", &vec.z, step, step_fast, flags);
 		}
 		ImGui::PopID();
 

--- a/src/tools/voxedit/modules/voxedit-ui/NodeInspectorPanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/NodeInspectorPanel.cpp
@@ -79,10 +79,18 @@ void NodeInspectorPanel::modelProperties(scenegraph::SceneGraphNode &node) {
 		ImGui::TableSetupColumn(_("Name"), colFlags);
 		ImGui::TableHeadersRow();
 
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::SetNextItemWidth(-1);
+		ImGui::InputInt("##positionstep", &_positionStep, 1, 10);
+		_positionStep = glm::clamp(_positionStep, 1, 64);
+		ImGui::TableNextColumn();
+		ImGui::TextUnformatted(_("Step"));
+
 		glm::ivec3 position = region.getLowerCorner();
 		const int minStep = _gridSize->intVal();
 		const int maxStep = 10;
-		const bool posChange = ImGui::InputXYZ(_("Position"), position, nullptr, ImGuiInputTextFlags_None, minStep, maxStep);
+		const bool posChange = ImGui::InputXYZ(_("Position"), position, nullptr, ImGuiInputTextFlags_None, _positionStep, maxStep);
 		if (posChange || ImGui::IsItemDeactivatedAfterEdit()) {
 			const glm::ivec3 &f = position - region.getLowerCorner();
 			_sceneMgr->nodeShift(node.id(), f);

--- a/src/tools/voxedit/modules/voxedit-ui/NodeInspectorPanel.h
+++ b/src/tools/voxedit/modules/voxedit-ui/NodeInspectorPanel.h
@@ -31,6 +31,7 @@ private:
 	core::VarPtr _regionSizes;
 	core::VarPtr _gridSize;
 	core::VarPtr _viewMode;
+	int _positionStep = 1;
 	core::Buffer<glm::ivec3> _validRegionSizes;
 	glm::ivec3 _newRegionSize{32, 32, 32};
 	SceneManagerPtr _sceneMgr;

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -1850,225 +1850,104 @@ bool SceneManager::mergeActiveToBackground() {
 
 	const scenegraph::FrameTransform &srcTransform =
 		_sceneGraph.transformForFrame(*sourceNode, _currentFrameIdx);
-	core::ScopedPtr<voxel::RawVolume> bakedSource;
-	const voxel::RawVolume *worldSource = sourceVolume;
+	// Always work on a copy so we can safely zero stamped regions later without
+	// mutating the live scene graph volume.
+	core::ScopedPtr<voxel::RawVolume> workingCopy;
 	if (!srcTransform.isIdentity()) {
-		bakedSource = voxelutil::applyTransformToVolume(
+		workingCopy = voxelutil::applyTransformToVolume(
 			*sourceVolume, srcTransform.worldMatrix(), sourceNode->pivot());
-		worldSource = &(*bakedSource);
+	} else {
+		workingCopy = new voxel::RawVolume(*sourceVolume);
 	}
+	if (&(*workingCopy) == nullptr) {
+		Log::warn("mergeactivetobackground: failed to bake source node");
+		return false;
+	}
+	voxel::RawVolume *worldSource = &(*workingCopy);
 	const voxel::Region &sourceWorldRegion = worldSource->region();
 	const palette::Palette &sourcePalette = sourceNode->palette();
-
-	// Detect grid parameters from existing background nodes
-	const int chunkSize = _maxSuggestedVolumeSize->intVal();
-	glm::ivec3 gridOffset(0);
-	int backgroundParentId = _sceneGraph.root().id();
-	for (auto iter = _sceneGraph.beginModel(); iter != _sceneGraph.end(); ++iter) {
-		const scenegraph::SceneGraphNode &node = *iter;
-		if (node.id() == sourceNodeId || !node.isModelNode()) {
-			continue;
-		}
-		const voxel::Region wr = _sceneGraph.sceneRegion(node, _currentFrameIdx);
-		if (!wr.isValid()) {
-			continue;
-		}
-		// Grid offset: lower corner modulo chunkSize (handle negative coords)
-		const glm::ivec3 &lc = wr.getLowerCorner();
-		gridOffset = ((lc % chunkSize) + glm::ivec3(chunkSize)) % glm::ivec3(chunkSize);
-		backgroundParentId = node.parent();
-		break;
-	}
-
-	// Floor division helper for grid cell origin (handles negative coordinates)
-	auto gridCellOrigin = [&](const glm::ivec3 &pos) -> glm::ivec3 {
-		const glm::ivec3 shifted = pos - gridOffset;
-		glm::ivec3 cell;
-		for (int i = 0; i < 3; ++i) {
-			cell[i] = (shifted[i] >= 0)
-				? (shifted[i] / chunkSize)
-				: ((shifted[i] - chunkSize + 1) / chunkSize);
-		}
-		return cell * chunkSize + gridOffset;
-	};
-
-	// Enumerate all grid cells the source overlaps
-	struct GridCell {
-		glm::ivec3 origin;
-		voxel::Region cellRegion;
-		int existingNodeId;
-	};
-	const glm::ivec3 firstCell = gridCellOrigin(sourceWorldRegion.getLowerCorner());
-	const glm::ivec3 lastCell = gridCellOrigin(sourceWorldRegion.getUpperCorner());
-	core::DynamicArray<GridCell> neededCells;
-	for (int y = firstCell.y; y <= lastCell.y; y += chunkSize) {
-		for (int z = firstCell.z; z <= lastCell.z; z += chunkSize) {
-			for (int x = firstCell.x; x <= lastCell.x; x += chunkSize) {
-				const glm::ivec3 origin(x, y, z);
-				const voxel::Region cellRegion(origin, origin + glm::ivec3(chunkSize - 1));
-				if (!voxel::intersects(sourceWorldRegion, cellRegion)) {
-					continue;
-				}
-				neededCells.push_back({origin, cellRegion, InvalidNodeId});
-			}
-		}
-	}
-
-	// Match existing background nodes to grid cells
-	for (auto iter = _sceneGraph.beginModel(); iter != _sceneGraph.end(); ++iter) {
-		const scenegraph::SceneGraphNode &node = *iter;
-		if (node.id() == sourceNodeId || !node.isModelNode()) {
-			continue;
-		}
-		const voxel::Region wr = _sceneGraph.sceneRegion(node, _currentFrameIdx);
-		if (!wr.isValid()) {
-			continue;
-		}
-		const glm::ivec3 nodeCell = gridCellOrigin(wr.getLowerCorner());
-		for (GridCell &cell : neededCells) {
-			if (cell.origin == nodeCell && cell.existingNodeId == InvalidNodeId) {
-				cell.existingNodeId = node.id();
-				break;
-			}
-		}
-	}
 
 	memento::ScopedMementoGroup mementoGroup(_mementoHandler, "mergeactivetobackground");
 
 	struct StampedNode {
 		int nodeId;
-		voxel::Region region;
+		voxel::Region localRegion;
+		voxel::Region worldRegion;
 	};
 	core::DynamicArray<StampedNode> stampedNodes;
-	stampedNodes.reserve(neededCells.size());
 	int stampedCount = 0;
 
-	for (const GridCell &cell : neededCells) {
-		// Compute the overlap of the source with this grid cell (in world coords)
-		voxel::Region cellSourceOverlap = sourceWorldRegion;
-		cellSourceOverlap.cropTo(cell.cellRegion);
+	// Stamp source into every overlapping background node (including air voxels).
+	// Use sceneRegion() for world-space intersection test (handles transforms).
+	// Translate world overlap to local volume coords for the actual write.
+	for (auto iter = _sceneGraph.beginAllModels(); iter != _sceneGraph.end(); ++iter) {
+		scenegraph::SceneGraphNode &targetNode = *iter;
+		if (targetNode.id() == sourceNodeId || !targetNode.isAnyModelNode()) {
+			continue;
+		}
+		voxel::RawVolume *targetVolume = targetNode.volume();
+		if (targetVolume == nullptr) {
+			continue;
+		}
+		const voxel::Region targetWorldRegion = _sceneGraph.sceneRegion(targetNode, _currentFrameIdx);
+		if (!targetWorldRegion.isValid()) {
+			continue;
+		}
+		if (!voxel::intersects(sourceWorldRegion, targetWorldRegion)) {
+			continue;
+		}
 
-		if (cell.existingNodeId != InvalidNodeId) {
-			// Existing node: expand if needed, then stamp
-			scenegraph::SceneGraphNode &targetNode = _sceneGraph.node(cell.existingNodeId);
-			voxel::RawVolume *targetVolume = targetNode.volume();
-			if (targetVolume == nullptr) {
-				continue;
+		// World-space overlap
+		voxel::Region worldOverlap = sourceWorldRegion;
+		worldOverlap.cropTo(targetWorldRegion);
+
+		// Offset from world to local volume coordinates
+		const glm::ivec3 worldToLocal =
+			targetVolume->region().getLowerCorner() - targetWorldRegion.getLowerCorner();
+		const voxel::Region localOverlap(
+			worldOverlap.getLowerCorner() + worldToLocal,
+			worldOverlap.getUpperCorner() + worldToLocal);
+
+		// Add missing source colors to the target palette before mapping
+		palette::Palette &destPalette = targetNode.palette();
+		bool paletteChanged = false;
+		for (int i = 0; i < sourcePalette.colorCount(); ++i) {
+			if (destPalette.tryAdd(sourcePalette.color(i), false)) {
+				paletteChanged = true;
 			}
+		}
+		if (paletteChanged) {
+			destPalette.markDirty();
+		}
+		palette::PaletteLookup palLookup(destPalette);
 
-			const voxel::Region targetWorldRegion =
-				_sceneGraph.sceneRegion(targetNode, _currentFrameIdx);
-			const glm::ivec3 worldToLocal =
-				targetVolume->region().getLowerCorner() - targetWorldRegion.getLowerCorner();
-
-			// The local region we need to write into
-			const voxel::Region neededLocalRegion(
-				cellSourceOverlap.getLowerCorner() + worldToLocal,
-				cellSourceOverlap.getUpperCorner() + worldToLocal);
-
-			// Expand the volume if it doesn't contain the needed region
-			const voxel::Region currentLocalRegion = targetVolume->region();
-			if (!currentLocalRegion.containsRegion(neededLocalRegion)) {
-				const voxel::Region expandedRegion(
-					glm::min(currentLocalRegion.getLowerCorner(), neededLocalRegion.getLowerCorner()),
-					glm::max(currentLocalRegion.getUpperCorner(), neededLocalRegion.getUpperCorner()));
-				voxel::RawVolume *newVolume = voxelutil::resize(targetVolume, expandedRegion);
-				if (newVolume == nullptr) {
-					Log::warn("mergeactivetobackground: failed to expand node %i", cell.existingNodeId);
-					continue;
-				}
-				targetNode.setVolume(newVolume);
-				targetVolume = newVolume;
-			}
-
-			// Add missing source colors to the target palette before mapping
-			palette::Palette &destPalette = targetNode.palette();
-			bool paletteChanged = false;
-			for (int i = 0; i < sourcePalette.colorCount(); ++i) {
-				if (destPalette.tryAdd(sourcePalette.color(i), false)) {
-					paletteChanged = true;
-				}
-			}
-			if (paletteChanged) {
-				destPalette.markDirty();
-			}
-			palette::PaletteLookup palLookup(destPalette);
-
-			// Stamp all voxels including air (overwrite destination in overlap)
-			int count = 0;
-			const glm::ivec3 &srcLower = cellSourceOverlap.getLowerCorner();
-			const glm::ivec3 &dstLower = neededLocalRegion.getLowerCorner();
-			const int32_t overlapW = cellSourceOverlap.getWidthInVoxels();
-			const int32_t overlapH = cellSourceOverlap.getHeightInVoxels();
-			const int32_t overlapD = cellSourceOverlap.getDepthInVoxels();
-			for (int32_t z = 0; z < overlapD; ++z) {
-				for (int32_t y = 0; y < overlapH; ++y) {
-					for (int32_t x = 0; x < overlapW; ++x) {
-						const voxel::Voxel srcVoxel = worldSource->voxel(
-							srcLower.x + x, srcLower.y + y, srcLower.z + z);
-						voxel::Voxel destVoxel;
-						if (voxel::isAir(srcVoxel.getMaterial())) {
-							destVoxel = voxel::Voxel();
-						} else {
-							const int idx = palLookup.findClosestIndex(
-								sourcePalette.color(srcVoxel.getColor()));
-							destVoxel = voxel::createVoxel(destPalette,
-								idx == palette::PaletteColorNotFound ? 0 : idx);
-						}
-						targetVolume->setVoxel(
-							dstLower.x + x, dstLower.y + y, dstLower.z + z, destVoxel);
-						++count;
-					}
-				}
-			}
-			if (count > 0) {
-				stampedNodes.push_back(StampedNode{cell.existingNodeId, neededLocalRegion});
-				stampedCount += count;
-			}
-		} else {
-			// No existing node for this grid cell: create a new one
-			// Single pass: stamp non-air source voxels into a new volume
-			voxel::RawVolume *newVolume = new voxel::RawVolume(cell.cellRegion);
-			palette::PaletteLookup palLookup(sourcePalette);
-
-			const glm::ivec3 &srcLower = cellSourceOverlap.getLowerCorner();
-			const int32_t overlapW = cellSourceOverlap.getWidthInVoxels();
-			const int32_t overlapH = cellSourceOverlap.getHeightInVoxels();
-			const int32_t overlapD = cellSourceOverlap.getDepthInVoxels();
-			int count = 0;
-			for (int32_t z = 0; z < overlapD; ++z) {
-				for (int32_t y = 0; y < overlapH; ++y) {
-					for (int32_t x = 0; x < overlapW; ++x) {
-						const voxel::Voxel srcVoxel = worldSource->voxel(
-							srcLower.x + x, srcLower.y + y, srcLower.z + z);
-						if (voxel::isAir(srcVoxel.getMaterial())) {
-							continue;
-						}
+		int count = 0;
+		const glm::ivec3 &worldLower = worldOverlap.getLowerCorner();
+		const glm::ivec3 &localLower = localOverlap.getLowerCorner();
+		const int32_t w = worldOverlap.getWidthInVoxels();
+		const int32_t h = worldOverlap.getHeightInVoxels();
+		const int32_t d = worldOverlap.getDepthInVoxels();
+		for (int32_t z = 0; z < d; ++z) {
+			for (int32_t y = 0; y < h; ++y) {
+				for (int32_t x = 0; x < w; ++x) {
+					const voxel::Voxel srcVoxel = worldSource->voxel(
+						worldLower.x + x, worldLower.y + y, worldLower.z + z);
+					voxel::Voxel destVoxel;
+					if (!voxel::isAir(srcVoxel.getMaterial())) {
 						const int idx = palLookup.findClosestIndex(
 							sourcePalette.color(srcVoxel.getColor()));
-						const voxel::Voxel destVoxel = voxel::createVoxel(sourcePalette,
+						destVoxel = voxel::createVoxel(destPalette,
 							idx == palette::PaletteColorNotFound ? 0 : idx);
-						newVolume->setVoxel(srcLower.x + x, srcLower.y + y, srcLower.z + z,
-							destVoxel);
-						++count;
 					}
+					targetVolume->setVoxel(
+						localLower.x + x, localLower.y + y, localLower.z + z, destVoxel);
+					++count;
 				}
 			}
-
-			if (count == 0) {
-				delete newVolume;
-				continue;
-			}
-
-			scenegraph::SceneGraphNode newNode(scenegraph::SceneGraphNodeType::Model);
-			newNode.setVolume(newVolume);
-			newNode.setPalette(sourcePalette);
-			newNode.setName("merged");
-			const int newNodeId = moveNodeToSceneGraph(newNode, backgroundParentId);
-			if (newNodeId != InvalidNodeId) {
-				stampedNodes.push_back(StampedNode{newNodeId, cellSourceOverlap});
-				stampedCount += count;
-			}
+		}
+		if (count > 0) {
+			stampedNodes.push_back(StampedNode{targetNode.id(), localOverlap, worldOverlap});
+			stampedCount += count;
 		}
 	}
 
@@ -2077,9 +1956,57 @@ bool SceneManager::mergeActiveToBackground() {
 		return false;
 	}
 
+	// Erase stamped world regions from the working copy, then check for survivors.
+	// Any voxels not covered by any destination node are preserved as a new node.
+	{
+		const voxel::Voxel airVoxel;
+		for (const StampedNode &entry : stampedNodes) {
+			const voxel::Region &wr = entry.worldRegion;
+			for (int32_t z = wr.getLowerZ(); z <= wr.getUpperZ(); ++z) {
+				for (int32_t y = wr.getLowerY(); y <= wr.getUpperY(); ++y) {
+					for (int32_t x = wr.getLowerX(); x <= wr.getUpperX(); ++x) {
+						worldSource->setVoxel(x, y, z, airVoxel);
+					}
+				}
+			}
+		}
+		// cropVolume returns nullptr both when empty AND when region didn't shrink.
+		// Scan the raw voxel array to detect survivors before deciding what to do.
+		const voxel::Region &srcReg = worldSource->region();
+		const voxel::Voxel *voxels = worldSource->voxels();
+		const int voxelCount =
+			srcReg.getWidthInVoxels() * srcReg.getHeightInVoxels() * srcReg.getDepthInVoxels();
+		bool hasRemainder = false;
+		for (int i = 0; i < voxelCount; ++i) {
+			if (!voxel::isAir(voxels[i].getMaterial())) {
+				hasRemainder = true;
+				break;
+			}
+		}
+		if (hasRemainder) {
+			voxel::RawVolume *remainder = voxelutil::cropVolume(worldSource);
+			if (remainder == nullptr) {
+				// cropVolume returns nullptr when region didn't shrink — copy as-is
+				remainder = new voxel::RawVolume(*worldSource);
+			}
+			int remainderParentId = _sceneGraph.root().id();
+			if (!stampedNodes.empty()) {
+				remainderParentId = _sceneGraph.node(stampedNodes[0].nodeId).parent();
+			}
+			scenegraph::SceneGraphNode remainderNode(scenegraph::SceneGraphNodeType::Model);
+			remainderNode.setVolume(remainder);
+			remainderNode.setPalette(sourcePalette);
+			remainderNode.setName(sourceNode->name());
+			const int newId = moveNodeToSceneGraph(remainderNode, remainderParentId);
+			if (newId != InvalidNodeId) {
+				stampedNodes.push_back(StampedNode{newId, remainder->region(), remainder->region()});
+			}
+		}
+	}
+
 	// Show all hidden model nodes and unhide them in the mesh state so that
 	// scheduleRegionExtraction does not skip extraction for hidden volumes
-	for (auto iter = _sceneGraph.beginModel(); iter != _sceneGraph.end(); ++iter) {
+	for (auto iter = _sceneGraph.beginAllModels(); iter != _sceneGraph.end(); ++iter) {
 		scenegraph::SceneGraphNode &node = *iter;
 		if (node.id() != sourceNodeId && !node.visible()) {
 			nodeSetVisible(node.id(), true);
@@ -2089,7 +2016,7 @@ bool SceneManager::mergeActiveToBackground() {
 
 	// Mark modified after nodes are visible so renderer processes the mesh updates
 	for (const StampedNode &entry : stampedNodes) {
-		modified(entry.nodeId, entry.region, SceneModifiedFlags::All);
+		modified(entry.nodeId, entry.localRegion, SceneModifiedFlags::All);
 	}
 
 	_mementoHandler.markNodeRemove(_sceneGraph, *sourceNode);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
@@ -467,7 +467,6 @@ void SelectBrush::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWra
 		break;
 	}
 	case SelectMode::Box3D: {
-		wrapper.removeFlags(wrapper.region(), voxel::FlagOutline);
 		voxelutil::VisitSolid condition;
 		voxelutil::visitVolumeParallel(wrapper, selectionRegion, func, condition);
 		// Store the exact box region so ModifierVolumeWrapper::skip() allows

--- a/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SceneManagerTest.cpp
@@ -1911,7 +1911,7 @@ TEST_F(SceneManagerTest, testMergeActiveToBackgroundPaletteTransfer) {
 
 TEST_F(SceneManagerTest, testMergeActiveToBackgroundExpandsNode) {
 	// Target node is cropped smaller than the grid cell. Source overlaps the gap.
-	// After merge, target should be expanded to cover the overlap.
+	// The voxel outside the target becomes a remainder node.
 	const voxel::Region targetRegion(0, 0, 0, 4, 4, 4);
 	ASSERT_TRUE(_sceneMgr->newScene(true, "expand_test", targetRegion));
 
@@ -1937,13 +1937,22 @@ TEST_F(SceneManagerTest, testMergeActiveToBackgroundExpandsNode) {
 	_sceneMgr->nodeActivate(sourceNodeId);
 	ASSERT_TRUE(_sceneMgr->mergeActiveToBackground());
 
-	// The target node should have been expanded to include (8,8,8)
-	const scenegraph::SceneGraphNode *resultNode = _sceneMgr->sceneGraphModelNode(targetNodeId);
-	ASSERT_NE(nullptr, resultNode);
-	const voxel::RawVolume *resultVol = resultNode->volume();
-	ASSERT_NE(nullptr, resultVol);
-	EXPECT_TRUE(resultVol->region().containsPoint(glm::ivec3(8, 8, 8)));
-	EXPECT_FALSE(voxel::isAir(resultVol->voxel(8, 8, 8).getMaterial()));
+	// The voxel at (8,8,8) is outside the target region, so it becomes a remainder node.
+	// Find the remainder node by scanning for a model node containing (8,8,8).
+	bool foundRemainder = false;
+	for (auto iter = _sceneMgr->sceneGraph().beginAllModels(); iter != _sceneMgr->sceneGraph().end(); ++iter) {
+		const scenegraph::SceneGraphNode &node = *iter;
+		if (node.id() == targetNodeId) {
+			continue;
+		}
+		const voxel::RawVolume *vol = node.volume();
+		if (vol != nullptr && vol->region().containsPoint(glm::ivec3(8, 8, 8))) {
+			EXPECT_FALSE(voxel::isAir(vol->voxel(8, 8, 8).getMaterial()));
+			foundRemainder = true;
+			break;
+		}
+	}
+	EXPECT_TRUE(foundRemainder) << "Expected a remainder node containing (8,8,8)";
 }
 
 TEST_F(SceneManagerTest, testMergeVisibleToTemp) {


### PR DESCRIPTION
## Summary
- **Box3D select fix**: Box3D selection no longer clears existing selections before applying a new one. The `removeFlags` call was unconditionally wiping all FlagOutline, breaking additive selection. No other select mode did this.
- **mergeActiveToBackground rewrite**: Simplified from grid-cell-based approach to directly stamping into overlapping background nodes. Always works on a copy to avoid mutating the live volume. Uncovered voxels are preserved as a new remainder node.
- **InputInt consistency + position step**: The Z-axis InputInt now uses `modified |=` consistently with the float path. Added a configurable position step (1-64) in NodeInspectorPanel, replacing the hardcoded grid size.

## Test plan
- [ ] Select voxels with Box3D, then select additional voxels - both selections should be preserved
- [ ] Use Erase modifier with Box3D to deselect a region from an existing selection
- [ ] mergeactivetobackground with a node overlapping multiple background nodes
- [ ] mergeactivetobackground with a node partially outside any background node (remainder node should be created)
- [ ] Change position step in NodeInspector and verify arrow clicks move by that amount