### PR TITLE
VOXEDIT: add Rectangle, Line and PolygonLasso surface select brushes

### DIFF
--- a/src/modules/voxelutil/CMakeLists.txt
+++ b/src/modules/voxelutil/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SRCS
 	tests/VolumeCropperTest.cpp
 	tests/VolumeVisitorTest.cpp
 	tests/VolumeSculptTest.cpp
+	tests/VolumeSelectTest.cpp
 	tests/VoxelUtilTest.cpp
 )
 

--- a/src/modules/voxelutil/VolumeSelect.cpp
+++ b/src/modules/voxelutil/VolumeSelect.cpp
@@ -8,6 +8,26 @@ namespace voxelutil {
 
 bool lassoContains(const core::DynamicArray<glm::ivec3> &path, int pu, int pv, int uAxis, int vAxis) {
 	const int n = (int)path.size();
+	// A point exactly on a polygon edge must count as inside. Ray-casting with strict
+	// inequalities drops such points, which would exclude the entire boundary row/column
+	// drawn by the user and break flood-fill seeding.
+	for (int i = 0, j = n - 1; i < n; j = i++) {
+		const int xi = path[i][uAxis];
+		const int yi = path[i][vAxis];
+		const int xj = path[j][uAxis];
+		const int yj = path[j][vAxis];
+		const long long cross = (long long)(xi - xj) * (long long)(pv - yj) -
+								(long long)(yi - yj) * (long long)(pu - xj);
+		if (cross == 0) {
+			const int minX = glm::min(xi, xj);
+			const int maxX = glm::max(xi, xj);
+			const int minY = glm::min(yi, yj);
+			const int maxY = glm::max(yi, yj);
+			if (pu >= minX && pu <= maxX && pv >= minY && pv <= maxY) {
+				return true;
+			}
+		}
+	}
 	bool inside = false;
 	for (int i = 0, j = n - 1; i < n; j = i++) {
 		const double xi = (double)path[i][uAxis];

--- a/src/modules/voxelutil/VolumeSelect.h
+++ b/src/modules/voxelutil/VolumeSelect.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include "core/GLM.h"
 #include "core/collection/DynamicArray.h"
+#include "core/collection/DynamicSet.h"
 #include "voxel/Region.h"
 #include "voxel/Voxel.h"
 #include <glm/common.hpp>
@@ -23,64 +25,435 @@ namespace voxelutil {
 bool lassoContains(const core::DynamicArray<glm::ivec3> &path, int pu, int pv, int uAxis, int vAxis);
 
 /**
- * @brief Draw the lasso edge between two vertices by scanning the face-normal column
- *        at each Bresenham step and marking the outermost surface voxel.
- * @param sampler Callable(glm::ivec3) -> voxel::Voxel used to sample the volume
- * @param markFunc Callable(int x, int y, int z, voxel::Voxel) called for each hit surface voxel
+ * @brief A solid (non-air) voxel inside @p region.
  */
-template<typename Sampler, typename MarkFunc>
-void drawLassoEdgeSurface(Sampler &&sampler, const glm::ivec3 &a, const glm::ivec3 &b,
-						  int uAxis, int vAxis, int wAxis, bool positiveNormal,
-						  const voxel::Region &region, MarkFunc &&markFunc) {
+template<typename Volume>
+inline bool selectIsSolid(const Volume &volume, const glm::ivec3 &p, const voxel::Region &region) {
+	if (!region.containsPoint(p)) {
+		return false;
+	}
+	return !voxel::isAir(volume.voxel(p.x, p.y, p.z).getMaterial());
+}
+
+/**
+ * @brief Front-most solid voxel depth in column (@p u, @p v), scanning inward from the clicked face.
+ *
+ * Early-outs at the first solid, so it never walks the whole column on a surface near the face.
+ * @param outW Receives the depth of the visible (front-most) surface voxel.
+ * @return true when the column contains a solid voxel.
+ */
+template<typename Volume>
+bool columnFrontSurface(const Volume &volume, int u, int v, int uAxis, int vAxis, int wAxis, bool positiveNormal,
+						const voxel::Region &region, int &outW) {
+	glm::ivec3 pos(0);
+	pos[uAxis] = u;
+	pos[vAxis] = v;
 	const int wLo = region.getLowerCorner()[wAxis];
 	const int wHi = region.getUpperCorner()[wAxis];
-
-	int u = a[uAxis];
-	int v = a[vAxis];
-	const int du = glm::abs(b[uAxis] - u);
-	const int dv = glm::abs(b[vAxis] - v);
-	const int su = a[uAxis] < b[uAxis] ? 1 : -1;
-	const int sv = a[vAxis] < b[vAxis] ? 1 : -1;
-	int err = du - dv;
-
-	while (true) {
-		glm::ivec3 pos;
-		pos[uAxis] = u;
-		pos[vAxis] = v;
-		// Scan from the face inward along W to find the outermost surface voxel
-		if (positiveNormal) {
-			for (int w = wHi; w >= wLo; --w) {
-				pos[wAxis] = w;
-				const voxel::Voxel vox = sampler(pos);
-				if (!voxel::isAir(vox.getMaterial())) {
-					markFunc(pos.x, pos.y, pos.z, vox);
-					break;
-				}
-			}
-		} else {
-			for (int w = wLo; w <= wHi; ++w) {
-				pos[wAxis] = w;
-				const voxel::Voxel vox = sampler(pos);
-				if (!voxel::isAir(vox.getMaterial())) {
-					markFunc(pos.x, pos.y, pos.z, vox);
-					break;
-				}
+	if (positiveNormal) {
+		for (int w = wHi; w >= wLo; --w) {
+			pos[wAxis] = w;
+			if (selectIsSolid(volume, pos, region)) {
+				outW = w;
+				return true;
 			}
 		}
-
-		if (u == b[uAxis] && v == b[vAxis]) {
-			break;
-		}
-		const int e2 = 2 * err;
-		if (e2 > -dv) {
-			err -= dv;
-			u += su;
-		}
-		if (e2 < du) {
-			err += du;
-			v += sv;
+	} else {
+		for (int w = wLo; w <= wHi; ++w) {
+			pos[wAxis] = w;
+			if (selectIsSolid(volume, pos, region)) {
+				outW = w;
+				return true;
+			}
 		}
 	}
+	return false;
+}
+
+// Forward declarations: these helper templates are defined later in this header.
+template<typename PlotFunc>
+void bresenham3d(const glm::ivec3 &a, const glm::ivec3 &b, PlotFunc &&plot);
+template<typename Volume, typename MarkFunc>
+void lineMarkSolid(const Volume &volume, const glm::ivec3 &a, const glm::ivec3 &b, int width,
+				   const voxel::Region &region, MarkFunc &&markFunc);
+template<typename Volume, typename MarkFunc>
+void lineDrapeSurface(const Volume &volume, const glm::ivec3 &a, const glm::ivec3 &b, int uAxis, int vAxis, int wAxis,
+					  bool positiveNormal, int width, const voxel::Region &region, MarkFunc &&markFunc);
+template<typename Volume>
+bool findSurfaceNear(const Volume &volume, int u, int v, int refW, int tolerance, int uAxis, int vAxis, int wAxis,
+					 bool positiveNormal, const voxel::Region &region, int &outW);
+
+/** Lateral neighbour offsets (4 face + 4 diagonal) used to bridge terrace risers in the lasso fill. */
+static const int LassoRiserNeighbourCount = 8;
+static const int LassoRiserNeighbourU[LassoRiserNeighbourCount] = {1, -1, 0, 0, 1, 1, -1, -1};
+static const int LassoRiserNeighbourV[LassoRiserNeighbourCount] = {0, 0, 1, -1, 1, -1, 1, -1};
+
+/**
+ * @brief Select the visible surface inside a lasso polygon, filling its whole interior.
+ *
+ * For every (u,v) cell inside the polygon (and along the drawn edges) the FRONT-most solid voxel
+ * along the face-normal axis is marked - the surface seen from the clicked face. To keep the
+ * projected selection gap-free across a steep step, a column also marks the riser face down to any
+ * adjacent in-polygon neighbour whose surface is more recessed (bounded by the step height). This
+ * is a per-column scan with an early-out at the first solid, so it allocates no per-voxel buffers
+ * and never enumerates the volume - it cannot freeze on a large model. A column over empty space
+ * is simply skipped, and a structure hidden behind the visible one is never the front-most, so it
+ * is ignored.
+ *
+ * @param path Polygon vertices (ordered).
+ * @param uAxis,vAxis Indices (0/1/2) of the polygon lateral axes.
+ * @param wAxis Index of the face-normal (depth) axis.
+ * @param positiveNormal True if the lasso face normal points in the +w direction.
+ * @param region Volume region used for bounds checks and the column scan.
+ * @param markFunc Callable(int x, int y, int z, const voxel::Voxel &) applied to each selected voxel.
+ * @param maxDeviation Currently unused; kept for call-site compatibility.
+ */
+template<typename Volume, typename MarkFunc>
+void lassoFloodFillSurface(const Volume &volume, const core::DynamicArray<glm::ivec3> &path, int uAxis, int vAxis,
+						   int wAxis, bool positiveNormal, const voxel::Region &region, MarkFunc &&markFunc,
+						   int maxDeviation) {
+	(void)maxDeviation;
+	if (path.size() < 2) {
+		return;
+	}
+
+	auto inPolygon = [&](int u, int v) { return lassoContains(path, u, v, uAxis, vAxis); };
+	auto columnFront = [&](int u, int v, int &outW) -> bool {
+		return columnFrontSurface(volume, u, v, uAxis, vAxis, wAxis, positiveNormal, region, outW);
+	};
+	auto markAt = [&](int u, int v, int w) {
+		glm::ivec3 q(0);
+		q[uAxis] = u;
+		q[vAxis] = v;
+		q[wAxis] = w;
+		const voxel::Voxel vox = volume.voxel(q.x, q.y, q.z);
+		markFunc(q.x, q.y, q.z, vox);
+	};
+
+	// Mark a column's visible skin: its front-most solid, plus the riser faces down to any adjacent
+	// in-direction neighbour whose surface is more recessed - so the projection has no vertical gaps
+	// across steep steps. All 8 neighbours (incl. diagonals) are bridged so a step that drops
+	// diagonally does not leave an unfilled corner. Only the higher column fills a given wall, so the
+	// wall is filled once. Filling only toward in-polygon neighbours keeps the boundary from growing
+	// a tall wall that would project past the lasso outline.
+	auto markColumn = [&](int u, int v) {
+		int d;
+		if (!columnFront(u, v, d)) {
+			return;
+		}
+		markAt(u, v, d);
+		for (int k = 0; k < LassoRiserNeighbourCount; ++k) {
+			const int nu = u + LassoRiserNeighbourU[k];
+			const int nv = v + LassoRiserNeighbourV[k];
+			if (!inPolygon(nu, nv)) {
+				continue;
+			}
+			int dn;
+			if (!columnFront(nu, nv, dn)) {
+				continue;
+			}
+			if (positiveNormal) {
+				for (int w = d - 1; w > dn; --w) {
+					glm::ivec3 q(0);
+					q[uAxis] = u;
+					q[vAxis] = v;
+					q[wAxis] = w;
+					if (selectIsSolid(volume, q, region)) {
+						markAt(u, v, w);
+					}
+				}
+			} else {
+				for (int w = d + 1; w < dn; ++w) {
+					glm::ivec3 q(0);
+					q[uAxis] = u;
+					q[vAxis] = v;
+					q[wAxis] = w;
+					if (selectIsSolid(volume, q, region)) {
+						markAt(u, v, w);
+					}
+				}
+			}
+		}
+	};
+
+	// Always cover the drawn edges (so a thin/degenerate polygon still yields a continuous line).
+	const int vertexCount = (int)path.size();
+	for (int i = 0; i < vertexCount; ++i) {
+		glm::ivec3 a2 = path[i];
+		glm::ivec3 b2 = path[(i + 1) % vertexCount];
+		a2[wAxis] = 0;
+		b2[wAxis] = 0;
+		bresenham3d(a2, b2, [&](const glm::ivec3 &c) { markColumn(c[uAxis], c[vAxis]); });
+	}
+
+	if (path.size() < 3) {
+		return;
+	}
+
+	int minU = path[0][uAxis];
+	int maxU = path[0][uAxis];
+	int minV = path[0][vAxis];
+	int maxV = path[0][vAxis];
+	for (const glm::ivec3 &p : path) {
+		minU = glm::min(minU, p[uAxis]);
+		maxU = glm::max(maxU, p[uAxis]);
+		minV = glm::min(minV, p[vAxis]);
+		maxV = glm::max(maxV, p[vAxis]);
+	}
+	// Fill the interior by point-in-polygon over the (u,v) bounding box.
+	for (int u = minU; u <= maxU; ++u) {
+		for (int v = minV; v <= maxV; ++v) {
+			if (inPolygon(u, v)) {
+				markColumn(u, v);
+			}
+		}
+	}
+}
+
+/**
+ * @brief Visit every integer cell on the 3D Bresenham line from @p a to @p b (inclusive).
+ * @param plot Callable(const glm::ivec3 &) invoked once per line cell.
+ */
+template<typename PlotFunc>
+void bresenham3d(const glm::ivec3 &a, const glm::ivec3 &b, PlotFunc &&plot) {
+	glm::ivec3 p = a;
+	const glm::ivec3 d = glm::abs(b - a);
+	const glm::ivec3 s(b.x >= a.x ? 1 : -1, b.y >= a.y ? 1 : -1, b.z >= a.z ? 1 : -1);
+	if (d.x >= d.y && d.x >= d.z) {
+		int e1 = 2 * d.y - d.x;
+		int e2 = 2 * d.z - d.x;
+		while (true) {
+			plot(p);
+			if (p.x == b.x) {
+				break;
+			}
+			if (e1 >= 0) {
+				p.y += s.y;
+				e1 -= 2 * d.x;
+			}
+			if (e2 >= 0) {
+				p.z += s.z;
+				e2 -= 2 * d.x;
+			}
+			p.x += s.x;
+			e1 += 2 * d.y;
+			e2 += 2 * d.z;
+		}
+	} else if (d.y >= d.x && d.y >= d.z) {
+		int e1 = 2 * d.x - d.y;
+		int e2 = 2 * d.z - d.y;
+		while (true) {
+			plot(p);
+			if (p.y == b.y) {
+				break;
+			}
+			if (e1 >= 0) {
+				p.x += s.x;
+				e1 -= 2 * d.y;
+			}
+			if (e2 >= 0) {
+				p.z += s.z;
+				e2 -= 2 * d.y;
+			}
+			p.y += s.y;
+			e1 += 2 * d.x;
+			e2 += 2 * d.z;
+		}
+	} else {
+		int e1 = 2 * d.y - d.z;
+		int e2 = 2 * d.x - d.z;
+		while (true) {
+			plot(p);
+			if (p.z == b.z) {
+				break;
+			}
+			if (e1 >= 0) {
+				p.y += s.y;
+				e1 -= 2 * d.z;
+			}
+			if (e2 >= 0) {
+				p.x += s.x;
+				e2 -= 2 * d.z;
+			}
+			p.z += s.z;
+			e1 += 2 * d.y;
+			e2 += 2 * d.x;
+		}
+	}
+}
+
+/**
+ * @brief Rasterize the straight 3D line @p a -> @p b and mark every solid voxel within
+ *        @p width of the line.
+ *
+ * @p width is the full thickness in voxels (1 = just the centerline). A voxel is marked
+ * when its Chebyshev distance to a line cell is at most @c width/2. Air cells are skipped,
+ * so where the line passes through empty space nothing is selected. Each voxel is reported
+ * at most once even where the thickened cells of successive line steps overlap.
+ *
+ * @param volume Read-only volume with voxel(x,y,z) access.
+ * @param region Bounds for both the solidity test and thickness clipping.
+ * @param markFunc Callable(int x, int y, int z, const voxel::Voxel &) invoked for each hit.
+ */
+template<typename Volume, typename MarkFunc>
+void lineMarkSolid(const Volume &volume, const glm::ivec3 &a, const glm::ivec3 &b, int width,
+				   const voxel::Region &region, MarkFunc &&markFunc) {
+	const int r = glm::max(0, width / 2);
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> marked;
+	auto plot = [&](const glm::ivec3 &c) {
+		for (int dz = -r; dz <= r; ++dz) {
+			for (int dy = -r; dy <= r; ++dy) {
+				for (int dx = -r; dx <= r; ++dx) {
+					const glm::ivec3 q(c.x + dx, c.y + dy, c.z + dz);
+					if (!region.containsPoint(q)) {
+						continue;
+					}
+					if (marked.has(q)) {
+						continue;
+					}
+					const voxel::Voxel v = volume.voxel(q.x, q.y, q.z);
+					if (voxel::isAir(v.getMaterial())) {
+						continue;
+					}
+					marked.insert(q);
+					markFunc(q.x, q.y, q.z, v);
+				}
+			}
+		}
+	};
+	bresenham3d(a, b, plot);
+}
+
+/**
+ * @brief Draw a line that drapes over the VISIBLE surface from @p a to @p b and stays continuous.
+ *
+ * Walks the 2D line in the (u,v) face plane and, at every step, marks the front-most solid voxel
+ * of that column - the surface the eye actually sees from the clicked face. Between two consecutive
+ * steps whose surface depth differs (a terrace riser), it fills the taller column's vertical face
+ * down to the lower neighbour, so the step is visible and the marked line never breaks. Unlike a
+ * 3D skin walk (which can thread the hidden back of a riser and render as disjoint treads), every
+ * marked voxel here is on the visible front, so the drawn line looks continuous on stepped terrain.
+ *
+ * The mark callback is expected to be idempotent (it sets a flag), so this keeps no dedup buffer.
+ *
+ * @param uAxis,vAxis Indices (0/1/2) of the lateral face-plane axes.
+ * @param wAxis Index of the face-normal (depth) axis.
+ * @param positiveNormal True if the face normal points in the +w direction.
+ * @param width Full thickness in voxels of the marked line (1 = a single voxel chain).
+ * @param markFunc Callable(int x, int y, int z, const voxel::Voxel &) invoked for each marked voxel.
+ */
+template<typename Volume, typename MarkFunc>
+void lineDrapeSurface(const Volume &volume, const glm::ivec3 &a, const glm::ivec3 &b, int uAxis, int vAxis, int wAxis,
+					  bool positiveNormal, int width, const voxel::Region &region, MarkFunc &&markFunc) {
+	const int r = glm::max(0, width / 2);
+	auto axisPos = [&](int u, int v, int w) {
+		glm::ivec3 c(0);
+		c[uAxis] = u;
+		c[vAxis] = v;
+		c[wAxis] = w;
+		return c;
+	};
+	// Mark a width ball of solid voxels around the centre (so thickness is uniform in 3D).
+	auto markBall = [&](const glm::ivec3 &center) {
+		for (int dz = -r; dz <= r; ++dz) {
+			for (int dy = -r; dy <= r; ++dy) {
+				for (int dx = -r; dx <= r; ++dx) {
+					const glm::ivec3 q(center.x + dx, center.y + dy, center.z + dz);
+					if (!selectIsSolid(volume, q, region)) {
+						continue;
+					}
+					const voxel::Voxel vox = volume.voxel(q.x, q.y, q.z);
+					markFunc(q.x, q.y, q.z, vox);
+				}
+			}
+		}
+	};
+
+	glm::ivec3 a2 = a;
+	glm::ivec3 b2 = b;
+	a2[wAxis] = 0;
+	b2[wAxis] = 0;
+	bool havePrev = false;
+	int prevU = 0;
+	int prevV = 0;
+	int prevW = 0;
+	bresenham3d(a2, b2, [&](const glm::ivec3 &c) {
+		const int u = c[uAxis];
+		const int v = c[vAxis];
+		int d;
+		if (!columnFrontSurface(volume, u, v, uAxis, vAxis, wAxis, positiveNormal, region, d)) {
+			// No surface in this column (the line passes over empty space) - break continuity.
+			havePrev = false;
+			return;
+		}
+		markBall(axisPos(u, v, d));
+		if (havePrev && (u != prevU || v != prevV)) {
+			// Bridge the riser between the two columns by filling the taller one's vertical face,
+			// so the step is visible and the line stays connected across it.
+			const int lo = glm::min(d, prevW);
+			const int hi = glm::max(d, prevW);
+			const bool currentTaller = positiveNormal ? (d >= prevW) : (d <= prevW);
+			const int wallU = currentTaller ? u : prevU;
+			const int wallV = currentTaller ? v : prevV;
+			for (int w = lo; w <= hi; ++w) {
+				markBall(axisPos(wallU, wallV, w));
+			}
+		}
+		prevU = u;
+		prevV = v;
+		prevW = d;
+		havePrev = true;
+	});
+}
+
+/**
+ * @brief In the column (@p u, @p v), find the exposed surface voxel whose depth is nearest to
+ *        @p refW (within @p tolerance) along the face-normal axis.
+ *
+ * A voxel qualifies only if it is solid AND its neighbour on the face side is air (or outside the
+ * region) - i.e. it is an actual surface voxel, not an interior one. The band is scanned nearest
+ * to @p refW first, so the surface closest to the reference depth wins.
+ *
+ * @param outW Receives the depth of the found surface voxel.
+ * @return true when an exposed surface voxel is found within @p tolerance of @p refW.
+ */
+template<typename Volume>
+bool findSurfaceNear(const Volume &volume, int u, int v, int refW, int tolerance, int uAxis, int vAxis, int wAxis,
+					 bool positiveNormal, const voxel::Region &region, int &outW) {
+	glm::ivec3 pos(0);
+	pos[uAxis] = u;
+	pos[vAxis] = v;
+	auto isExposedSurface = [&](int w) {
+		pos[wAxis] = w;
+		if (!region.containsPoint(pos)) {
+			return false;
+		}
+		if (voxel::isAir(volume.voxel(pos.x, pos.y, pos.z).getMaterial())) {
+			return false;
+		}
+		// The neighbour toward the face must be air (or out of bounds) for this to be a surface voxel.
+		glm::ivec3 np = pos;
+		np[wAxis] = positiveNormal ? w + 1 : w - 1;
+		if (!region.containsPoint(np)) {
+			return true;
+		}
+		return voxel::isAir(volume.voxel(np.x, np.y, np.z).getMaterial());
+	};
+	for (int d = 0; d <= tolerance; ++d) {
+		const int first = positiveNormal ? refW + d : refW - d;
+		if (isExposedSurface(first)) {
+			outW = first;
+			return true;
+		}
+		if (d != 0) {
+			const int second = positiveNormal ? refW - d : refW + d;
+			if (isExposedSurface(second)) {
+				outW = second;
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 } // namespace voxelutil

--- a/src/modules/voxelutil/tests/VolumeSelectTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSelectTest.cpp
@@ -1,0 +1,428 @@
+/**
+ * @file
+ */
+
+#include "voxelutil/VolumeSelect.h"
+#include "app/tests/AbstractTest.h"
+#include "voxel/Connectivity.h"
+#include "voxel/Face.h"
+#include "voxel/RawVolume.h"
+#include "voxel/Voxel.h"
+
+namespace voxelutil {
+
+class VolumeSelectTest : public app::AbstractTest {};
+
+static void fillBox(voxel::RawVolume &volume, const voxel::Region &r, const voxel::Voxel &v) {
+	const glm::ivec3 &lo = r.getLowerCorner();
+	const glm::ivec3 &hi = r.getUpperCorner();
+	for (int z = lo.z; z <= hi.z; ++z) {
+		for (int y = lo.y; y <= hi.y; ++y) {
+			for (int x = lo.x; x <= hi.x; ++x) {
+				volume.setVoxel(x, y, z, v);
+			}
+		}
+	}
+}
+
+// Regression: lasso drawn on an upper structure must not sweep in a lower structure that
+// merely shares the (u, v) silhouette. Before flood-fill, selectionFinalizeLasso filtered
+// every surface voxel in the volume by 2D point-in-polygon only, so a tower behind a
+// lassoed rooftop got picked up too.
+TEST_F(VolumeSelectTest, testLassoFloodFillDoesNotCrossDisjointStructures) {
+	voxel::Region region(0, 29);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Upper slab at y=20, lower slab at y=5. Same X/Z footprint, disjoint in Y. With a
+	// PositiveY lasso drawing U=Z, V=X, both slabs project to the same (u, v) silhouette.
+	fillBox(volume, voxel::Region(glm::ivec3(5, 20, 5), glm::ivec3(15, 20, 15)), solid);
+	fillBox(volume, voxel::Region(glm::ivec3(5, 5, 5), glm::ivec3(15, 5, 15)), solid);
+
+	// Polygon vertices live on the upper slab's top surface so edge rasterization seeds
+	// only the upper slab. Path traces a square covering the whole upper slab footprint.
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(5, 20, 5));
+	path.push_back(glm::ivec3(15, 20, 5));
+	path.push_back(glm::ivec3(15, 20, 15));
+	path.push_back(glm::ivec3(5, 20, 15));
+
+	int selectedUpper = 0;
+	int selectedLower = 0;
+	int selectedElsewhere = 0;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) {
+		if (y == 20) {
+			++selectedUpper;
+		} else if (y == 5) {
+			++selectedLower;
+		} else {
+			++selectedElsewhere;
+		}
+	};
+
+	// PositiveY face: U=Z (axis 2), V=X (axis 0), W=Y (axis 1), positiveNormal=true
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*depthTolerance*/ 2);
+
+	EXPECT_GT(selectedUpper, 0) << "upper slab should be selected";
+	EXPECT_EQ(selectedLower, 0) << "lower slab must not be swept in despite sharing (X,Z)";
+	EXPECT_EQ(selectedElsewhere, 0);
+}
+
+// A lasso drawn on the front (+X) face of a column must select only that visible front
+// surface - it must NOT wrap down the side walls or reach the back face. The flood works on
+// the frontmost solid per (u,v) column, so side/back voxels (which are never frontmost) are
+// left out. This is the behavior that keeps the selection a thin skin instead of a 3D chunk.
+TEST_F(VolumeSelectTest, testLassoFloodFillFrontSurfaceOnly) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Vertical column at (8..11, 0..15, 8..11).
+	fillBox(volume, voxel::Region(glm::ivec3(8, 0, 8), glm::ivec3(11, 15, 11)), solid);
+
+	// Lasso drawn on the +X face: U=Y (axis 1), V=Z (axis 2), W=X (axis 0).
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(11, 2, 8));
+	path.push_back(glm::ivec3(11, 13, 8));
+	path.push_back(glm::ivec3(11, 13, 11));
+	path.push_back(glm::ivec3(11, 2, 11));
+
+	core::DynamicSet<glm::ivec3, 257, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	// PositiveX face: U=Y (1), V=Z (2), W=X (0), positiveNormal=true
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 1, /*vAxis*/ 2, /*wAxis*/ 0,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*depthTolerance*/ 2);
+
+	bool frontHit = false;
+	bool backHit = false;
+	bool interiorHit = false;
+	for (auto *entry : selected) {
+		if (entry->key.x == 11) {
+			frontHit = true;
+		} else if (entry->key.x == 8) {
+			backHit = true;
+		} else if (entry->key.x == 9 || entry->key.x == 10) {
+			interiorHit = true;
+		}
+	}
+	EXPECT_TRUE(frontHit) << "front face (x=11) should be selected";
+	EXPECT_FALSE(backHit) << "back face (x=8) must NOT be reached - no wrapping through walls";
+	EXPECT_FALSE(interiorHit) << "interior depth voxels must NOT be selected - front surface only";
+}
+
+// Concave polygon: if the first seed alone couldn't reach every interior corner via flood,
+// seeding from every edge pixel protects us from the trap. Drawing an L-shape polygon on a
+// flat surface must still cover the whole inside of the L.
+TEST_F(VolumeSelectTest, testLassoFloodFillConcavePolygon) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 12x12 flat top at y=5
+	fillBox(volume, voxel::Region(glm::ivec3(2, 5, 2), glm::ivec3(13, 5, 13)), solid);
+
+	// L-shape polygon in (Z=U, X=V):
+	//   Z in [2..13], X in [2..7] (wide stroke)
+	//   Z in [8..13], X in [7..13] (narrow stroke) - forms an L
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(2, 5, 2));
+	path.push_back(glm::ivec3(7, 5, 2));
+	path.push_back(glm::ivec3(7, 5, 8));
+	path.push_back(glm::ivec3(13, 5, 8));
+	path.push_back(glm::ivec3(13, 5, 13));
+	path.push_back(glm::ivec3(2, 5, 13));
+
+	int selectedCount = 0;
+	bool insideLCorner = false;	 // voxel at (3, 5, 12) - deep inside wide stroke
+	bool insideLNarrow = false;	 // voxel at (10, 5, 10) - inside narrow stroke
+	bool outsideCorner = false;	 // voxel at (12, 5, 3) - outside the L's notch
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) {
+		++selectedCount;
+		if (x == 3 && y == 5 && z == 12) {
+			insideLCorner = true;
+		}
+		if (x == 10 && y == 5 && z == 10) {
+			insideLNarrow = true;
+		}
+		if (x == 12 && y == 5 && z == 3) {
+			outsideCorner = true;
+		}
+	};
+
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*depthTolerance*/ 2);
+
+	EXPECT_GT(selectedCount, 0);
+	EXPECT_TRUE(insideLCorner) << "flood should reach deep inside the wide stroke";
+	EXPECT_TRUE(insideLNarrow) << "flood should reach the narrow stroke past the bend";
+	EXPECT_FALSE(outsideCorner) << "voxels outside the L notch must not be selected";
+}
+
+// Regression: drawing a thin line (a degenerate out-and-back path enclosing ~zero area)
+// must still select a continuous line of surface voxels along the stroke. Before seeds were
+// marked directly, the point-in-polygon area gate rejected almost every seed for such a
+// sliver polygon, leaving grid-aliased dashes instead of a connected line.
+TEST_F(VolumeSelectTest, testLassoFloodFillThinLine) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat top at y=5
+	fillBox(volume, voxel::Region(glm::ivec3(2, 5, 2), glm::ivec3(13, 5, 13)), solid);
+
+	// Degenerate sliver: trace a diagonal out and immediately back along the same line.
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(2, 5, 2));
+	path.push_back(glm::ivec3(13, 5, 13));
+	path.push_back(glm::ivec3(2, 5, 2));
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*depthTolerance*/ 2);
+
+	// Every voxel along the drawn diagonal must be selected - no aliased gaps.
+	for (int k = 2; k <= 13; ++k) {
+		EXPECT_TRUE(selected.has(glm::ivec3(k, 5, k)))
+			<< "diagonal voxel (" << k << ",5," << k << ") should be part of the thin-line selection";
+	}
+}
+
+// The fill takes the visible (frontmost) surface in every column, so a pit inside the polygon is
+// filled at its floor - that is the surface seen looking down into it.
+TEST_F(VolumeSelectTest, testLassoFillsPitFloor) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Plateau solid up to y=10 over x,z in [2..13]; a central 4x4 pit (x,z in [6..9]) carved out
+	// above y=4, so the pit floor sits 6 voxels below the plateau top.
+	fillBox(volume, voxel::Region(glm::ivec3(2, 0, 2), glm::ivec3(13, 10, 13)), solid);
+	fillBox(volume, voxel::Region(glm::ivec3(6, 5, 6), glm::ivec3(9, 10, 9)), voxel::createVoxel(voxel::VoxelType::Air, 0));
+
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(2, 10, 2));
+	path.push_back(glm::ivec3(13, 10, 2));
+	path.push_back(glm::ivec3(13, 10, 13));
+	path.push_back(glm::ivec3(2, 10, 13));
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*maxDeviation*/ 0);
+	EXPECT_TRUE(selected.has(glm::ivec3(3, 10, 3))) << "plateau surface should be selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(7, 4, 7))) << "pit floor (the visible surface there) should be selected";
+}
+
+// The interior must fill completely even across a riser that a per-step continuity flood would
+// stop at, as long as the surface stays within the deviation of the fitted lasso plane.
+TEST_F(VolumeSelectTest, testLassoFillsAcrossRiser) {
+	voxel::Region region(0, 29);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Surface: flat top y=10 for x in [0..8], a 4-voxel riser up to y=14 for x in [9..20].
+	for (int x = 0; x <= 20; ++x) {
+		const int top = x <= 8 ? 10 : 14;
+		for (int z = 0; z <= 10; ++z) {
+			for (int y = 0; y <= top; ++y) {
+				volume.setVoxel(x, y, z, solid);
+			}
+		}
+	}
+
+	// Rectangle lasso spanning both levels; vertices sit on the surface at each end.
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(4, 10, 3));
+	path.push_back(glm::ivec3(16, 14, 3));
+	path.push_back(glm::ivec3(16, 14, 7));
+	path.push_back(glm::ivec3(4, 10, 7));
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	// PositiveY face: U=Z (2), V=X (0), W=Y (1). depthTolerance=4 covers the riser.
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*maxDeviation*/ 4);
+
+	EXPECT_TRUE(selected.has(glm::ivec3(6, 10, 5))) << "interior on the lower level should be filled";
+	EXPECT_TRUE(selected.has(glm::ivec3(12, 14, 5)))
+		<< "interior on the upper level past the riser should be filled (plane fill, not per-step flood)";
+	EXPECT_FALSE(selected.has(glm::ivec3(12, 5, 5))) << "interior depth voxels below the surface must not be selected";
+}
+
+// lineMarkSolid rasterizes a straight 3D segment and marks solid voxels within the width.
+// Air cells along the line are skipped, and voxels off the line are never marked.
+TEST_F(VolumeSelectTest, testLineMarkSolidSkipsAirAndOffLine) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Solid run along X at y=2,z=2 from x=2..8, with a one-voxel air gap at x=5.
+	for (int x = 2; x <= 8; ++x) {
+		if (x == 5) {
+			continue;
+		}
+		volume.setVoxel(x, 2, 2, solid);
+	}
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	lineMarkSolid(volume, glm::ivec3(2, 2, 2), glm::ivec3(8, 2, 2), /*width*/ 1, region, markFunc);
+
+	for (int x = 2; x <= 8; ++x) {
+		if (x == 5) {
+			EXPECT_FALSE(selected.has(glm::ivec3(5, 2, 2))) << "air gap on the line must not be selected";
+			continue;
+		}
+		EXPECT_TRUE(selected.has(glm::ivec3(x, 2, 2))) << "solid voxel " << x << " on the line should be selected";
+	}
+}
+
+// width controls the Chebyshev thickness around the centerline (width 3 -> radius 1).
+TEST_F(VolumeSelectTest, testLineMarkSolidWidth) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	fillBox(volume, voxel::Region(glm::ivec3(0, 0, 0), glm::ivec3(10, 10, 10)), solid);
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	lineMarkSolid(volume, glm::ivec3(2, 5, 5), glm::ivec3(8, 5, 5), /*width*/ 3, region, markFunc);
+
+	// Centerline plus a one-voxel Chebyshev shell around it (off-axis neighbours).
+	EXPECT_TRUE(selected.has(glm::ivec3(5, 5, 5))) << "centerline voxel selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(5, 6, 5))) << "neighbour within width selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(5, 5, 6))) << "neighbour within width selected";
+	EXPECT_FALSE(selected.has(glm::ivec3(5, 7, 5))) << "voxel two away from centerline not selected at width 3";
+}
+
+// Returns true if every voxel in @p set is reachable from any other via 6-connected (face)
+// steps that stay inside the set - i.e. the selection is a single gap-free connected line.
+static bool isFaceConnected(const core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> &set) {
+	if (set.empty()) {
+		return false;
+	}
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> seen;
+	core::DynamicArray<glm::ivec3> stack;
+	stack.push_back((*set.begin())->key);
+	seen.insert((*set.begin())->key);
+	int reached = 0;
+	while (!stack.empty()) {
+		const glm::ivec3 cur = stack.back();
+		stack.pop();
+		++reached;
+		for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+			const glm::ivec3 nb = cur + offset;
+			if (!set.has(nb) || seen.has(nb)) {
+				continue;
+			}
+			seen.insert(nb);
+			stack.push_back(nb);
+		}
+	}
+	return reached == (int)set.size();
+}
+
+// THE rectangle "disjoint edge" regression: an edge draped down a terraced slope must be ONE
+// face-connected, fully-visible chain - the riser faces between treads must be filled so the line
+// does not render as disconnected tread segments.
+TEST_F(VolumeSelectTest, testLineDrapeSurfaceFillsRisersConnected) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Steep staircase along X: top(x) = 10 - 2*x (drops 2 per column), so each step has a 2-voxel
+	// riser face that a per-column line would skip.
+	for (int x = 0; x <= 5; ++x) {
+		const int top = 10 - 2 * x;
+		for (int z = 3; z <= 7; ++z) {
+			for (int y = 0; y <= top; ++y) {
+				volume.setVoxel(x, y, z, solid);
+			}
+		}
+	}
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	// Drape from the top tread to the bottom: uAxis=X(0), vAxis=Z(2), wAxis=Y(1), positiveNormal.
+	lineDrapeSurface(volume, glm::ivec3(0, 10, 5), glm::ivec3(5, 0, 5), /*uAxis*/ 0, /*vAxis*/ 2, /*wAxis*/ 1,
+					 /*positiveNormal*/ true, /*width*/ 1, region, markFunc);
+
+	EXPECT_TRUE(selected.has(glm::ivec3(0, 10, 5))) << "top tread selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(5, 0, 5))) << "bottom tread selected";
+	// Riser faces between the first two steps must be filled (top(0)=10, top(1)=8 -> riser at y=9).
+	EXPECT_TRUE(selected.has(glm::ivec3(0, 9, 5))) << "riser face between first two steps must be filled";
+	EXPECT_TRUE(isFaceConnected(selected)) << "the draped line must be one gap-free face-connected chain";
+}
+
+// lineDrapeSurface marks the visible (front-most) surface and must NOT jump to a far surface.
+TEST_F(VolumeSelectTest, testLineDrapeSurfaceNoGhost) {
+	voxel::Region region(0, 29);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+	for (int x = 0; x <= 10; ++x) {
+		volume.setVoxel(x, 20, 5, solid);
+		volume.setVoxel(x, 2, 5, solid);
+	}
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	lineDrapeSurface(volume, glm::ivec3(0, 20, 5), glm::ivec3(10, 20, 5), /*uAxis*/ 0, /*vAxis*/ 2, /*wAxis*/ 1,
+					 /*positiveNormal*/ true, /*width*/ 1, region, markFunc);
+
+	for (int x = 0; x <= 10; ++x) {
+		EXPECT_TRUE(selected.has(glm::ivec3(x, 20, 5))) << "near surface selected at x=" << x;
+		EXPECT_FALSE(selected.has(glm::ivec3(x, 2, 5))) << "far surface must NOT be selected (no ghost) at x=" << x;
+	}
+}
+
+// THE floodfill-completeness regression: a vertical wall face that is exposed to the
+// front-connected air (the side of a tall block standing next to a shorter shelf) must be
+// selected. The old per-column "frontmost solid" heightfield grabbed only the single top voxel
+// of each column, so it selected the two flat tops but left the whole vertical wall between them
+// unselected - the gaps the user saw.
+TEST_F(VolumeSelectTest, testLassoFloodFillSelectsExposedWall) {
+	voxel::Region region(0, 19);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Tall block (top y=10) for x in [0..4]; short shelf (top y=5) for x in [5..9]. The +X face
+	// of the tall block (x=4, y in [6..10]) is a vertical wall exposed to the air above the shelf.
+	fillBox(volume, voxel::Region(glm::ivec3(0, 0, 0), glm::ivec3(4, 10, 9)), solid);
+	fillBox(volume, voxel::Region(glm::ivec3(5, 0, 0), glm::ivec3(9, 5, 9)), solid);
+
+	// Top-down lasso (+Y) over the whole footprint: U=Z (2), V=X (0), W=Y (1). Point-in-polygon
+	// uses only (z,x), so the vertices' y just needs to sit on the surface for the edge walk.
+	core::DynamicArray<glm::ivec3> path;
+	path.push_back(glm::ivec3(0, 10, 0));
+	path.push_back(glm::ivec3(9, 5, 0));
+	path.push_back(glm::ivec3(9, 5, 9));
+	path.push_back(glm::ivec3(0, 10, 9));
+
+	core::DynamicSet<glm::ivec3, 1031, glm::hash<glm::ivec3>> selected;
+	auto markFunc = [&](int x, int y, int z, const voxel::Voxel &) { selected.insert(glm::ivec3(x, y, z)); };
+
+	lassoFloodFillSurface(volume, path, /*uAxis*/ 2, /*vAxis*/ 0, /*wAxis*/ 1,
+						  /*positiveNormal*/ true, volume.region(), markFunc, /*maxDeviation*/ 0);
+
+	// The two flat tops (what the heightfield already got).
+	EXPECT_TRUE(selected.has(glm::ivec3(2, 10, 5))) << "tall block top selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(7, 5, 5))) << "short shelf top selected";
+	// The exposed vertical wall (x=4) - what the heightfield missed and the air flood now gets.
+	EXPECT_TRUE(selected.has(glm::ivec3(4, 6, 5))) << "bottom of the exposed wall must be selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(4, 8, 5))) << "middle of the exposed wall must be selected";
+	EXPECT_TRUE(selected.has(glm::ivec3(4, 10, 5))) << "top of the exposed wall must be selected";
+	// Voxels with no front-connected air neighbour stay unselected.
+	EXPECT_FALSE(selected.has(glm::ivec3(2, 5, 5))) << "deep interior of the tall block must NOT be selected";
+	EXPECT_FALSE(selected.has(glm::ivec3(7, 2, 5))) << "interior of the short shelf must NOT be selected";
+}
+
+} // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SelectBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SelectBrushTool.cpp
@@ -25,11 +25,17 @@ static SelectMode parseSelectMode(const core::String &mode) {
 	if (mode == "connected") {
 		return SelectMode::Connected;
 	}
+	if (mode == "rectangle") {
+		return SelectMode::Rectangle;
+	}
+	if (mode == "line") {
+		return SelectMode::Line;
+	}
 	return SelectMode::All;
 }
 
 SelectBrushTool::SelectBrushTool() : BrushTool("voxedit_select_brush") {
-	_tool.set("description", "Select voxels in a region with various modes (All, Surface, SameColor, FuzzyColor, Connected)");
+	_tool.set("description", "Select voxels in a region with various modes (All, Surface, SameColor, FuzzyColor, Connected, Rectangle, Line)");
 
 	json::Json inputSchema = json::Json::object();
 	inputSchema.set("type", "object");
@@ -47,16 +53,57 @@ SelectBrushTool::SelectBrushTool() : BrushTool("voxedit_select_brush") {
 	selectModeProp.set("type", "string");
 	selectModeProp.set("description",
 		"The selection mode: 'all' (all voxels), 'surface' (visible surface only), 'samecolor' (exact color match), "
-		"'fuzzycolor' (similar colors), 'connected' (flood fill same color)");
+		"'fuzzycolor' (similar colors), 'connected' (flood fill same color), 'rectangle' (only the twelve wireframe "
+		"edges of the box), 'line' (solid voxels along the straight 3D line between the region corners)");
 	json::Json _enumArr = json::Json::array();
 	_enumArr.push("all");
 	_enumArr.push("surface");
 	_enumArr.push("samecolor");
 	_enumArr.push("fuzzycolor");
 	_enumArr.push("connected");
+	_enumArr.push("rectangle");
+	_enumArr.push("line");
 	selectModeProp.set("enum", _enumArr);
 	selectModeProp.set("default", "all");
 	properties.set("selectMode", selectModeProp);
+
+	// Edge width for rectangle mode
+	json::Json edgeWidthProp = json::Json::object();
+	edgeWidthProp.set("type", "integer");
+	edgeWidthProp.set("description", "Edge width in voxels for rectangle mode (thickness of the selected box edges)");
+	edgeWidthProp.set("default", 1);
+	edgeWidthProp.set("minimum", 1);
+	edgeWidthProp.set("maximum", 32);
+	properties.set("edgeWidth", edgeWidthProp);
+
+	// Width for line mode
+	json::Json lineWidthProp = json::Json::object();
+	lineWidthProp.set("type", "integer");
+	lineWidthProp.set("description", "Width in voxels for line mode (thickness of the selected line)");
+	lineWidthProp.set("default", 1);
+	lineWidthProp.set("minimum", 1);
+	lineWidthProp.set("maximum", 32);
+	properties.set("lineWidth", lineWidthProp);
+
+	// Path mode for line and rectangle modes
+	json::Json pathModeProp = json::Json::object();
+	pathModeProp.set("type", "string");
+	pathModeProp.set("description", "Path tracking for 'line'/'rectangle' modes: 'followsurface' (snap depth to the "
+									"surface) or 'straight' (plain 3D chord). Default: followsurface for line, straight for rectangle");
+	json::Json _pathEnumArr = json::Json::array();
+	_pathEnumArr.push("followsurface");
+	_pathEnumArr.push("straight");
+	pathModeProp.set("enum", _pathEnumArr);
+	properties.set("pathMode", pathModeProp);
+
+	// In-plane rotation for the 2D rectangle outline
+	json::Json rectAngleProp = json::Json::object();
+	rectAngleProp.set("type", "integer");
+	rectAngleProp.set("description", "In-plane rotation in degrees for the rectangle outline (-180..180)");
+	rectAngleProp.set("default", 0);
+	rectAngleProp.set("minimum", -180);
+	rectAngleProp.set("maximum", 180);
+	properties.set("rectAngle", rectAngleProp);
 
 	// Color threshold for fuzzy color mode
 	json::Json thresholdProp = json::Json::object();
@@ -95,6 +142,10 @@ bool SelectBrushTool::execute(const json::Json &id, const json::Json &args, Tool
 	const core::String selectModeStr = args.strVal("selectMode", "all").c_str();
 	const SelectMode selectMode = parseSelectMode(selectModeStr);
 	const float colorThreshold = args.floatVal("colorThreshold", 0.3f);
+	const int edgeWidth = args.intVal("edgeWidth", 1);
+	const int lineWidth = args.intVal("lineWidth", 1);
+	const core::String pathModeStr = args.strVal("pathMode", "").c_str();
+	const int rectAngle = args.intVal("rectAngle", 0);
 	const bool clearSelection = args.boolVal("clearSelection", false);
 
 	scenegraph::SceneGraphNode *node = ctx.sceneMgr->sceneGraphNodeByUUID(nodeUUID);
@@ -128,11 +179,23 @@ bool SelectBrushTool::execute(const json::Json &id, const json::Json &args, Tool
 	const BrushType prevBrushType = modifier.brushType();
 	const SelectMode prevSelectMode = selectBrush.selectMode();
 	const float prevColorThreshold = selectBrush.fuzzyColor().colorThreshold();
+	const int prevEdgeWidth = selectBrush.rectangle().edgeWidth();
+	const int prevLineWidth = selectBrush.line().width();
+	const select::PathMode prevLinePathMode = selectBrush.line().pathMode();
+	const int prevRectAngle = selectBrush.rectangle().angle();
 
 	// Configure the select brush
 	modifier.setBrushType(BrushType::Select);
 	selectBrush.setSelectMode(selectMode);
 	selectBrush.fuzzyColor().setColorThreshold(colorThreshold);
+	selectBrush.rectangle().setEdgeWidth(edgeWidth);
+	selectBrush.line().setWidth(lineWidth);
+	if (pathModeStr == "followsurface") {
+		selectBrush.line().setPathMode(select::PathMode::FollowSurface);
+	} else if (pathModeStr == "straight") {
+		selectBrush.line().setPathMode(select::PathMode::Straight);
+	}
+	selectBrush.rectangle().setAngle(rectAngle);
 	selectBrush.setBoxMode();
 
 	// Set up the AABB region
@@ -151,6 +214,10 @@ bool SelectBrushTool::execute(const json::Json &id, const json::Json &args, Tool
 	// Restore previous state
 	selectBrush.setSelectMode(prevSelectMode);
 	selectBrush.fuzzyColor().setColorThreshold(prevColorThreshold);
+	selectBrush.rectangle().setEdgeWidth(prevEdgeWidth);
+	selectBrush.line().setWidth(prevLineWidth);
+	selectBrush.line().setPathMode(prevLinePathMode);
+	selectBrush.rectangle().setAngle(prevRectAngle);
 	modifier.setBrushType(prevBrushType);
 
 	const voxel::Region &dirtyRegion = wrapper.dirtyRegion();

--- a/src/tools/voxedit/modules/voxedit-ui/Viewport.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/Viewport.cpp
@@ -1147,6 +1147,32 @@ bool Viewport::runBrushGizmo(const video::Camera &camera, float headerSize) {
 		}
 	}
 
+	if (state.operations & BrushGizmo_WorldPolyline) {
+		if (state.worldPolyline != nullptr && state.worldPolyline->size() >= 2) {
+			const auto &points = *state.worldPolyline;
+			ImVec2 windowPos = ImGui::GetWindowPos();
+			windowPos.y += headerSize;
+			const glm::vec2 scale = dpiScale();
+			ImDrawList *drawList = ImGui::GetWindowDrawList();
+			const ImU32 lineColor = ImGui::GetColorU32(ImVec4(style::color(style::ColorBrushGizmoLine)));
+			const float lineThickness = 2.0f;
+			const int n = (int)points.size();
+			auto toScreen = [&](const glm::vec3 &world) {
+				const glm::ivec2 s = camera.worldToScreen(world);
+				return ImVec2(windowPos.x + (float)s.x / scale.x, windowPos.y + (float)s.y / scale.y);
+			};
+			for (int i = 0; i < n - 1; ++i) {
+				drawList->AddLine(toScreen(points[i]), toScreen(points[i + 1]), lineColor, lineThickness);
+			}
+			if (state.worldPolylineClosed && n >= 3) {
+				drawList->AddLine(toScreen(points[n - 1]), toScreen(points[0]), lineColor, lineThickness);
+			}
+			for (int i = 0; i < n; ++i) {
+				drawList->AddCircleFilled(toScreen(points[i]), 3.0f, lineColor);
+			}
+		}
+	}
+
 	if (state.operations & BrushGizmo_ScreenPolygon) {
 		if (state.screenPolygon != nullptr && state.screenPolygon->size() >= 2) {
 			const auto &points = *state.screenPolygon;

--- a/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSelect.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSelect.cpp
@@ -96,6 +96,100 @@ void BrushPanelSelect::handleSelectBox3D(BrushPanelContext &ctx, int nodeId) {
 	ImGui::Text(_("Size: %d x %d x %d"), size.x, size.y, size.z);
 }
 
+void BrushPanelSelect::handleSelectRectangle(BrushPanelContext &ctx, int nodeId) {
+	select::Rectangle &rect = ctx.sceneMgr->modifier().selectBrush().rectangle();
+	ImGui::SeparatorText(_("Rectangle"));
+	ImGui::TextUnformatted(_("Draw a 2D rectangle outline on the surface"));
+	const float btnW = ImGui::GetFrameHeight();
+	const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+
+	auto adjusterSlider = [&](const char *id, const char *label, const char *tooltip, int value, int lo, int hi,
+							  void (select::Rectangle::*setter)(int)) {
+		ImGui::TextUnformatted(label);
+		ImGui::TooltipTextUnformatted(tooltip);
+		ImGui::PushID(id);
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			(rect.*setter)(value - 1);
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("##slider", &value, lo, hi)) {
+			(rect.*setter)(value);
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			(rect.*setter)(value + 1);
+		}
+		ImGui::PopID();
+	};
+
+	adjusterSlider("rectthickness", _("Thickness"), _("Thickness in voxels of the rectangle outline lines."),
+				   rect.edgeWidth(), 1, 32, &select::Rectangle::setEdgeWidth);
+	adjusterSlider("rectangle", _("Rotation (deg)"),
+				   _("Rotate the rectangle in the surface plane, e.g. for a 45 degree rectangle."), rect.angle(), -180,
+				   180, &select::Rectangle::setAngle);
+	adjusterSlider("rectdeviation", _("Max surface deviation"),
+				   _("How far the surface may deviate from the straight edge and still be followed."),
+				   rect.maxDeviation(), 0, 64, &select::Rectangle::setMaxDeviation);
+}
+
+void BrushPanelSelect::handleSelectLine(BrushPanelContext &ctx, int nodeId) {
+	SelectBrush &brush = ctx.sceneMgr->modifier().selectBrush();
+	ImGui::SeparatorText(_("Line"));
+	int pathMode = (int)brush.line().pathMode();
+	if (ImGui::Combo(_("Path"), &pathMode, select::PathModeStr, (int)select::PathMode::Max)) {
+		brush.line().setPathMode((select::PathMode)pathMode);
+	}
+	ImGui::TooltipTextUnformatted(
+		_("Follow surface snaps the line depth to the surface so the width always reaches it; "
+		  "Straight draws a plain 3D chord between the two clicked points."));
+	static constexpr int MaxLineWidth = 32;
+	int width = brush.line().width();
+	const float btnW = ImGui::GetFrameHeight();
+	const float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+	ImGui::TextUnformatted(_("Width"));
+	ImGui::TooltipTextUnformatted(
+		_("Thickness in voxels of the selected line. Solid voxels within this width of the straight line "
+		  "between the two clicked points are selected."));
+	ImGui::PushID("linewidth");
+	if (ImGui::Button("-", ImVec2(btnW, 0))) {
+		brush.line().setWidth(width - 1);
+	}
+	ImGui::SameLine(0, spacing);
+	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+	if (ImGui::SliderInt("##linewidth", &width, 1, MaxLineWidth)) {
+		brush.line().setWidth(width);
+	}
+	ImGui::SameLine(0, spacing);
+	if (ImGui::Button("+", ImVec2(btnW, 0))) {
+		brush.line().setWidth(width + 1);
+	}
+	ImGui::PopID();
+
+	if (brush.line().pathMode() == select::PathMode::FollowSurface) {
+		static constexpr int MaxLineDeviation = 64;
+		int deviation = brush.line().maxDeviation();
+		ImGui::TextUnformatted(_("Max surface deviation"));
+		ImGui::TooltipTextUnformatted(
+			_("Follow surface: how far the surface may deviate from the straight 3D line and still be followed. "
+			  "Larger values crawl further over steps; too large may snap to a far surface."));
+		ImGui::PushID("linedeviation");
+		if (ImGui::Button("-", ImVec2(btnW, 0))) {
+			brush.line().setMaxDeviation(deviation - 1);
+		}
+		ImGui::SameLine(0, spacing);
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - btnW - spacing);
+		if (ImGui::SliderInt("##linedeviation", &deviation, 0, MaxLineDeviation)) {
+			brush.line().setMaxDeviation(deviation);
+		}
+		ImGui::SameLine(0, spacing);
+		if (ImGui::Button("+", ImVec2(btnW, 0))) {
+			brush.line().setMaxDeviation(deviation + 1);
+		}
+		ImGui::PopID();
+	}
+}
+
 void BrushPanelSelect::handleSelectCircle(BrushPanelContext &ctx, int nodeId) {
 	const scenegraph::SceneGraphNode *node = ctx.sceneMgr->sceneGraphNode(nodeId);
 	if (node == nullptr) {
@@ -247,6 +341,12 @@ void BrushPanelSelect::handleSelectLasso(command::CommandExecutionListener &list
 	ImGui::TextUnformatted(_("Click and drag to draw a selection polygon"));
 }
 
+void BrushPanelSelect::handleSelectPolygonLasso(BrushPanelContext &ctx) {
+	ImGui::SeparatorText(_("Polygon lasso"));
+	ImGui::TextUnformatted(_("Click to drop vertices; click near the first to close"));
+	ImGui::TextUnformatted(_("Fills the visible surface inside the polygon"));
+}
+
 void BrushPanelSelect::update(BrushPanelContext &ctx, command::CommandExecutionListener &listener) {
 	Modifier &modifier = ctx.sceneMgr->modifier();
 	SelectBrush &brush = modifier.selectBrush();
@@ -301,6 +401,10 @@ void BrushPanelSelect::update(BrushPanelContext &ctx, command::CommandExecutionL
 		handleSelectLasso(listener);
 	}
 
+	if (brush.selectMode() == SelectMode::PolygonLasso) {
+		handleSelectPolygonLasso(ctx);
+	}
+
 	if (brush.selectMode() == SelectMode::Paint) {
 		handleSelectPaint(ctx, nodeId);
 	}
@@ -311,6 +415,14 @@ void BrushPanelSelect::update(BrushPanelContext &ctx, command::CommandExecutionL
 
 	if (brush.selectMode() == SelectMode::Box3D) {
 		handleSelectBox3D(ctx, nodeId);
+	}
+
+	if (brush.selectMode() == SelectMode::Rectangle) {
+		handleSelectRectangle(ctx, nodeId);
+	}
+
+	if (brush.selectMode() == SelectMode::Line) {
+		handleSelectLine(ctx, nodeId);
 	}
 
 	if (brush.selectMode() == SelectMode::Script) {

--- a/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSelect.h
+++ b/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSelect.h
@@ -21,11 +21,14 @@ public:
 
 private:
 	void handleSelectBox3D(BrushPanelContext &ctx, int nodeId);
+	void handleSelectRectangle(BrushPanelContext &ctx, int nodeId);
+	void handleSelectLine(BrushPanelContext &ctx, int nodeId);
 	void handleSelectCircle(BrushPanelContext &ctx, int nodeId);
 	void handleSelectPaint(BrushPanelContext &ctx, int nodeId);
 	void handleSelectFuzzyColor(BrushPanelContext &ctx);
 	void handleSelectFlatSurface(BrushPanelContext &ctx);
 	void handleSelectLasso(command::CommandExecutionListener &listener);
+	void handleSelectPolygonLasso(BrushPanelContext &ctx);
 };
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
+++ b/src/tools/voxedit/modules/voxedit-util/CMakeLists.txt
@@ -21,8 +21,11 @@ set(SRCS
 	modifier/brush/select/Connected.cpp modifier/brush/select/Connected.h
 	modifier/brush/select/FlatSurface.cpp modifier/brush/select/FlatSurface.h
 	modifier/brush/select/Box3D.cpp modifier/brush/select/Box3D.h
+	modifier/brush/select/Rectangle.cpp modifier/brush/select/Rectangle.h
+	modifier/brush/select/Line.cpp modifier/brush/select/Line.h
 	modifier/brush/select/Circle.cpp modifier/brush/select/Circle.h
 	modifier/brush/select/Lasso.cpp modifier/brush/select/Lasso.h
+	modifier/brush/select/PolygonLasso.cpp modifier/brush/select/PolygonLasso.h
 	modifier/brush/select/Paint.cpp modifier/brush/select/Paint.h
 	modifier/brush/select/Script.cpp modifier/brush/select/Script.h
 	modifier/brush/ExtrudeBrush.cpp modifier/brush/ExtrudeBrush.h

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.cpp
@@ -79,6 +79,7 @@
 #include "voxelutil/VolumeRescaler.h"
 #include "voxelutil/VolumeResizer.h"
 #include "voxelutil/VolumeRotator.h"
+#include "voxelutil/VolumeSelect.h"
 #include "voxelutil/VolumeSplitter.h"
 #include "voxelutil/VolumeVisitor.h"
 #include "voxelutil/VolumeMerger.h"
@@ -2865,6 +2866,68 @@ void SceneManager::selectionSetEllipse(int nodeId) {
 	}
 
 	modified(nodeId, dirtyRegion, SceneModifiedFlags::NoUndo);
+}
+
+void SceneManager::selectionFinalizeLasso(int nodeId) {
+	scenegraph::SceneGraphNode *node = sceneGraphModelNode(nodeId);
+	if (node == nullptr) {
+		return;
+	}
+	SelectBrush &brush = _modifier.selectBrush();
+	select::PolygonLasso &lasso = brush.polygonLasso();
+	if (!lasso.accumulating() || lasso.path().size() < 3) {
+		return;
+	}
+	// Copy path and axes before invalidating the strategy (invalidate() clears them)
+	const core::DynamicArray<glm::ivec3> path = lasso.path();
+	const int uAxis = lasso.uAxis();
+	const int vAxis = lasso.vAxis();
+	const int wAxis = lasso.faceAxisIdx();
+	const bool positiveNormal = voxel::isPositiveFace(lasso.face());
+	const int depthTolerance = lasso.depthTolerance();
+
+	voxel::RawVolume *volume = node->volume();
+	voxel::Region dirtyRegion = voxel::Region::InvalidRegion;
+
+	// The in-progress polygon is only a viewport overlay (no volume marks), so there is
+	// nothing to revert before applying the selection.
+	lasso.invalidate();
+
+	auto selectFunc = [&](int x, int y, int z, const voxel::Voxel &v) {
+		const glm::ivec3 pos(x, y, z);
+		voxel::Voxel modified = v;
+		modified.setFlags(modified.getFlags() | voxel::FlagOutline);
+		volume->setVoxel(pos, modified);
+		dirtyRegion.accumulate(pos);
+	};
+	// Flood-fill the front surface inside the polygon: seed along the drawn edges, then expand
+	// across (u,v) cells staying on the same surface (depth continuity within the tolerance).
+	// This keeps the selection on the visible skin instead of wrapping down side walls, and
+	// still skips a disjoint structure that merely shares the (u, v) silhouette.
+	voxelutil::lassoFloodFillSurface(*volume, path, uAxis, vAxis, wAxis, positiveNormal,
+									 volume->region(), selectFunc, depthTolerance);
+
+	if (dirtyRegion.isValid()) {
+		modified(nodeId, dirtyRegion, SceneModifiedFlags::All);
+	}
+}
+
+void SceneManager::selectionCancelLasso(int nodeId) {
+	// The in-progress polygon is only a viewport overlay (no volume marks), so cancelling
+	// just discards the accumulated vertices.
+	SelectBrush &brush = _modifier.selectBrush();
+	brush.polygonLasso().invalidate();
+}
+
+void SceneManager::selectionLassoUndoVertex(int nodeId) {
+	SelectBrush &brush = _modifier.selectBrush();
+	select::PolygonLasso &lasso = brush.polygonLasso();
+	if (!lasso.accumulating() || lasso.path().size() < 2) {
+		return;
+	}
+	// Drop the last vertex. The overlay polyline is rebuilt from the path on the next
+	// PolygonLasso::update(), so no volume update is needed here.
+	lasso.popLastPathEntry();
 }
 
 void SceneManager::resetLastTrace() {

--- a/src/tools/voxedit/modules/voxedit-util/SceneManager.h
+++ b/src/tools/voxedit/modules/voxedit-util/SceneManager.h
@@ -472,6 +472,9 @@ public:
 	void selectionSelectAll(int nodeId);
 	void selectionSetBounds(int nodeId, const voxel::Region &region);
 	void selectionSetEllipse(int nodeId);
+	void selectionFinalizeLasso(int nodeId);
+	void selectionCancelLasso(int nodeId);
+	void selectionLassoUndoVertex(int nodeId);
 	bool hasSelection(int nodeId) const;
 	bool isSelected(int nodeId, const glm::ivec3 &pos) const;
 	voxel::Region selectionCalculateRegion(int nodeId) const;

--- a/src/tools/voxedit/modules/voxedit-util/modifier/PreviewManager.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/PreviewManager.cpp
@@ -190,6 +190,13 @@ void PreviewManager::updateBrushVolumePreview(Modifier &modifier, palette::Palet
 		return;
 	}
 
+	// Some brushes preview themselves with a cheap gizmo overlay (e.g. Line/Rectangle select) and
+	// don't want a per-frame preview volume - skip it. resetPreview() above already cleared any
+	// previous preview, and the gizmo is drawn separately by the viewport.
+	if (!brush->wantsVolumePreview()) {
+		return;
+	}
+
 	modifier.preExecuteBrush(activeVolume);
 	const voxel::Region &region = brush->calcRegion(brushContext);
 	if (!region.isValid()) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/AABBBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/AABBBrush.cpp
@@ -53,7 +53,10 @@ void AABBBrush::reset() {
 	Super::reset();
 	_secondPosValid = false;
 	_boxMode = false;
-	_mode = 0u;
+	// Preserve _mode (AABB/Single/Center) - it is a user preference set via UI commands
+	// (e.g., SelectBrush::setSelectMode(Paint) calls setSingleMode()). Resetting it here
+	// causes a mismatch: the derived brush still shows its mode in the UI, but the
+	// underlying AABBBrush reverts to AABB behavior after a brush type round-trip.
 	_aabbFace = voxel::FaceNames::Max;
 	_aabbFirstPos = glm::ivec3(0);
 	_aabbSecondPos = glm::ivec3(0);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/Brush.h
@@ -332,6 +332,15 @@ public:
 	}
 
 	/**
+	 * @brief Whether the brush wants a voxel-volume preview generated each frame.
+	 * Brushes that preview themselves cheaply (e.g. a gizmo overlay) can return false to
+	 * skip the per-frame revert/mark of a preview volume - important for large operations.
+	 */
+	virtual bool wantsVolumePreview() const {
+		return true;
+	}
+
+	/**
 	 * @brief Consume and return a pending undo region accumulated during NoUndo operation.
 	 *
 	 * Called after endBrush() by the modifier button to push a single deferred undo entry

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushGizmo.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/BrushGizmo.h
@@ -9,6 +9,7 @@
 #include "core/collection/DynamicArray.h"
 #include <glm/mat4x4.hpp>
 #include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
 
 namespace voxedit {
 
@@ -31,6 +32,8 @@ enum BrushGizmoOperation : uint32_t {
 	BrushGizmo_Line = (1u << 8),
 	/** Screen-space polygon overlay (e.g. lasso selection) - does not use ImGuizmo */
 	BrushGizmo_ScreenPolygon = (1u << 9),
+	/** World-space polyline overlay of arbitrary length (e.g. polygon lasso edges) - does not use ImGuizmo */
+	BrushGizmo_WorldPolyline = (1u << 10),
 };
 
 /**
@@ -67,6 +70,11 @@ struct BrushGizmoState {
 
 	/** Screen-space polygon points for BrushGizmo_ScreenPolygon (e.g. lasso) */
 	const core::DynamicArray<glm::vec2> *screenPolygon = nullptr;
+
+	/** World-space points for BrushGizmo_WorldPolyline - drawn as a polyline with a dot at each vertex */
+	const core::DynamicArray<glm::vec3> *worldPolyline = nullptr;
+	/** When true, draw a closing segment from the last point back to the first (polygon ready to close) */
+	bool worldPolylineClosed = false;
 };
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.cpp
@@ -3,12 +3,15 @@
  */
 
 #include "SelectBrush.h"
+#include "voxedit-util/SceneManager.h"
+#include "scenegraph/SceneGraph.h"
 
 namespace voxedit {
 
 SelectBrush::SelectBrush(SceneManager *sceneManager)
 	: Super(BrushType::Select, ModifierType::Override, ModifierType::Override | ModifierType::Erase),
-	  _sceneManager(sceneManager), _lassoStrategy(sceneManager), _scriptStrategy(sceneManager) {
+	  _sceneManager(sceneManager), _lassoStrategy(sceneManager), _polygonLassoStrategy(sceneManager),
+	  _rectangleStrategy(sceneManager), _lineStrategy(sceneManager), _scriptStrategy(sceneManager) {
 	setClampToVolume(true);
 	_strategies[(int)SelectMode::All] = &_selectAll;
 	_strategies[(int)SelectMode::Surface] = &_selectSurface;
@@ -17,8 +20,11 @@ SelectBrush::SelectBrush(SceneManager *sceneManager)
 	_strategies[(int)SelectMode::Connected] = &_selectConnected;
 	_strategies[(int)SelectMode::FlatSurface] = &_flatSurfaceStrategy;
 	_strategies[(int)SelectMode::Box3D] = &_box3DStrategy;
+	_strategies[(int)SelectMode::Rectangle] = &_rectangleStrategy;
+	_strategies[(int)SelectMode::Line] = &_lineStrategy;
 	_strategies[(int)SelectMode::Circle] = &_circleStrategy;
 	_strategies[(int)SelectMode::Lasso] = &_lassoStrategy;
+	_strategies[(int)SelectMode::PolygonLasso] = &_polygonLassoStrategy;
 	_strategies[(int)SelectMode::Paint] = &_paintStrategy;
 	_strategies[(int)SelectMode::Script] = &_scriptStrategy;
 }
@@ -66,6 +72,19 @@ bool SelectBrush::hasPendingChanges() const {
 	return Super::hasPendingChanges();
 }
 
+voxel::Region SelectBrush::revertChanges(voxel::RawVolume *volume) {
+	return Super::revertChanges(volume);
+}
+
+bool SelectBrush::onDeactivated() {
+	// Discard a mid-accumulation PolygonLasso when switching away. The polygon is only a
+	// viewport overlay (no volume marks), so this just clears the in-progress vertex list.
+	if (_selectMode == SelectMode::PolygonLasso && _polygonLassoStrategy.accumulating() && _sceneManager != nullptr) {
+		_sceneManager->selectionCancelLasso(_sceneManager->sceneGraph().activeNode());
+	}
+	return Super::onDeactivated();
+}
+
 void SelectBrush::endBrush(BrushContext &ctx) {
 	activeStrategy()->endBrush(ctx);
 	_sceneModifiedFlags = activeStrategy()->_modifiedFlags;
@@ -82,6 +101,30 @@ voxel::Region SelectBrush::consumePendingUndoRegion() {
 void SelectBrush::update(const BrushContext &ctx, double nowSeconds) {
 	Super::update(ctx, nowSeconds);
 	activeStrategy()->update(ctx, nowSeconds);
+	// The polygon-lasso rubber band is now a viewport overlay (BrushGizmo_WorldPolyline)
+	// rebuilt in PolygonLasso::update(), so no per-frame volume flush is needed here.
+
+	// Feed the line gizmo its live endpoints while dragging. This is the preview for the Line
+	// mode (a cheap world-space line) instead of a preview volume that would vanish past the
+	// preview-size cap for long lines.
+	if (_selectMode == SelectMode::Line) {
+		if (Super::active()) {
+			const select::AABBBrushState state = buildState(ctx);
+			_lineStrategy.setPreview(state.aabbFirstPos, state.cursorPosition);
+		} else {
+			_lineStrategy.clearPreview();
+		}
+	}
+
+	// Rectangle previews its outline as a world-space polyline gizmo (no preview-size cap).
+	if (_selectMode == SelectMode::Rectangle) {
+		if (Super::active()) {
+			const select::AABBBrushState state = buildState(ctx);
+			_rectangleStrategy.setPreview(Super::calcRegion(ctx), state.aabbFace);
+		} else {
+			_rectangleStrategy.clearPreview();
+		}
+	}
 }
 
 void SelectBrush::setSelectMode(SelectMode mode) {
@@ -89,6 +132,13 @@ void SelectBrush::setSelectMode(SelectMode mode) {
 		if (_selectMode == SelectMode::Paint) {
 			setBoxMode();
 			_sceneModifiedFlags = SceneModifiedFlags::All;
+		}
+		// Revert any in-progress polygon-lasso edge/rubber-band marks on the real
+		// volume before switching modes. Without this, FlagOutline on those voxels
+		// stays as an orphaned selection after the mode change.
+		if (_selectMode == SelectMode::PolygonLasso && _polygonLassoStrategy.accumulating() &&
+			_sceneManager != nullptr) {
+			_sceneManager->selectionCancelLasso(_sceneManager->sceneGraph().activeNode());
 		}
 		activeStrategy()->reset();
 		_circleStrategy.reset();

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SelectBrush.h
@@ -14,7 +14,10 @@
 #include "select/FlatSurface.h"
 #include "select/FuzzyColor.h"
 #include "select/Lasso.h"
+#include "select/Line.h"
 #include "select/Paint.h"
+#include "select/PolygonLasso.h"
+#include "select/Rectangle.h"
 #include "select/SameColor.h"
 #include "select/Script.h"
 #include "select/Surface.h"
@@ -50,10 +53,16 @@ enum class SelectMode : uint8_t {
 	FlatSurface,
 	/** Replace the current selection with all solid voxels in the drawn 3D box region */
 	Box3D,
+	/** Select only the twelve wireframe edges of the drawn 3D box with a configurable edge width */
+	Rectangle,
+	/** Select the solid voxels along a straight 3D line between the two drag endpoints with a configurable width */
+	Line,
 	/** Select surface voxels within a circular radius from the clicked center point */
 	Circle,
-	/** Free-form polygon selection: click vertices to build a polygon, close it to select enclosed surface voxels */
+	/** Screen-space drag-fill lasso: hold and drag to define a free-form polygon, fills on release */
 	Lasso,
+	/** Voxel-space click-vertex polygon lasso: click vertices, close near start, surface flood-fill */
+	PolygonLasso,
 	/** Continuous paint-style selection: hold mouse and drag to select solid voxels within brush radius.
 	 *  Uses single mode for continuous execution. Single undo entry on release. */
 	Paint,
@@ -66,9 +75,9 @@ enum class SelectMode : uint8_t {
 static constexpr const char *SelectModeStr[] = {
 	NC_("SelectMode", "All"),          NC_("SelectMode", "Surface"),      NC_("SelectMode", "Same Color"),
 	NC_("SelectMode", "Fuzzy Color"),  NC_("SelectMode", "Connected"),    NC_("SelectMode", "Flat Surface"),
-	NC_("SelectMode", "3D Box"),       NC_("SelectMode", "Circle"),
-	NC_("SelectMode", "Lasso"),        NC_("SelectMode", "Brush select"),
-	NC_("SelectMode", "Script")};
+	NC_("SelectMode", "3D Box"),       NC_("SelectMode", "2D Rectangle"), NC_("SelectMode", "Line"),
+	NC_("SelectMode", "Circle"),       NC_("SelectMode", "Lasso"),        NC_("SelectMode", "Polygon Lasso"),
+	NC_("SelectMode", "Brush select"), NC_("SelectMode", "Script")};
 static_assert(lengthof(SelectModeStr) == (int)SelectMode::Max, "SelectModeStr size mismatch");
 
 static constexpr const char *SelectModeIcons[] = {
@@ -79,8 +88,11 @@ static constexpr const char *SelectModeIcons[] = {
 	ICON_LC_WAYPOINTS,           // Connected
 	ICON_LC_LAND_PLOT,           // FlatSurface
 	ICON_LC_BOX,                 // Box3D
+	ICON_LC_FRAME,               // Rectangle
+	ICON_LC_PEN_LINE,            // Line
 	ICON_LC_CIRCLE,              // Circle
 	ICON_LC_LASSO,               // Lasso
+	ICON_LC_PEN_TOOL,            // PolygonLasso
 	ICON_LC_PAINTBRUSH,          // Paint
 	ICON_LC_CODE,                // Script
 };
@@ -99,8 +111,11 @@ private:
 
 	select::Circle _circleStrategy;
 	select::Lasso _lassoStrategy;
+	select::PolygonLasso _polygonLassoStrategy;
 	select::Paint _paintStrategy;
 	select::Box3D _box3DStrategy;
+	select::Rectangle _rectangleStrategy;
+	select::Line _lineStrategy;
 	select::FuzzyColor _fuzzyColorStrategy;
 	select::FlatSurface _flatSurfaceStrategy;
 	select::Script _scriptStrategy;
@@ -123,6 +138,7 @@ public:
 	virtual ~SelectBrush() = default;
 
 	bool isSimplePreview() const override;
+	bool wantsVolumePreview() const override;
 
 	voxel::Region calcRegion(const BrushContext &ctx) const override;
 	bool managesOwnSelection() const override;
@@ -143,7 +159,9 @@ public:
 	void endBrush(BrushContext &ctx) override;
 
 	bool hasPendingChanges() const override;
+	voxel::Region revertChanges(voxel::RawVolume *volume) override;
 	voxel::Region consumePendingUndoRegion() override;
+	bool onDeactivated() override;
 
 	void abort(BrushContext &ctx) override;
 
@@ -156,10 +174,16 @@ public:
 	const select::Circle &circle() const;
 	select::Lasso &lasso();
 	const select::Lasso &lasso() const;
+	select::PolygonLasso &polygonLasso();
+	const select::PolygonLasso &polygonLasso() const;
 	select::Paint &paint();
 	const select::Paint &paint() const;
 	select::Box3D &box3D();
 	const select::Box3D &box3D() const;
+	select::Rectangle &rectangle();
+	const select::Rectangle &rectangle() const;
+	select::Line &line();
+	const select::Line &line() const;
 	select::FuzzyColor &fuzzyColor();
 	const select::FuzzyColor &fuzzyColor() const;
 	select::FlatSurface &flatSurface();
@@ -170,6 +194,12 @@ public:
 
 inline bool SelectBrush::managesOwnSelection() const {
 	return true;
+}
+
+inline bool SelectBrush::wantsVolumePreview() const {
+	// Line and Rectangle preview themselves with a gizmo outline; skip the per-frame preview
+	// volume so large drags do not lag from reverting/marking voxels every frame.
+	return _selectMode != SelectMode::Line && _selectMode != SelectMode::Rectangle;
 }
 
 inline SelectMode SelectBrush::selectMode() const {
@@ -204,6 +234,14 @@ inline const select::Lasso &SelectBrush::lasso() const {
 	return _lassoStrategy;
 }
 
+inline select::PolygonLasso &SelectBrush::polygonLasso() {
+	return _polygonLassoStrategy;
+}
+
+inline const select::PolygonLasso &SelectBrush::polygonLasso() const {
+	return _polygonLassoStrategy;
+}
+
 inline select::Paint &SelectBrush::paint() {
 	return _paintStrategy;
 }
@@ -218,6 +256,22 @@ inline select::Box3D &SelectBrush::box3D() {
 
 inline const select::Box3D &SelectBrush::box3D() const {
 	return _box3DStrategy;
+}
+
+inline select::Rectangle &SelectBrush::rectangle() {
+	return _rectangleStrategy;
+}
+
+inline const select::Rectangle &SelectBrush::rectangle() const {
+	return _rectangleStrategy;
+}
+
+inline select::Line &SelectBrush::line() {
+	return _lineStrategy;
+}
+
+inline const select::Line &SelectBrush::line() const {
+	return _lineStrategy;
 }
 
 inline select::FuzzyColor &SelectBrush::fuzzyColor() {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Line.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Line.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file
+ */
+
+#include "Line.h"
+#include "Circle.h"
+#include "math/Axis.h"
+#include "voxedit-util/SceneManager.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxedit-util/modifier/brush/Brush.h"
+#include "voxedit-util/modifier/brush/BrushGizmo.h"
+#include "voxel/Face.h"
+#include "voxelutil/VolumeSelect.h"
+#include <glm/mat4x4.hpp>
+#include <glm/vec4.hpp>
+
+namespace voxedit {
+namespace select {
+
+void Line::reset() {
+	Super::reset();
+	_previewActive = false;
+}
+
+void Line::abort(BrushContext &ctx) {
+	Super::abort(ctx);
+	_previewActive = false;
+}
+
+void Line::endBrush(BrushContext &ctx) {
+	Super::endBrush(ctx);
+	_previewActive = false;
+}
+
+bool Line::wantBrushGizmo(const BrushContext &ctx) const {
+	return _previewActive;
+}
+
+void Line::brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const {
+	const glm::mat4 model = _sceneManager != nullptr ? _sceneManager->worldMatrix() : glm::mat4(1.0f);
+	auto toWorld = [&model](const glm::ivec3 &local) {
+		// Center on the voxel so the line runs through voxel centers.
+		return glm::vec3(model * glm::vec4(glm::vec3(local) + 0.5f, 1.0f));
+	};
+	state.operations = BrushGizmo_Line;
+	state.positions[0] = toWorld(_previewStart);
+	state.positions[1] = toWorld(_previewEnd);
+	state.numPositions = 2;
+}
+
+void Line::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+					const voxel::Region &region, const AABBBrushState &state) {
+	auto func = [&wrapper](int x, int y, int z, const voxel::Voxel &) {
+		if (wrapper.modifierType() == ModifierType::Erase) {
+			wrapper.removeFlagAt(x, y, z, voxel::FlagOutline);
+		} else {
+			wrapper.setFlagAt(x, y, z, voxel::FlagOutline);
+		}
+	};
+	// The two drag endpoints define the segment.
+	if (_pathMode == PathMode::FollowSurface && state.aabbFace != voxel::FaceNames::Max) {
+		int uAxis;
+		int vAxis;
+		Circle::ellipseAxes(state.aabbFace, uAxis, vAxis);
+		const int wAxis = math::getIndexForAxis(voxel::faceToAxis(state.aabbFace));
+		const bool positiveNormal = voxel::isPositiveFace(state.aabbFace);
+		// Drape the line over the visible surface between the endpoints, filling the riser faces,
+		// so it stays continuous AND visible across terraces (no per-column gaps, no hidden risers).
+		voxelutil::lineDrapeSurface(wrapper, state.aabbFirstPos, state.cursorPosition, uAxis, vAxis, wAxis,
+									positiveNormal, _width, ctx.targetVolumeRegion, func);
+	} else {
+		voxelutil::lineMarkSolid(wrapper, state.aabbFirstPos, state.cursorPosition, _width, ctx.targetVolumeRegion, func);
+	}
+}
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Line.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Line.h
@@ -1,0 +1,102 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "SelectStrategy.h"
+#include "voxel/Region.h"
+#include <glm/common.hpp>
+#include <glm/vec3.hpp>
+
+namespace voxedit {
+
+class SceneManager;
+
+namespace select {
+
+/**
+ * @brief Selects the solid voxels along a line between the two drag endpoints.
+ *
+ * In PathMode::FollowSurface (default) the line is draped over the visible surface between the
+ * endpoints (voxelutil::lineDrapeSurface): it marks the front-most surface at each step and fills
+ * the riser faces of terrace steps, so it stays continuous AND visible across stepped/sloped
+ * geometry. In PathMode::Straight it is a plain 3D chord that only selects the solid voxels it
+ * passes through (voxelutil::lineMarkSolid). @c _width controls the thickness in both modes.
+ *
+ * While dragging, the line is previewed as a cheap world-space gizmo line (BrushGizmo_Line)
+ * rather than a preview volume, so the preview never hits the preview-size cap and does not
+ * vanish for long lines.
+ * @ingroup Brushes
+ */
+class Line : public Strategy {
+private:
+	using Super = Strategy;
+	SceneManager *_sceneManager;
+	int _width = 1;
+	/** FollowSurface: how far the surface may deviate from the straight 3D line and still be followed. */
+	int _maxDeviation = 8;
+	PathMode _pathMode = PathMode::FollowSurface;
+	/** Live drag endpoints (node-local voxel coords) for the gizmo line preview. */
+	glm::ivec3 _previewStart{0};
+	glm::ivec3 _previewEnd{0};
+	bool _previewActive = false;
+
+public:
+	explicit Line(SceneManager *sceneManager) : _sceneManager(sceneManager) {
+	}
+
+	voxel::Region calcRegion(const BrushContext &ctx, const AABBBrushState &state) const override {
+		return voxel::Region::InvalidRegion;
+	}
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region, const AABBBrushState &state) override;
+	/** @brief A line is fully defined by the two drag endpoints, so no third placement click is needed. */
+	bool needsAdditionalAction(const BrushContext &ctx) const override {
+		return false;
+	}
+
+	void reset() override;
+	void abort(BrushContext &ctx) override;
+	void endBrush(BrushContext &ctx) override;
+
+	bool wantBrushGizmo(const BrushContext &ctx) const override;
+	void brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const override;
+
+	/** Update the live gizmo-line endpoints during the drag. */
+	void setPreview(const glm::ivec3 &start, const glm::ivec3 &end) {
+		_previewStart = start;
+		_previewEnd = end;
+		_previewActive = true;
+	}
+	void clearPreview() {
+		_previewActive = false;
+	}
+
+	int width() const {
+		return _width;
+	}
+
+	void setWidth(int width) {
+		_width = glm::clamp(width, 1, 32);
+	}
+
+	int maxDeviation() const {
+		return _maxDeviation;
+	}
+
+	void setMaxDeviation(int deviation) {
+		_maxDeviation = glm::clamp(deviation, 0, 64);
+	}
+
+	PathMode pathMode() const {
+		return _pathMode;
+	}
+
+	void setPathMode(PathMode mode) {
+		_pathMode = mode;
+	}
+};
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/PolygonLasso.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/PolygonLasso.cpp
@@ -1,0 +1,205 @@
+/**
+ * @file
+ */
+
+#include "PolygonLasso.h"
+#include "Circle.h"
+#include "math/Axis.h"
+#include "voxedit-util/SceneManager.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxedit-util/modifier/brush/Brush.h"
+#include "voxedit-util/modifier/brush/BrushGizmo.h"
+#include "voxel/RawVolume.h"
+#include "voxelutil/VolumeSelect.h"
+#include <glm/common.hpp>
+#include <glm/mat4x4.hpp>
+#include <glm/vec4.hpp>
+
+namespace voxedit {
+namespace select {
+
+glm::ivec3 PolygonLasso::snapToGrid(const glm::ivec3 &pos, int resolution) {
+	if (resolution <= 1) {
+		return pos;
+	}
+	glm::ivec3 out = pos;
+	if (out.x % resolution != 0) {
+		out.x = (out.x / resolution) * resolution;
+	}
+	if (out.y % resolution != 0) {
+		out.y = (out.y / resolution) * resolution;
+	}
+	if (out.z % resolution != 0) {
+		out.z = (out.z / resolution) * resolution;
+	}
+	return out;
+}
+
+void PolygonLasso::ellipseAxes(voxel::FaceNames face, int &uAxis, int &vAxis) {
+	Circle::ellipseAxes(face, uAxis, vAxis);
+}
+
+void PolygonLasso::reset() {
+	_path.clear();
+	_overlayPoints.clear();
+	_overlayClosable = false;
+	_accumulating = false;
+	_face = voxel::FaceNames::Max;
+	_lastCursorPos = glm::ivec3(InvalidCursorCoord);
+	_modifiedFlags = SceneModifiedFlags::All;
+}
+
+void PolygonLasso::abort(BrushContext &ctx) {
+	if (_accumulating) {
+		_path.clear();
+		_overlayPoints.clear();
+		_overlayClosable = false;
+		_accumulating = false;
+		_modifiedFlags = SceneModifiedFlags::All;
+	}
+}
+
+void PolygonLasso::invalidate() {
+	_accumulating = false;
+	_path.clear();
+	_overlayPoints.clear();
+	_overlayClosable = false;
+}
+
+void PolygonLasso::popLastPathEntry() {
+	if (!_path.empty()) {
+		_path.pop();
+	}
+}
+
+void PolygonLasso::buildOverlayPoints(const BrushContext &ctx) {
+	_overlayPoints.clear();
+	_overlayClosable = false;
+	if (_path.empty()) {
+		return;
+	}
+	const glm::mat4 model = _sceneManager != nullptr ? _sceneManager->worldMatrix() : glm::mat4(1.0f);
+	auto toWorld = [&model](const glm::ivec3 &local) {
+		// Center on the voxel so the overlay line runs through voxel centers.
+		return glm::vec3(model * glm::vec4(glm::vec3(local) + 0.5f, 1.0f));
+	};
+	_overlayPoints.reserve(_path.size() + 1);
+	for (const glm::ivec3 &vertex : _path) {
+		_overlayPoints.push_back(toWorld(vertex));
+	}
+	// Append the live cursor as the rubber-band endpoint.
+	const glm::ivec3 cursor = snapToGrid(ctx.cursorPosition, ctx.gridResolution);
+	_overlayPoints.push_back(toWorld(cursor));
+	if (_path.size() >= 3) {
+		const glm::ivec3 &firstPt = _path[0];
+		const int du = glm::abs(cursor[_uAxis] - firstPt[_uAxis]);
+		const int dv = glm::abs(cursor[_vAxis] - firstPt[_vAxis]);
+		_overlayClosable = du <= CloseThresholdVoxels && dv <= CloseThresholdVoxels;
+	}
+}
+
+void PolygonLasso::update(const BrushContext &ctx, double nowSeconds) {
+	if (!_accumulating) {
+		return;
+	}
+	_lastCursorPos = ctx.cursorPosition;
+	buildOverlayPoints(ctx);
+}
+
+bool PolygonLasso::wantBrushGizmo(const BrushContext &ctx) const {
+	return _accumulating && !_overlayPoints.empty();
+}
+
+void PolygonLasso::brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const {
+	state.operations = BrushGizmo_WorldPolyline;
+	state.worldPolyline = &_overlayPoints;
+	state.worldPolylineClosed = _overlayClosable;
+}
+
+bool PolygonLasso::beginBrush(const BrushContext &ctx, const AABBBrushState &state) {
+	if (_accumulating) {
+		const glm::ivec3 cursor = snapToGrid(ctx.cursorPosition, ctx.gridResolution);
+		// Close the polygon when clicking near the first vertex
+		if (_path.size() >= 3) {
+			const glm::ivec3 &firstPt = _path[0];
+			const int du = glm::abs(cursor[_uAxis] - firstPt[_uAxis]);
+			const int dv = glm::abs(cursor[_vAxis] - firstPt[_vAxis]);
+			if (du <= CloseThresholdVoxels && dv <= CloseThresholdVoxels) {
+				_accumulating = false;
+				_overlayPoints.clear();
+				_overlayClosable = false;
+				_modifiedFlags = SceneModifiedFlags::All;
+				return true;
+			}
+		}
+		// Add the next vertex to the polygon
+		_path.push_back(cursor);
+		buildOverlayPoints(ctx);
+		_modifiedFlags = SceneModifiedFlags::NoUndo;
+		return true;
+	}
+	// Start a new lasso polygon
+	_path.clear();
+	_overlayPoints.clear();
+	_overlayClosable = false;
+	_path.reserve(PathInitialReserve);
+	_path.push_back(snapToGrid(ctx.cursorPosition, ctx.gridResolution));
+	_face = ctx.cursorFace;
+	ellipseAxes(_face, _uAxis, _vAxis);
+	_faceAxisIdx = math::getIndexForAxis(voxel::faceToAxis(_face));
+	_accumulating = true;
+	buildOverlayPoints(ctx);
+	_modifiedFlags = SceneModifiedFlags::NoUndo;
+	return true;
+}
+
+voxel::Region PolygonLasso::calcRegion(const BrushContext &ctx, const AABBBrushState &state) const {
+	// During accumulation nothing is written to the volume - the polygon is shown as a
+	// viewport overlay. Returning an invalid region keeps the PreviewManager from
+	// allocating a preview copy every frame.
+	if (_accumulating) {
+		return voxel::Region::InvalidRegion;
+	}
+	return ctx.targetVolumeRegion;
+}
+
+void PolygonLasso::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+							const voxel::Region &region, const AABBBrushState &state) {
+	if (_face == voxel::FaceNames::Max || _path.empty()) {
+		return;
+	}
+	// While accumulating, the in-progress polygon is drawn as a world-space overlay
+	// (see wantBrushGizmo/brushGizmoState). Nothing is written to the volume until the
+	// polygon is closed, so this is a no-op every frame/click during accumulation.
+	if (_accumulating) {
+		_modifiedFlags = SceneModifiedFlags::NoUndo;
+		return;
+	}
+
+	// Polygon closed: apply selection to surface voxels inside the polygon.
+	_modifiedFlags = SceneModifiedFlags::All;
+	if (_path.size() < 3) {
+		return;
+	}
+	const int uAxis = _uAxis;
+	const int vAxis = _vAxis;
+	const int wAxis = _faceAxisIdx;
+	const bool positiveNormal = voxel::isPositiveFace(_face);
+	auto func = [&wrapper](int x, int y, int z, const voxel::Voxel &voxel) {
+		if (wrapper.modifierType() == ModifierType::Erase) {
+			wrapper.removeFlagAt(x, y, z, voxel::FlagOutline);
+		} else {
+			wrapper.setFlagAt(x, y, z, voxel::FlagOutline);
+		}
+	};
+	// Flood-fill the front surface inside the polygon: seed along the drawn edges, then expand
+	// across (u,v) cells staying on the same surface (depth continuity within _depthTolerance).
+	// This keeps the selection on the visible skin instead of wrapping down side walls, and
+	// still skips disjoint structures that merely share the (u, v) silhouette.
+	voxelutil::lassoFloodFillSurface(wrapper, _path, uAxis, vAxis, wAxis, positiveNormal, ctx.targetVolumeRegion, func,
+									 _depthTolerance);
+	_path.clear();
+}
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/PolygonLasso.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/PolygonLasso.h
@@ -1,0 +1,118 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "SelectStrategy.h"
+#include "core/GLM.h"
+#include "core/collection/DynamicArray.h"
+#include "voxel/Face.h"
+#include <glm/vec3.hpp>
+
+namespace voxel {
+class RawVolume;
+} // namespace voxel
+
+namespace voxedit {
+
+class SceneManager;
+
+namespace select {
+
+/**
+ * @brief Click-vertex polygonal lasso with surface flood-fill on close.
+ *
+ * Distinct from the screen-space drag-fill Lasso strategy. The user clicks individual
+ * voxels to drop polygon vertices; the in-progress polygon is shown as a lightweight
+ * world-space overlay polyline (BrushGizmo_WorldPolyline) rather than by writing marks
+ * onto the volume - so accumulation stays cheap on large models. On close (click near
+ * the first vertex) surface voxels are flood-filled from edge seeds inside the polygon,
+ * avoiding disjoint structures that share the (u, v) silhouette.
+ */
+class PolygonLasso : public Strategy {
+public:
+	/** Max U/V distance from the first vertex that auto-closes the polygon on click */
+	static constexpr int CloseThresholdVoxels = 1;
+	/** Initial capacity reserved for the polygon vertex list */
+	static constexpr int PathInitialReserve = 32;
+	/** Sentinel value for the last-cursor-pos check to force a refresh on first update() */
+	static constexpr int InvalidCursorCoord = -100000;
+
+private:
+	using Super = Strategy;
+	SceneManager *_sceneManager;
+	/** Polygon vertices accumulated across clicks */
+	core::DynamicArray<glm::ivec3> _path;
+	/** World-space points for the viewport overlay polyline: all vertices plus the live cursor */
+	core::DynamicArray<glm::vec3> _overlayPoints;
+	/** True when the cursor is near the first vertex so a click would close the polygon */
+	bool _overlayClosable = false;
+	bool _accumulating = false;
+	int _uAxis = 0;
+	int _vAxis = 1;
+	int _faceAxisIdx = 2;
+	/** Max depth the surface may deviate from the fitted lasso plane and still be filled */
+	int _depthTolerance = 4;
+	voxel::FaceNames _face = voxel::FaceNames::Max;
+	glm::ivec3 _lastCursorPos{InvalidCursorCoord};
+
+	static glm::ivec3 snapToGrid(const glm::ivec3 &pos, int resolution);
+	static void ellipseAxes(voxel::FaceNames face, int &uAxis, int &vAxis);
+	/** Rebuild the world-space overlay polyline from the current path plus the live cursor */
+	void buildOverlayPoints(const BrushContext &ctx);
+
+public:
+	explicit PolygonLasso(SceneManager *sceneManager) : _sceneManager(sceneManager) {
+	}
+
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region, const AABBBrushState &state) override;
+	voxel::Region calcRegion(const BrushContext &ctx, const AABBBrushState &state) const override;
+	bool beginBrush(const BrushContext &ctx, const AABBBrushState &state) override;
+	void abort(BrushContext &ctx) override;
+	void reset() override;
+	void update(const BrushContext &ctx, double nowSeconds) override;
+	bool active() const override {
+		return _accumulating;
+	}
+	bool needsAdditionalAction(const BrushContext &ctx) const override {
+		return false;
+	}
+
+	bool wantBrushGizmo(const BrushContext &ctx) const override;
+	void brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const override;
+
+	bool accumulating() const {
+		return _accumulating;
+	}
+	const core::DynamicArray<glm::ivec3> &path() const {
+		return _path;
+	}
+	int uAxis() const {
+		return _uAxis;
+	}
+	int vAxis() const {
+		return _vAxis;
+	}
+	int faceAxisIdx() const {
+		return _faceAxisIdx;
+	}
+	voxel::FaceNames face() const {
+		return _face;
+	}
+	int depthTolerance() const {
+		return _depthTolerance;
+	}
+	void setDepthTolerance(int tolerance) {
+		_depthTolerance = glm::clamp(tolerance, 0, 32);
+	}
+
+	/** Discard the in-progress polygon */
+	void invalidate();
+	/** Remove the last placed polygon vertex */
+	void popLastPathEntry();
+};
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Rectangle.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Rectangle.cpp
@@ -1,0 +1,140 @@
+/**
+ * @file
+ */
+
+#include "Rectangle.h"
+#include "Circle.h"
+#include "math/Axis.h"
+#include "voxedit-util/SceneManager.h"
+#include "voxedit-util/modifier/ModifierVolumeWrapper.h"
+#include "voxedit-util/modifier/brush/Brush.h"
+#include "voxedit-util/modifier/brush/BrushGizmo.h"
+#include "voxel/Face.h"
+#include "voxelutil/VolumeSelect.h"
+#include <glm/mat4x4.hpp>
+#include <glm/trigonometric.hpp>
+#include <glm/vec4.hpp>
+
+namespace voxedit {
+namespace select {
+
+void Rectangle::computeCorners(const voxel::Region &region, voxel::FaceNames face, glm::ivec3 corners[4]) const {
+	int uAxis;
+	int vAxis;
+	Circle::ellipseAxes(face, uAxis, vAxis);
+	const int wAxis = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveNormal = voxel::isPositiveFace(face);
+	const glm::ivec3 mins = region.getLowerCorner();
+	const glm::ivec3 maxs = region.getUpperCorner();
+	const float cu = (float)(mins[uAxis] + maxs[uAxis]) * 0.5f;
+	const float cv = (float)(mins[vAxis] + maxs[vAxis]) * 0.5f;
+	const float hu = (float)(maxs[uAxis] - mins[uAxis]) * 0.5f;
+	const float hv = (float)(maxs[vAxis] - mins[vAxis]) * 0.5f;
+	// Anchor the outline at the clicked (near) face depth.
+	const int w0 = positiveNormal ? maxs[wAxis] : mins[wAxis];
+	const float rad = glm::radians((float)_angle);
+	const float cs = glm::cos(rad);
+	const float sn = glm::sin(rad);
+	const float local[4][2] = {{hu, hv}, {-hu, hv}, {-hu, -hv}, {hu, -hv}};
+	for (int i = 0; i < 4; ++i) {
+		const float lu = local[i][0];
+		const float lv = local[i][1];
+		glm::ivec3 p(0);
+		p[uAxis] = (int)glm::round(cu + lu * cs - lv * sn);
+		p[vAxis] = (int)glm::round(cv + lu * sn + lv * cs);
+		p[wAxis] = w0;
+		corners[i] = p;
+	}
+}
+
+void Rectangle::generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+						 const voxel::Region &region, const AABBBrushState &state) {
+	if (state.aabbFace == voxel::FaceNames::Max) {
+		return;
+	}
+	int uAxis;
+	int vAxis;
+	Circle::ellipseAxes(state.aabbFace, uAxis, vAxis);
+	const int wAxis = math::getIndexForAxis(voxel::faceToAxis(state.aabbFace));
+	const bool positiveNormal = voxel::isPositiveFace(state.aabbFace);
+
+	glm::ivec3 corners[4];
+	computeCorners(region, state.aabbFace, corners);
+
+	// Snap each corner to the actual surface depth at its (u,v) so the edge chord follows the
+	// surface across terraces instead of staying pinned to the single clicked depth (which left
+	// the down-slope edges broken at every riser).
+	const voxel::Region &vol = ctx.targetVolumeRegion;
+	const int w0 = corners[0][wAxis];
+	const int columnTol = vol.getUpperCorner()[wAxis] - vol.getLowerCorner()[wAxis];
+	for (int i = 0; i < 4; ++i) {
+		int sw;
+		if (voxelutil::findSurfaceNear(wrapper, corners[i][uAxis], corners[i][vAxis], w0, columnTol, uAxis, vAxis, wAxis,
+									   positiveNormal, vol, sw)) {
+			corners[i][wAxis] = sw;
+		}
+	}
+
+	auto func = [&wrapper](int x, int y, int z, const voxel::Voxel &) {
+		if (wrapper.modifierType() == ModifierType::Erase) {
+			wrapper.removeFlagAt(x, y, z, voxel::FlagOutline);
+		} else {
+			wrapper.setFlagAt(x, y, z, voxel::FlagOutline);
+		}
+	};
+	// Draw the four edges of the (rotated) rectangle as lines draped over the visible surface, so
+	// each edge stays continuous AND visible across terraces/risers (riser faces are filled in).
+	for (int i = 0; i < 4; ++i) {
+		voxelutil::lineDrapeSurface(wrapper, corners[i], corners[(i + 1) % 4], uAxis, vAxis, wAxis, positiveNormal,
+									_edgeWidth, vol, func);
+	}
+}
+
+void Rectangle::reset() {
+	Super::reset();
+	_previewActive = false;
+	_overlayPoints.clear();
+}
+
+void Rectangle::abort(BrushContext &ctx) {
+	Super::abort(ctx);
+	_previewActive = false;
+	_overlayPoints.clear();
+}
+
+void Rectangle::endBrush(BrushContext &ctx) {
+	Super::endBrush(ctx);
+	_previewActive = false;
+	_overlayPoints.clear();
+}
+
+void Rectangle::setPreview(const voxel::Region &region, voxel::FaceNames face) {
+	if (face == voxel::FaceNames::Max || !region.isValid()) {
+		_previewActive = false;
+		_overlayPoints.clear();
+		return;
+	}
+	glm::ivec3 corners[4];
+	computeCorners(region, face, corners);
+	const glm::mat4 model = _sceneManager != nullptr ? _sceneManager->worldMatrix() : glm::mat4(1.0f);
+	_overlayPoints.clear();
+	_overlayPoints.reserve(4);
+	for (int i = 0; i < 4; ++i) {
+		// Center on the voxel so the outline runs through voxel centers.
+		_overlayPoints.push_back(glm::vec3(model * glm::vec4(glm::vec3(corners[i]) + 0.5f, 1.0f)));
+	}
+	_previewActive = true;
+}
+
+bool Rectangle::wantBrushGizmo(const BrushContext &ctx) const {
+	return _previewActive && _overlayPoints.size() == 4;
+}
+
+void Rectangle::brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const {
+	state.operations = BrushGizmo_WorldPolyline;
+	state.worldPolyline = &_overlayPoints;
+	state.worldPolylineClosed = true;
+}
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Rectangle.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/Rectangle.h
@@ -1,0 +1,97 @@
+/**
+ * @file
+ */
+
+#pragma once
+
+#include "SelectStrategy.h"
+#include "core/collection/DynamicArray.h"
+#include "voxel/Region.h"
+#include <glm/common.hpp>
+#include <glm/vec3.hpp>
+
+namespace voxedit {
+
+class SceneManager;
+
+namespace select {
+
+/**
+ * @brief Selects a 2D rectangle outline drawn on the clicked surface.
+ *
+ * The two drag corners define a rectangle in the clicked face plane that can be rotated by
+ * @c _angle degrees. Its four edges are draped over the visible surface (voxelutil::lineDrapeSurface)
+ * with thickness @c _edgeWidth, filling terrace riser faces so each edge stays continuous AND
+ * visible. While dragging it is previewed as a cheap world-space outline (BrushGizmo_WorldPolyline)
+ * so the preview never hits the preview-size cap and shows the rotation.
+ * @ingroup Brushes
+ */
+class Rectangle : public Strategy {
+private:
+	using Super = Strategy;
+	SceneManager *_sceneManager;
+	/** Thickness in voxels of the rectangle outline. */
+	int _edgeWidth = 1;
+	/** In-plane rotation of the rectangle around the clicked face normal, in degrees. */
+	int _angle = 0;
+	/** How far the surface may deviate from the straight edge and still be followed. */
+	int _maxDeviation = 64;
+	/** Live world-space corners for the gizmo outline preview (rebuilt each frame while dragging). */
+	core::DynamicArray<glm::vec3> _overlayPoints;
+	bool _previewActive = false;
+
+	/** Compute the four rotated rectangle corners (node-local) for the given drag box and face. */
+	void computeCorners(const voxel::Region &region, voxel::FaceNames face, glm::ivec3 corners[4]) const;
+
+public:
+	explicit Rectangle(SceneManager *sceneManager) : _sceneManager(sceneManager) {
+	}
+
+	voxel::Region calcRegion(const BrushContext &ctx, const AABBBrushState &state) const override {
+		return voxel::Region::InvalidRegion;
+	}
+	void generate(scenegraph::SceneGraph &sceneGraph, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
+				  const voxel::Region &region, const AABBBrushState &state) override;
+	/** @brief A 2D rectangle is defined by the two drag corners, so no third placement click is needed. */
+	bool needsAdditionalAction(const BrushContext &ctx) const override {
+		return false;
+	}
+
+	void reset() override;
+	void abort(BrushContext &ctx) override;
+	void endBrush(BrushContext &ctx) override;
+	bool wantBrushGizmo(const BrushContext &ctx) const override;
+	void brushGizmoState(const BrushContext &ctx, BrushGizmoState &state) const override;
+	/** Update the live gizmo outline from the drag box and clicked face. */
+	void setPreview(const voxel::Region &region, voxel::FaceNames face);
+	void clearPreview() {
+		_previewActive = false;
+	}
+
+	int edgeWidth() const {
+		return _edgeWidth;
+	}
+
+	void setEdgeWidth(int width) {
+		_edgeWidth = glm::clamp(width, 1, 32);
+	}
+
+	int angle() const {
+		return _angle;
+	}
+
+	void setAngle(int angle) {
+		_angle = glm::clamp(angle, -180, 180);
+	}
+
+	int maxDeviation() const {
+		return _maxDeviation;
+	}
+
+	void setMaxDeviation(int deviation) {
+		_maxDeviation = glm::clamp(deviation, 0, 64);
+	}
+};
+
+} // namespace select
+} // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/SelectStrategy.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/select/SelectStrategy.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "app/I18NMarkers.h"
+#include "core/ArrayLength.h"
 #include "voxedit-util/modifier/SceneModifiedFlags.h"
 #include "voxel/Face.h"
 #include "voxel/Region.h"
@@ -21,6 +23,23 @@ struct BrushContext;
 class ModifierVolumeWrapper;
 
 namespace select {
+
+/**
+ * @brief How a line/edge tracks the volume between its endpoints.
+ *
+ * FollowSurface keeps the path straight in the face plane but snaps the depth to the
+ * surface, so the thickness always reaches it on stepped/sloped geometry. Straight draws a
+ * plain 3D chord between the endpoints and only selects solid voxels it actually passes
+ * through.
+ */
+enum class PathMode : uint8_t { FollowSurface, Straight, Max };
+
+// clang-format off
+static constexpr const char *PathModeStr[] = {
+	NC_("PathMode", "Follow surface"),
+	NC_("PathMode", "Straight")};
+// clang-format on
+static_assert(lengthof(PathModeStr) == (int)PathMode::Max, "PathModeStr size mismatch");
 
 /**
  * @brief AABB state passed from the brush to strategies that need it

--- a/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SelectBrushTest.cpp
@@ -213,6 +213,226 @@ TEST_F(SelectBrushTest, testSelectModeVisible) {
 	brush.shutdown();
 }
 
+TEST_F(SelectBrushTest, testSelectModeRectangleOutline) {
+	voxel::RawVolume volume({-5, 5});
+	// Solid 5x5x5 box from (-2,-2,-2) to (2,2,2)
+	for (int z = -2; z <= 2; ++z) {
+		for (int y = -2; y <= 2; ++y) {
+			for (int x = -2; x <= 2; ++x) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SelectBrush brush(nullptr);
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Rectangle);
+	brush.rectangle().setAngle(0);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.referencePos = glm::ivec3(-2, -2, -2);
+
+	// prepare() uses cursorFace=PositiveX, so the outline is drawn on the +X surface (x=2).
+	prepare(brush, ctx, glm::ivec3(-2, -2, -2), glm::ivec3(2, 2, 2));
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// Only the 4 edges of the rectangle on the +X face are selected; the interior is not.
+	EXPECT_TRUE((volume.voxel(2, 2, 0).getFlags() & voxel::FlagOutline) != 0) << "Y=+2 edge should be selected";
+	EXPECT_TRUE((volume.voxel(2, -2, 0).getFlags() & voxel::FlagOutline) != 0) << "Y=-2 edge should be selected";
+	EXPECT_TRUE((volume.voxel(2, 0, 2).getFlags() & voxel::FlagOutline) != 0) << "Z=+2 edge should be selected";
+	EXPECT_TRUE((volume.voxel(2, 0, -2).getFlags() & voxel::FlagOutline) != 0) << "Z=-2 edge should be selected";
+	EXPECT_FALSE((volume.voxel(2, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "rectangle interior (center) must NOT be selected - outline only";
+	EXPECT_FALSE((volume.voxel(1, 0, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "voxel behind the surface must NOT be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeRectangleOutlineRotated) {
+	voxel::RawVolume volume({0, 24});
+	// Flat top surface at y=10
+	for (int x = 0; x <= 20; ++x) {
+		for (int z = 0; z <= 20; ++z) {
+			for (int y = 0; y <= 10; ++y) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SelectBrush brush(nullptr);
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Rectangle);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.referencePos = glm::ivec3(4, 10, 4);
+
+	auto runRect = [&](int angle) {
+		for (int x = 0; x <= 20; ++x) {
+			for (int z = 0; z <= 20; ++z) {
+				voxel::Voxel v = volume.voxel(x, 10, z);
+				v.setFlags(0);
+				volume.setVoxel(x, 10, z, v);
+			}
+		}
+		brush.rectangle().setAngle(angle);
+		ctx.cursorFace = voxel::FaceNames::PositiveY;
+		ctx.cursorPosition = glm::ivec3(4, 10, 4);
+		EXPECT_TRUE(brush.beginBrush(ctx));
+		ctx.cursorPosition = glm::ivec3(16, 10, 16);
+		brush.step(ctx);
+		executeSelect(brush, node, ctx, ModifierType::Override);
+	};
+
+	// Rectangle (4,4)-(16,16) on the top, center (10,10). The outline runs through the corners.
+	runRect(0);
+	EXPECT_TRUE((volume.voxel(4, 10, 4).getFlags() & voxel::FlagOutline) != 0)
+		<< "axis-aligned corner is on the unrotated outline";
+	EXPECT_FALSE((volume.voxel(10, 10, 10).getFlags() & voxel::FlagOutline) != 0)
+		<< "center is inside the outline, not on it";
+
+	runRect(45);
+	EXPECT_FALSE((volume.voxel(4, 10, 4).getFlags() & voxel::FlagOutline) != 0)
+		<< "corner is no longer on the rotated (diamond) outline";
+	// The rotated rectangle's corner now points along +X: (10 + ~8.5, 10) -> around x=18.
+	EXPECT_TRUE((volume.voxel(18, 10, 10).getFlags() & voxel::FlagOutline) != 0)
+		<< "the diamond tip along +X should be on the rotated outline";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeLine) {
+	voxel::RawVolume volume({-5, 5});
+	// Fill a solid 5x5x5 box from (-2,-2,-2) to (2,2,2)
+	for (int z = -2; z <= 2; ++z) {
+		for (int y = -2; y <= 2; ++y) {
+			for (int x = -2; x <= 2; ++x) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SelectBrush brush(nullptr);
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Line);
+	brush.line().setWidth(1);
+	brush.line().setPathMode(select::PathMode::Straight);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.referencePos = glm::ivec3(-2, -2, -2);
+
+	// Draw the main diagonal from (-2,-2,-2) to (2,2,2)
+	prepare(brush, ctx, glm::ivec3(-2, -2, -2), glm::ivec3(2, 2, 2));
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// Every voxel on the diagonal is selected
+	for (int k = -2; k <= 2; ++k) {
+		EXPECT_TRUE((volume.voxel(k, k, k).getFlags() & voxel::FlagOutline) != 0)
+			<< "diagonal voxel (" << k << "," << k << "," << k << ") should be selected";
+	}
+	// A corner off the diagonal is not on the line
+	EXPECT_FALSE((volume.voxel(2, -2, -2).getFlags() & voxel::FlagOutline) != 0)
+		<< "off-diagonal corner at (2,-2,-2) should NOT be selected";
+	EXPECT_FALSE((volume.voxel(-2, 2, -2).getFlags() & voxel::FlagOutline) != 0)
+		<< "off-diagonal corner at (-2,2,-2) should NOT be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeLineWidth) {
+	voxel::RawVolume volume({-5, 5});
+	for (int z = -2; z <= 2; ++z) {
+		for (int y = -2; y <= 2; ++y) {
+			for (int x = -2; x <= 2; ++x) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SelectBrush brush(nullptr);
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Line);
+	brush.line().setWidth(3);
+	brush.line().setPathMode(select::PathMode::Straight);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.referencePos = glm::ivec3(-2, 0, 0);
+
+	// Straight line along X at y=0,z=0
+	prepare(brush, ctx, glm::ivec3(-2, 0, 0), glm::ivec3(2, 0, 0));
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// Centerline and the one-voxel shell around it are selected with width 3
+	EXPECT_TRUE((volume.voxel(0, 0, 0).getFlags() & voxel::FlagOutline) != 0) << "centerline voxel should be selected";
+	EXPECT_TRUE((volume.voxel(0, 1, 0).getFlags() & voxel::FlagOutline) != 0)
+		<< "neighbour within width should be selected";
+	EXPECT_TRUE((volume.voxel(0, 0, 1).getFlags() & voxel::FlagOutline) != 0)
+		<< "neighbour within width should be selected";
+
+	brush.shutdown();
+}
+
+TEST_F(SelectBrushTest, testSelectModeLineFollowSurface) {
+	voxel::RawVolume volume({0, 19});
+	// Terraced top surface (PositiveY face): columns x in [0..10], z in [0..2].
+	// Top is y=10 for x<=5, then steps down to y=9 for x>=6 (a one-voxel step the
+	// width-1 follow tolerance can cross).
+	for (int x = 0; x <= 10; ++x) {
+		const int top = x <= 5 ? 10 : 9;
+		for (int z = 0; z <= 2; ++z) {
+			for (int y = 0; y <= top; ++y) {
+				volume.setVoxel(x, y, z, voxel::createVoxel(voxel::VoxelType::Generic, 0));
+			}
+		}
+	}
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SelectBrush brush(nullptr);
+	ASSERT_TRUE(brush.init());
+	brush.setSelectMode(SelectMode::Line);
+	brush.line().setWidth(1);
+	brush.line().setPathMode(select::PathMode::FollowSurface);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.referencePos = glm::ivec3(0, 10, 1);
+
+	// prepare() hardcodes cursorFace=PositiveX, so set the top face manually.
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+	ctx.cursorPosition = glm::ivec3(0, 10, 1);
+	EXPECT_TRUE(brush.beginBrush(ctx));
+	ctx.cursorPosition = glm::ivec3(10, 9, 1);
+	brush.step(ctx);
+	executeSelect(brush, node, ctx, ModifierType::Override);
+
+	// The line tracks the surface: the top voxel of each column along the path is selected,
+	// including across the step where a straight chord would float in the air above plateau B.
+	EXPECT_TRUE((volume.voxel(5, 10, 1).getFlags() & voxel::FlagOutline) != 0)
+		<< "top of the upper plateau should be selected";
+	EXPECT_TRUE((volume.voxel(6, 9, 1).getFlags() & voxel::FlagOutline) != 0)
+		<< "top of the lower plateau (across the step) should be selected";
+	EXPECT_TRUE((volume.voxel(10, 9, 1).getFlags() & voxel::FlagOutline) != 0)
+		<< "top of the lower plateau end should be selected";
+	// Interior voxels below the surface are not selected at width 1
+	EXPECT_FALSE((volume.voxel(5, 5, 1).getFlags() & voxel::FlagOutline) != 0)
+		<< "interior voxel well below the surface should NOT be selected";
+
+	brush.shutdown();
+}
+
 TEST_F(SelectBrushTest, testSelectRemove) {
 	voxel::RawVolume volume({-5, 5});
 	// Fill volume with voxels, all selected


### PR DESCRIPTION
Adds three surface-aware selection brushes on top of the existing select modes, plus the shared plumbing they need.

## Brushes
- **Rectangle / Line** select are draped over the visible surface (`lineDrapeSurface`): each step marks the front-most surface voxel and fills terrace riser faces, so an edge stays continuous **and** visible across stepped/sloped geometry instead of disappearing into hidden faces.
- **PolygonLasso** accumulates as a world-space overlay polyline (`BrushGizmo_WorldPolyline`) instead of marking the volume every frame. The close action runs a bounded per-column flood fill (`lassoFloodFillSurface`) with 8-neighbour riser bridging that:
  - fills the enclosed front surface, bridging diagonal terrace steps without holes or bleed,
  - skips a disjoint structure that merely shares the (u, v) silhouette,
  - cannot freeze on large models (no per-voxel buffers).
- `columnFrontSurface` helper shared by the line and lasso paths.

## Plumbing
- `SceneManager::selectionFinalizeLasso` / `selectionCancelLasso` / `selectionLassoUndoVertex` drive the lasso lifecycle.
- `AABBBrush::reset()` no longer clears `_mode`, so a brush-type round-trip preserves the Paint/Single mode set via the UI.

## Tests
- 11 `VolumeSelectTest` cases (drape connectivity / visible-risers / no-ghost, lasso wall/pit/riser/concave/thin/front-only).
- New Rectangle/Line/Lasso `SelectBrushTest` cases (40 pass total).

Built and tested against the release tree.