### PR TITLE
VOXEDIT: add SmoothWall sculpt mode, snapshot perf rewrite and reskin fixes

### DIFF
--- a/docs/lua/sculpt.md
+++ b/docs/lua/sculpt.md
@@ -14,6 +14,7 @@ Global: `g_sculpt`
 | `smoothadditive(volume, face, heightThreshold, iterations, color)` | Fill height gaps by scanning layers along a face normal. Air voxels on solid ground get filled when a neighbor column is significantly taller. Each iteration adds at most one voxel per column. |
 | `smootherode(volume, face, iterations, preserveTopHeight, trimPerStep)` | Remove edge voxels from the top of columns along a face normal. Scans top-to-bottom, removing top-of-column voxels that have fewer than 4 solid planar neighbors. Each iteration removes at most one voxel per column. |
 | `smoothgaussian(volume, face, kernelSize, sigma, iterations, color)` | Blur the height map using a 2D Gaussian kernel along a face normal. Columns taller than the weighted average are trimmed, shorter ones are filled. Uses circular sampling within the kernel radius. |
+| `smoothwall(volume, face, iterations, color, removeAboveDepth, interpolation)` | Smooth a wall surface by interpolating interior column heights from nearest edge columns in 4 directions. |
 | `squashtoplane(volume, face, planeCoord)` | Project all solid voxels onto a single plane. For each column along the face normal, if any voxel exists, one is placed at the plane coordinate. All others are removed. |
 
 ## Detailed Documentation
@@ -167,6 +168,27 @@ Blur the height map using a 2D Gaussian kernel along a face normal. Columns tall
 | `sigma` | `number` | Standard deviation of the Gaussian bell curve (optional, default 1.0). Lower = sharper, higher = broader smoothing. |
 | `iterations` | `integer` | Number of blur passes (optional, default 1). |
 | `color` | `integer` | Palette color index for new voxels (optional, default 1). |
+
+**Returns:**
+
+| Type | Description |
+| ---- | ----------- |
+| `integer` | Number of voxels changed. |
+
+### smoothwall
+
+Smooth a wall surface by interpolating interior column heights from nearest edge columns in 4 directions. Edge columns (selected voxels bordering non-selected) are preserved for seamless blending. A gap-fill pass extends columns downward to match the lowest neighbor, preventing holes at corners.
+
+**Parameters:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `volume` | `volume` | The volume to smooth. |
+| `face` | `string` | Face direction defining the surface normal: 'up', 'down', 'left', 'right', 'front', 'back'. |
+| `iterations` | `integer` | Number of smoothing passes (optional, default 1). |
+| `color` | `integer` | Palette color index for new voxels (optional, default 1). |
+| `removeAboveDepth` | `integer` | How many voxels above the smooth surface to clear (optional, default 0 = don't clear). |
+| `interpolation` | `string` | Interpolation mode: 'linear', 'inversedistance' (default), or 'edgeaware'. |
 
 **Returns:**
 

--- a/src/modules/voxelgenerator/LUAApi.cpp
+++ b/src/modules/voxelgenerator/LUAApi.cpp
@@ -2662,9 +2662,9 @@ static int luaVoxel_sculpt_reskin(lua_State *s) {
 	const char *followStr = luaL_optstring(s, 5, "voxel");
 	const int skinDepth = (int)luaL_optinteger(s, 6, 0);
 	const int surfaceOffset = (int)luaL_optinteger(s, 7, 0);
-	const char *skinUpStr = luaL_optstring(s, 8, "y");
 
 	voxelutil::ReskinConfig config;
+	config.preview = false;
 
 	if (core::string::iequals(modeStr, "replace")) {
 		config.mode = voxelutil::ReskinMode::Replace;
@@ -2678,16 +2678,24 @@ static int luaVoxel_sculpt_reskin(lua_State *s) {
 		config.follow = voxelutil::ReskinFollow::None;
 	} else if (core::string::iequals(followStr, "median")) {
 		config.follow = voxelutil::ReskinFollow::Median;
+	} else if (core::string::iequals(followStr, "corneraverage")) {
+		config.follow = voxelutil::ReskinFollow::CornerAverage;
 	} else {
 		config.follow = voxelutil::ReskinFollow::Voxel;
 	}
 
-	const math::Axis parsedAxis = math::toAxis(skinUpStr);
-	config.skinUpAxis = (parsedAxis != math::Axis::None) ? parsedAxis : math::Axis::Y;
-
 	const voxel::Region &skinRegion = skinVolume->volume()->region();
-	const int skinUpIdx = math::getIndexForAxis(config.skinUpAxis);
-	const int defaultDepth = skinRegion.getUpperCorner()[skinUpIdx] - skinRegion.getLowerCorner()[skinUpIdx] + 1;
+	// Auto-detect depth axis from thinnest dimension
+	const glm::ivec3 skinExtents = skinRegion.getUpperCorner() - skinRegion.getLowerCorner() + 1;
+	if (skinExtents.x <= skinExtents.y && skinExtents.x <= skinExtents.z) {
+		config.skinFace = voxel::FaceNames::PositiveX;
+	} else if (skinExtents.z <= skinExtents.x && skinExtents.z <= skinExtents.y) {
+		config.skinFace = voxel::FaceNames::PositiveZ;
+	} else {
+		config.skinFace = voxel::FaceNames::PositiveY;
+	}
+	const int depthIdx = math::getIndexForAxis(voxel::faceToAxis(config.skinFace));
+	const int defaultDepth = skinExtents[depthIdx];
 	config.skinDepth = skinDepth > 0 ? skinDepth : defaultDepth;
 	config.zOffset = surfaceOffset;
 
@@ -2722,10 +2730,9 @@ static int luaVoxel_sculpt_reskin_jsonhelp(lua_State *s) {
 			{"name": "skin", "type": "volume", "description": "The skin volume providing the pattern."},
 			{"name": "face", "type": "string", "description": "Face direction defining surface normal: 'up', 'down', 'left', 'right', 'front', 'back'."},
 			{"name": "mode", "type": "string", "description": "Reskin mode: 'replace' (skin overwrites, air removes), 'blend' (skin overwrites, air preserves), 'negate' (skin removes, air preserves) (optional, default 'blend')."},
-			{"name": "follow", "type": "string", "description": "Surface follow mode: 'none' (flat plane), 'median' (median height plane), 'voxel' (per-column) (optional, default 'voxel')."},
-			{"name": "skinDepth", "type": "integer", "description": "Number of skin layers to apply (optional, default: full skin depth along up axis)."},
-			{"name": "surfaceOffset", "type": "integer", "description": "Offset from surface: positive = above, negative = below (optional, default 0)."},
-			{"name": "skinUpAxis", "type": "string", "description": "Which skin axis is outward: 'x', 'y', 'z' (optional, default 'y')."}
+			{"name": "follow", "type": "string", "description": "Surface follow mode: 'none' (flat plane), 'median' (median height plane), 'voxel' (per-column), 'corneraverage' (bilinear from corners) (optional, default 'voxel')."},
+			{"name": "skinDepth", "type": "integer", "description": "Number of skin layers to apply (optional, default: full skin Y-axis depth)."},
+			{"name": "surfaceOffset", "type": "integer", "description": "Offset from surface: positive = above, negative = below (optional, default 0)."}
 		],
 		"returns": [
 			{"type": "integer", "description": "Number of voxels changed."}
@@ -2759,6 +2766,52 @@ static int luaVoxel_sculpt_smoothgaussian_jsonhelp(lua_State *s) {
 			{"name": "sigma", "type": "number", "description": "Standard deviation of the Gaussian bell curve (optional, default 1.0). Lower = sharper, higher = broader smoothing."},
 			{"name": "iterations", "type": "integer", "description": "Number of blur passes (optional, default 1)."},
 			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."}
+		],
+		"returns": [
+			{"type": "integer", "description": "Number of voxels changed."}
+		]})";
+	lua_pushstring(s, json);
+	return 1;
+}
+
+static voxelutil::SmoothWallInterp luaVoxel_parseSmoothWallInterp(const char *str) {
+	if (SDL_strcmp(str, "linear") == 0) {
+		return voxelutil::SmoothWallInterp::Linear;
+	}
+	if (SDL_strcmp(str, "edgeaware") == 0) {
+		return voxelutil::SmoothWallInterp::EdgeAware;
+	}
+	return voxelutil::SmoothWallInterp::InverseDistance;
+}
+
+static int luaVoxel_sculpt_smoothwall(lua_State *s) {
+	LuaRawVolumeWrapper *volume = luaVoxel_tovolumewrapper(s, 1);
+	const voxel::FaceNames face = luaVoxel_getFace(s, 2);
+	const int iterations = (int)luaL_optinteger(s, 3, 1);
+	const int color = (int)luaL_optinteger(s, 4, 1);
+	const int removeAboveDepth = (int)luaL_optinteger(s, 5, 0);
+	const char *interpStr = luaL_optstring(s, 6, "inversedistance");
+	const voxelutil::SmoothWallInterp interp = luaVoxel_parseSmoothWallInterp(interpStr);
+	const bool fillHoles = lua_toboolean(s, 7) != 0 || lua_isnoneornil(s, 7);
+	const voxel::Voxel fillVoxel = voxel::createVoxel(voxel::VoxelType::Generic, color);
+	const int changed = voxelutil::sculptSmoothWall(*volume->volume(), volume->volume()->region(), face,
+													iterations, fillVoxel, removeAboveDepth, interp, fillHoles);
+	lua_pushinteger(s, changed);
+	return 1;
+}
+
+static int luaVoxel_sculpt_smoothwall_jsonhelp(lua_State *s) {
+	const char *json = R"({
+		"name": "smoothwall",
+		"summary": "Smooth a wall surface by interpolating interior column heights from edge columns. For each interior (U,V) position, computes a target height from the nearest boundary columns in 4 directions. Edge columns are preserved for seamless blending.",
+		"parameters": [
+			{"name": "volume", "type": "volume", "description": "The volume to smooth."},
+			{"name": "face", "type": "string", "description": "Face direction defining the surface normal: 'up', 'down', 'left', 'right', 'front', 'back'."},
+			{"name": "iterations", "type": "integer", "description": "Number of smoothing passes (optional, default 1)."},
+			{"name": "color", "type": "integer", "description": "Palette color index for new voxels (optional, default 1)."},
+			{"name": "removeAboveDepth", "type": "integer", "description": "How many voxels above the smooth surface to clear (optional, default 0 = don't clear)."},
+			{"name": "interpolation", "type": "string", "description": "Interpolation mode: 'linear', 'inversedistance' (default, smooth curves), or 'edgeaware' (follows sharp corners by favoring edges with similar height)."},
+			{"name": "fillHoles", "type": "boolean", "description": "Fill enclosed empty areas with interpolated heights (optional, default true). When false, empty columns are skipped and only solid columns are smoothed."}
 		],
 		"returns": [
 			{"type": "integer", "description": "Number of voxels changed."}
@@ -6840,6 +6893,7 @@ void luaVoxel_prepareState(lua_State* s) {
 		{"bridgegap", luaVoxel_sculpt_bridgegap, luaVoxel_sculpt_bridgegap_jsonhelp},
 		{"squashtoplane", luaVoxel_sculpt_squashtoplane, luaVoxel_sculpt_squashtoplane_jsonhelp},
 		{"reskin", luaVoxel_sculpt_reskin, luaVoxel_sculpt_reskin_jsonhelp},
+		{"smoothwall", luaVoxel_sculpt_smoothwall, luaVoxel_sculpt_smoothwall_jsonhelp},
 		{nullptr, nullptr, nullptr}
 	};
 	clua_registerfuncsglobal(s, sculptFuncs, luaVoxel_metasculpt(), "g_sculpt");

--- a/src/modules/voxelutil/VolumeSculpt.cpp
+++ b/src/modules/voxelutil/VolumeSculpt.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "VolumeSculpt.h"
+#include "core/Log.h"
 #include "app/ForParallel.h"
 #include "core/GLM.h"
 #include "core/Trace.h"
@@ -18,6 +19,7 @@
 #include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
 #include "core/Algorithm.h"
+#include "palette/Palette.h"
 #include <cfloat>
 #include <climits>
 
@@ -1019,6 +1021,617 @@ void sculptSmoothGaussian(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap
 	}
 }
 
+// Fill a single voxel position: mark solid in BitVolume and copy color from nearest neighbor.
+// Templated to work with SparseVolume (full path) or RawVolume (fast path).
+template<typename ColorSource>
+static void fillSmoothWallVoxel(voxel::BitVolume &solid, ColorSource &colorSource,
+								const glm::ivec3 &pos, const voxel::Voxel &fillVoxel,
+								core::DynamicArray<glm::ivec3> &addedPositions) {
+	if (solid.hasValue(pos.x, pos.y, pos.z)) {
+		return;
+	}
+	solid.setVoxel(pos, true);
+	addedPositions.push_back(pos);
+	voxel::Voxel newVoxel = fillVoxel;
+	for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+		const glm::ivec3 neighbor = pos + offset;
+		const voxel::Voxel &nv = colorSource.voxel(neighbor);
+		if (voxel::isBlocked(nv.getMaterial())) {
+			newVoxel = nv;
+			break;
+		}
+	}
+	colorSource.setVoxel(pos, newVoxel);
+}
+
+template<typename ColorSource>
+static void sculptSmoothWallImpl(voxel::BitVolume &solid, ColorSource &colorSource, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles,
+					  core::DynamicArray<glm::ivec3> &addedPositions) {
+	core_trace_scoped(SculptSmoothWall);
+
+	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+	const bool positiveUp = voxel::isPositiveFace(face);
+	const voxel::Region &region = solid.region();
+	const glm::ivec3 &lo = region.getLowerCorner();
+	const glm::ivec3 &hi = region.getUpperCorner();
+
+	// U and V are the two axes perpendicular to the face normal
+	const int uAxis = (axisIdx == 0) ? 1 : 0;
+	const int vAxis = (axisIdx == 2) ? 1 : 2;
+
+	const int baseU = lo[uAxis];
+	const int baseV = lo[vAxis];
+	const int extentU = hi[uAxis] - baseU + 1;
+	const int extentV = hi[vAxis] - baseV + 1;
+
+	// Need at least 3 columns in each direction (edges + 1 interior)
+	if (extentU < 3 || extentV < 3) {
+		return;
+	}
+
+	const int numColumns = extentU * extentV;
+	addedPositions.reserve(numColumns);
+	static constexpr int EMPTY = INT_MIN;
+	const int axisLo = lo[axisIdx];
+	const int axisHi = hi[axisIdx];
+	// removeAboveDepth == 0 means don't clear anything above the target surface.
+	// Negative values are clamped to 0.
+	if (removeAboveDepth < 0) {
+		removeAboveDepth = 0;
+	}
+
+	// Flat 2D arrays for column heights (preallocated, reused across iterations)
+	core::DynamicArray<int> colTopArr(numColumns);
+	core::DynamicArray<int> colBotArr(numColumns);
+	core::DynamicArray<int> targetArr(numColumns);
+	core::DynamicArray<bool> isEdgeArr(numColumns);
+
+	// Per-column nearest-edge precomputed arrays (4 directions)
+	core::DynamicArray<int> nearEdgeHeightLeft(numColumns);
+	core::DynamicArray<int> nearEdgeDistLeft(numColumns);
+	core::DynamicArray<int> nearEdgeHeightRight(numColumns);
+	core::DynamicArray<int> nearEdgeDistRight(numColumns);
+	core::DynamicArray<int> nearEdgeHeightTop(numColumns);
+	core::DynamicArray<int> nearEdgeDistTop(numColumns);
+	core::DynamicArray<int> nearEdgeHeightBottom(numColumns);
+	core::DynamicArray<int> nearEdgeDistBottom(numColumns);
+
+	// Exterior-empty BFS (only used when fillHoles=true)
+	core::DynamicArray<bool> isExteriorEmpty;
+	core::DynamicArray<int> bfsQueue;
+	if (fillHoles) {
+		isExteriorEmpty.resize(numColumns);
+		bfsQueue.reserve(numColumns);
+	}
+
+	for (int iter = 0; iter < iterations; ++iter) {
+		// Step 1: Build column top/bottom from the solid BitVolume only (parallel).
+		// Anchor voxels (non-selected solid neighbors) are intentionally excluded:
+		// they are not in solid and cannot be cleared, so including them in the
+		// height scan causes colTopArr to reflect positions that the clear loop
+		// cannot remove (solid.hasValue returns false for anchors).
+		for (int idx = 0; idx < numColumns; ++idx) {
+			colTopArr[idx] = EMPTY;
+			colBotArr[idx] = EMPTY;
+		}
+
+		app::for_parallel(0, extentU, [&](int startRow, int endRow) {
+			for (int iu = startRow; iu < endRow; ++iu) {
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const int coordU = baseU + iu;
+					const int coordV = baseV + iv;
+					// Scan from both ends to find top and bottom in O(depth) worst case
+					// but O(1) for thin selections (e.g. 1-voxel thick wall in 200-deep range).
+					// positiveUp: top = max height (scan from axisHi down), bottom = min height (scan from axisLo up)
+					// negativeUp: top = min height (scan from axisLo up), bottom = max height (scan from axisHi down)
+					int topVal = EMPTY;
+					int botVal = EMPTY;
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+					if (positiveUp) {
+						for (int av = axisHi; av >= axisLo; --av) {
+							pos[axisIdx] = av;
+							if (solid.hasValue(pos.x, pos.y, pos.z)) {
+								topVal = av;
+								break;
+							}
+						}
+						if (topVal != EMPTY) {
+							for (int av = axisLo; av <= topVal; ++av) {
+								pos[axisIdx] = av;
+								if (solid.hasValue(pos.x, pos.y, pos.z)) {
+									botVal = av;
+									break;
+								}
+							}
+						}
+					} else {
+						for (int av = axisLo; av <= axisHi; ++av) {
+							pos[axisIdx] = av;
+							if (solid.hasValue(pos.x, pos.y, pos.z)) {
+								topVal = av;
+								break;
+							}
+						}
+						if (topVal != EMPTY) {
+							for (int av = axisHi; av >= topVal; --av) {
+								pos[axisIdx] = av;
+								if (solid.hasValue(pos.x, pos.y, pos.z)) {
+									botVal = av;
+									break;
+								}
+							}
+						}
+					}
+					colTopArr[flatIdx] = topVal;
+					colBotArr[flatIdx] = botVal;
+				}
+			}
+		});
+
+		// Step 1.5 (fillHoles only): BFS from boundary to identify exterior-empty columns.
+		// Interior-empty columns (holes) are those not reachable from outside.
+		if (fillHoles) {
+			for (int idx = 0; idx < numColumns; ++idx) {
+				isExteriorEmpty[idx] = false;
+			}
+			bfsQueue.clear();
+			for (int iu = 0; iu < extentU; ++iu) {
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const bool onBoundary = (iu == 0 || iu == extentU - 1 || iv == 0 || iv == extentV - 1);
+					if (onBoundary && colTopArr[flatIdx] == EMPTY) {
+						isExteriorEmpty[flatIdx] = true;
+						bfsQueue.push_back(flatIdx);
+					}
+				}
+			}
+			static constexpr int bfsDU[4] = {-1, 1, 0, 0};
+			static constexpr int bfsDV[4] = {0, 0, -1, 1};
+			for (int qi = 0; qi < (int)bfsQueue.size(); ++qi) {
+				const int fi = bfsQueue[qi];
+				const int biu = fi / extentV;
+				const int biv = fi % extentV;
+				for (int di = 0; di < 4; ++di) {
+					const int nu = biu + bfsDU[di];
+					const int nv = biv + bfsDV[di];
+					if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+						continue;
+					}
+					const int nIdx = nu * extentV + nv;
+					if (isExteriorEmpty[nIdx] || colTopArr[nIdx] != EMPTY) {
+						continue;
+					}
+					isExteriorEmpty[nIdx] = true;
+					bfsQueue.push_back(nIdx);
+				}
+			}
+		}
+
+		// Step 2: Identify edge columns, precompute nearest-edge in 4 directions
+		// via O(N) sweeps, then compute target heights for interior columns.
+		for (int idx = 0; idx < numColumns; ++idx) {
+			targetArr[idx] = EMPTY;
+		}
+
+		// Mark edge columns.
+		// fillHoles=false: solid column adjacent to any empty or out-of-bounds UV neighbor.
+		// fillHoles=true: solid column adjacent to exterior-empty or out-of-bounds only
+		//   (hole-boundary columns are NOT edges -- they get interpolated heights too).
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (int iv = 0; iv < extentV; ++iv) {
+				const int flatIdx = iu * extentV + iv;
+				if (colTopArr[flatIdx] == EMPTY) {
+					isEdgeArr[flatIdx] = false;
+					continue;
+				}
+				if (fillHoles) {
+					bool enclosingEdge = false;
+					static constexpr int edgeDU[4] = {-1, 1, 0, 0};
+					static constexpr int edgeDV[4] = {0, 0, -1, 1};
+					for (int di = 0; di < 4; ++di) {
+						const int nu = iu + edgeDU[di];
+						const int nv = iv + edgeDV[di];
+						if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+							enclosingEdge = true;
+							break;
+						}
+						if (isExteriorEmpty[nu * extentV + nv]) {
+							enclosingEdge = true;
+							break;
+						}
+					}
+					isEdgeArr[flatIdx] = enclosingEdge;
+				} else {
+					bool edge = (iu == 0 || iu == extentU - 1 || iv == 0 || iv == extentV - 1);
+					if (!edge) {
+						edge = (colTopArr[(iu - 1) * extentV + iv] == EMPTY)
+							|| (colTopArr[(iu + 1) * extentV + iv] == EMPTY)
+							|| (colTopArr[iu * extentV + (iv - 1)] == EMPTY)
+							|| (colTopArr[iu * extentV + (iv + 1)] == EMPTY);
+					}
+					isEdgeArr[flatIdx] = edge;
+				}
+			}
+		}
+
+		// Sweep precomputation: for each column, find nearest edge in 4 directions.
+		// Each sweep is O(extentU * extentV), total O(N) instead of O(N * sqrt(N)).
+
+		// Left (-U) and Right (+U) sweeps: for each row iv, sweep along iu (parallel).
+		// fillHoles=true: holes (interior empty) are transparent -- only exterior-empty resets.
+		// fillHoles=false: any empty column resets (current behavior).
+		app::for_parallel(0, extentV, [&](int startIv, int endIv) {
+			for (int iv = startIv; iv < endIv; ++iv) {
+				// Left sweep: iu = 0 to extentU-1
+				int lastEdgeHeight = EMPTY;
+				int lastEdgeDist = 0;
+				for (int iu = 0; iu < extentU; ++iu) {
+					const int flatIdx = iu * extentV + iv;
+					const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+					if (shouldReset) {
+						lastEdgeHeight = EMPTY;
+					} else if (isEdgeArr[flatIdx]) {
+						lastEdgeHeight = colTopArr[flatIdx];
+						lastEdgeDist = 0;
+					}
+					if (lastEdgeHeight != EMPTY) {
+						++lastEdgeDist;
+					}
+					nearEdgeHeightLeft[flatIdx] = lastEdgeHeight;
+					nearEdgeDistLeft[flatIdx] = lastEdgeDist;
+				}
+				// Right sweep: iu = extentU-1 to 0
+				lastEdgeHeight = EMPTY;
+				lastEdgeDist = 0;
+				for (int iu = extentU - 1; iu >= 0; --iu) {
+					const int flatIdx = iu * extentV + iv;
+					const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+					if (shouldReset) {
+						lastEdgeHeight = EMPTY;
+					} else if (isEdgeArr[flatIdx]) {
+						lastEdgeHeight = colTopArr[flatIdx];
+						lastEdgeDist = 0;
+					}
+					if (lastEdgeHeight != EMPTY) {
+						++lastEdgeDist;
+					}
+					nearEdgeHeightRight[flatIdx] = lastEdgeHeight;
+					nearEdgeDistRight[flatIdx] = lastEdgeDist;
+				}
+			}
+		});
+		// Top (-V) and Bottom (+V) sweeps: for each column iu, sweep along iv (parallel).
+		app::for_parallel(0, extentU, [&](int startIu, int endIu) {
+			for (int iu = startIu; iu < endIu; ++iu) {
+				// Top sweep: iv = 0 to extentV-1
+				int lastEdgeHeight = EMPTY;
+				int lastEdgeDist = 0;
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+					if (shouldReset) {
+						lastEdgeHeight = EMPTY;
+					} else if (isEdgeArr[flatIdx]) {
+						lastEdgeHeight = colTopArr[flatIdx];
+						lastEdgeDist = 0;
+					}
+					if (lastEdgeHeight != EMPTY) {
+						++lastEdgeDist;
+					}
+					nearEdgeHeightTop[flatIdx] = lastEdgeHeight;
+					nearEdgeDistTop[flatIdx] = lastEdgeDist;
+				}
+				// Bottom sweep: iv = extentV-1 to 0
+				lastEdgeHeight = EMPTY;
+				lastEdgeDist = 0;
+				for (int iv = extentV - 1; iv >= 0; --iv) {
+					const int flatIdx = iu * extentV + iv;
+					const bool shouldReset = fillHoles ? isExteriorEmpty[flatIdx] : (colTopArr[flatIdx] == EMPTY);
+					if (shouldReset) {
+						lastEdgeHeight = EMPTY;
+					} else if (isEdgeArr[flatIdx]) {
+						lastEdgeHeight = colTopArr[flatIdx];
+						lastEdgeDist = 0;
+					}
+					if (lastEdgeHeight != EMPTY) {
+						++lastEdgeDist;
+					}
+					nearEdgeHeightBottom[flatIdx] = lastEdgeHeight;
+					nearEdgeDistBottom[flatIdx] = lastEdgeDist;
+				}
+			}
+		});
+
+		// Compute target for each interior column using precomputed nearest edges (parallel).
+		// fillHoles=true: also compute targets for interior-hole columns (EMPTY, not exterior-empty).
+		// fillHoles=false: only process solid interior columns.
+		app::for_parallel(0, extentU, [&](int startIu, int endIu) {
+			for (int iu = startIu; iu < endIu; ++iu) {
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					if (fillHoles) {
+						if (isExteriorEmpty[flatIdx] || isEdgeArr[flatIdx]) {
+							continue;
+						}
+					} else {
+						if (colTopArr[flatIdx] == EMPTY || isEdgeArr[flatIdx]) {
+							continue;
+						}
+					}
+
+					const int edgeLeft = nearEdgeHeightLeft[flatIdx];
+					const int distLeft = nearEdgeDistLeft[flatIdx];
+					const int edgeRight = nearEdgeHeightRight[flatIdx];
+					const int distRight = nearEdgeDistRight[flatIdx];
+					const int edgeTop = nearEdgeHeightTop[flatIdx];
+					const int distTop = nearEdgeDistTop[flatIdx];
+					const int edgeBottom = nearEdgeHeightBottom[flatIdx];
+					const int distBottom = nearEdgeDistBottom[flatIdx];
+
+					// Count valid edges
+					int edgeCount = 0;
+					int edgeHeights[4];
+					int edgeDists[4];
+					if (edgeLeft != EMPTY) {
+						edgeHeights[edgeCount] = edgeLeft;
+						edgeDists[edgeCount] = distLeft;
+						++edgeCount;
+					}
+					if (edgeRight != EMPTY) {
+						edgeHeights[edgeCount] = edgeRight;
+						edgeDists[edgeCount] = distRight;
+						++edgeCount;
+					}
+					if (edgeTop != EMPTY) {
+						edgeHeights[edgeCount] = edgeTop;
+						edgeDists[edgeCount] = distTop;
+						++edgeCount;
+					}
+					if (edgeBottom != EMPTY) {
+						edgeHeights[edgeCount] = edgeBottom;
+						edgeDists[edgeCount] = distBottom;
+						++edgeCount;
+					}
+
+					if (edgeCount < 2) {
+						continue;
+					}
+
+					int target;
+					if (interp == SmoothWallInterp::Linear && edgeLeft != EMPTY && edgeRight != EMPTY
+						&& edgeTop != EMPTY && edgeBottom != EMPTY) {
+						// Bilinear: lerp along each axis, then average
+						const int totalU = distLeft + distRight;
+						const int totalV = distTop + distBottom;
+						const int64_t interpU = ((int64_t)edgeLeft * distRight + (int64_t)edgeRight * distLeft
+												  + totalU / 2) / totalU;
+						const int64_t interpV = ((int64_t)edgeTop * distBottom + (int64_t)edgeBottom * distTop
+												  + totalV / 2) / totalV;
+						target = (int)((interpU + interpV + 1) / 2);
+					} else if (interp == SmoothWallInterp::EdgeAware && edgeCount >= 2) {
+						// Edge-aware IDW: weight = 1 / (dist * (1 + gradientAlongAxis)).
+						// Flat-wall axis pairs (small gradient) get stronger influence.
+						const float gradientU = (edgeLeft != EMPTY && edgeRight != EMPTY)
+							? (float)glm::abs(edgeLeft - edgeRight) : 0.0f;
+						const float gradientV = (edgeTop != EMPTY && edgeBottom != EMPTY)
+							? (float)glm::abs(edgeTop - edgeBottom) : 0.0f;
+						float totalWeight = 0.0f;
+						float weightedHeight = 0.0f;
+						if (edgeLeft != EMPTY) {
+							const float w = 1.0f / ((float)distLeft * (1.0f + gradientU));
+							totalWeight += w;
+							weightedHeight += (float)edgeLeft * w;
+						}
+						if (edgeRight != EMPTY) {
+							const float w = 1.0f / ((float)distRight * (1.0f + gradientU));
+							totalWeight += w;
+							weightedHeight += (float)edgeRight * w;
+						}
+						if (edgeTop != EMPTY) {
+							const float w = 1.0f / ((float)distTop * (1.0f + gradientV));
+							totalWeight += w;
+							weightedHeight += (float)edgeTop * w;
+						}
+						if (edgeBottom != EMPTY) {
+							const float w = 1.0f / ((float)distBottom * (1.0f + gradientV));
+							totalWeight += w;
+							weightedHeight += (float)edgeBottom * w;
+						}
+						target = (int)glm::round(weightedHeight / totalWeight);
+					} else {
+						// IDW fallback (also used for Linear when not all 4 edges found)
+						float totalWeight = 0.0f;
+						float weightedHeight = 0.0f;
+						for (int ei = 0; ei < edgeCount; ++ei) {
+							const float w = 1.0f / (float)edgeDists[ei];
+							totalWeight += w;
+							weightedHeight += (float)edgeHeights[ei] * w;
+						}
+						target = (int)glm::round(weightedHeight / totalWeight);
+					}
+
+					targetArr[flatIdx] = glm::clamp(target, axisLo, axisHi);
+				}
+			}
+		});
+
+		// Step 3: Enforce the smooth surface for each interior column (parallel collect, sequential write).
+		struct VoxelOp {
+			glm::ivec3 pos;
+			voxel::Voxel color;
+			bool add;
+		};
+		core::DynamicArray<core::DynamicArray<VoxelOp>> perRowOps(extentU);
+
+		app::for_parallel(0, extentU, [&](int startIu, int endIu) {
+			for (int iu = startIu; iu < endIu; ++iu) {
+				core::DynamicArray<VoxelOp> &ops = perRowOps[iu];
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const int target = targetArr[flatIdx];
+					if (target == EMPTY) {
+						continue;
+					}
+					const bool isInteriorHole = fillHoles && (colTopArr[flatIdx] == EMPTY) && !isExteriorEmpty[flatIdx];
+					const int currentBottom = isInteriorHole ? (positiveUp ? axisLo : axisHi) : colBotArr[flatIdx];
+					if (currentBottom == EMPTY) {
+						continue;
+					}
+					const int coordU = baseU + iu;
+					const int coordV = baseV + iv;
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+
+					if (isInteriorHole) {
+						pos[axisIdx] = target;
+						ops.push_back({pos, fillVoxel, true});
+					} else {
+						const int colTop = colTopArr[flatIdx];
+						const int fillLo = positiveUp ? colTop + 1 : target;
+						const int fillHi = positiveUp ? target : colTop - 1;
+						if (fillLo <= fillHi) {
+							pos[axisIdx] = colTop;
+							voxel::Voxel lastColor = fillVoxel;
+							const voxel::Voxel &edgeVoxel = colorSource.voxel(pos);
+							if (voxel::isBlocked(edgeVoxel.getMaterial())) {
+								lastColor = edgeVoxel;
+							}
+							for (int av = fillLo; av <= fillHi; ++av) {
+								pos[axisIdx] = av;
+								ops.push_back({pos, lastColor, true});
+							}
+						}
+					}
+
+					if (removeAboveDepth > 0 && !isInteriorHole) {
+						const int colTop = colTopArr[flatIdx];
+						const int clearStart = positiveUp ? target + 1 : target - 1;
+						const int clearEnd = positiveUp
+							? glm::min(glm::min(target + removeAboveDepth, axisHi), colTop)
+							: glm::max(glm::max(target - removeAboveDepth, axisLo), colTop);
+						const int clearStep = positiveUp ? 1 : -1;
+						for (int av = clearStart; positiveUp ? (av <= clearEnd) : (av >= clearEnd); av += clearStep) {
+							pos[axisIdx] = av;
+							ops.push_back({pos, voxel::Voxel(), false});
+						}
+					}
+				}
+			}
+		});
+		int totalOps = 0;
+		for (int iu = 0; iu < extentU; ++iu) {
+			totalOps += (int)perRowOps[iu].size();
+		}
+
+		// Reserve addedPositions to avoid catastrophic reallocation
+		// (DynamicArray grows by 32 elements, not doubling — without reserve,
+		// 676K pushes cause ~17K reallocations each copying the full array)
+		addedPositions.reserve(addedPositions.size() + totalOps);
+
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (const VoxelOp &op : perRowOps[iu]) {
+				if (op.add) {
+					solid.setVoxel(op.pos, true);
+					addedPositions.push_back(op.pos);
+					colorSource.setVoxel(op.pos, op.color);
+				} else {
+					solid.setVoxel(op.pos, false);
+					colorSource.setVoxel(op.pos, voxel::Voxel());
+				}
+			}
+		}
+
+		// Step 4: Gap-fill pass (parallel collect, sequential write).
+		// For each column, extend +/-3 toward neighbor heights to close seams.
+		core::DynamicArray<core::DynamicArray<glm::ivec3>> s4PerRowAdds(extentU);
+
+		app::for_parallel(0, extentU, [&](int startIu, int endIu) {
+			for (int iu = startIu; iu < endIu; ++iu) {
+				core::DynamicArray<glm::ivec3> &adds = s4PerRowAdds[iu];
+				for (int iv = 0; iv < extentV; ++iv) {
+					const int flatIdx = iu * extentV + iv;
+					const int myTarget = targetArr[flatIdx];
+					if (myTarget == EMPTY) {
+						continue;
+					}
+					const bool isInteriorHole = fillHoles && (colTopArr[flatIdx] == EMPTY) && !isExteriorEmpty[flatIdx];
+					const int currentBottom = isInteriorHole ? (positiveUp ? axisLo : axisHi) : colBotArr[flatIdx];
+					if (currentBottom == EMPTY) {
+						continue;
+					}
+
+					int neighborMin = myTarget;
+					int neighborMax = myTarget;
+					static constexpr int neighborOffsets[8][2] = {
+						{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}
+					};
+					for (const auto &off : neighborOffsets) {
+						const int nu = iu + off[0];
+						const int nv = iv + off[1];
+						if (nu < 0 || nu >= extentU || nv < 0 || nv >= extentV) {
+							continue;
+						}
+						const int nIdx = nu * extentV + nv;
+						const int nHeight = (targetArr[nIdx] != EMPTY) ? targetArr[nIdx] : colTopArr[nIdx];
+						if (nHeight == EMPTY) {
+							continue;
+						}
+						neighborMin = glm::min(neighborMin, nHeight);
+						neighborMax = glm::max(neighborMax, nHeight);
+					}
+
+					const int fillLo = glm::max(neighborMin, myTarget - 3);
+					const int fillHi = glm::min(neighborMax, myTarget + 3);
+					const int coordU = baseU + iu;
+					const int coordV = baseV + iv;
+					glm::ivec3 pos;
+					pos[uAxis] = coordU;
+					pos[vAxis] = coordV;
+					for (int av = fillLo; av <= fillHi; ++av) {
+						pos[axisIdx] = av;
+						if (!solid.hasValue(pos.x, pos.y, pos.z)) {
+							adds.push_back(pos);
+						}
+					}
+				}
+			}
+		});
+
+		// Count and reserve before writing
+		int s4Total = 0;
+		for (int iu = 0; iu < extentU; ++iu) {
+			s4Total += (int)s4PerRowAdds[iu].size();
+		}
+		addedPositions.reserve(addedPositions.size() + s4Total);
+		for (int iu = 0; iu < extentU; ++iu) {
+			for (const glm::ivec3 &pos : s4PerRowAdds[iu]) {
+				fillSmoothWallVoxel(solid, colorSource, pos, fillVoxel, addedPositions);
+			}
+		}
+	}
+}
+
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles,
+					  core::DynamicArray<glm::ivec3> &addedPositions) {
+	sculptSmoothWallImpl(solid, voxelMap, anchors, face, iterations, fillVoxel, removeAboveDepth, interp, fillHoles, addedPositions);
+}
+
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::RawVolume &colorVolume, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles,
+					  core::DynamicArray<glm::ivec3> &addedPositions) {
+	sculptSmoothWallImpl(solid, colorVolume, anchors, face, iterations, fillVoxel, removeAboveDepth, interp, fillHoles, addedPositions);
+}
+
+
 void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, voxel::FaceNames face,
 						 int planeCoord) {
 	if (face == voxel::FaceNames::Max) {
@@ -1091,7 +1704,8 @@ void sculptSquashToPlane(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap,
 }
 
 void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::RawVolume &skin,
-				  voxel::FaceNames face, const ReskinConfig &config) {
+				  voxel::FaceNames face, const ReskinConfig &config,
+				  const palette::Palette *skinPalette, palette::Palette *targetPalette) {
 	if (face == voxel::FaceNames::Max) {
 		return;
 	}
@@ -1103,16 +1717,59 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 		return;
 	}
 
-	// Determine which skin axis is the outward direction based on config
-	const int skinUpIdx = math::getIndexForAxis(config.skinUpAxis);
-	const int skinUIdx = (skinUpIdx + 1) % 3; // first tiling axis of skin
-	const int skinVIdx = (skinUpIdx + 2) % 3; // second tiling axis of skin
+	// Build color remap table: skin palette index -> target palette index.
+	// Only import colors that are actually used by skin voxels into the target palette.
+	static constexpr int PaletteSize = palette::PaletteMaxColors;
+	bool hasRemap = false;
+	uint8_t colorRemap[PaletteSize];
+	if (skinPalette != nullptr && targetPalette != nullptr) {
+		hasRemap = true;
+		for (int i = 0; i < PaletteSize; ++i) {
+			colorRemap[i] = 0;
+		}
+		// Scan skin volume to find which color indices are actually used
+		bool usedColors[PaletteSize];
+		for (int i = 0; i < PaletteSize; ++i) {
+			usedColors[i] = false;
+		}
+		const glm::ivec3 &sLo = skinRegion.getLowerCorner();
+		const glm::ivec3 &sHi = skinRegion.getUpperCorner();
+		for (int z = sLo.z; z <= sHi.z; ++z) {
+			for (int y = sLo.y; y <= sHi.y; ++y) {
+				for (int x = sLo.x; x <= sHi.x; ++x) {
+					const voxel::Voxel &v = skin.voxel(x, y, z);
+					if (voxel::isBlocked(v.getMaterial())) {
+						usedColors[v.getColor()] = true;
+					}
+				}
+			}
+		}
+		// Only add used colors to the target palette
+		for (int i = 0; i < PaletteSize; ++i) {
+			if (!usedColors[i]) {
+				continue;
+			}
+			const color::RGBA skinColor = skinPalette->color(i);
+			uint8_t targetIdx = 0;
+			if (!targetPalette->tryAdd(skinColor, true, &targetIdx, false)) {
+				// Color already exists or is very similar - tryAdd sets targetIdx
+			}
+			colorRemap[i] = targetIdx;
+		}
+	}
+
+	// Skin axes: skinFace encodes both the depth axis and reading direction.
+	// Skin layer 0 (skinLo on the up axis) is the base placed at the surface; deeper
+	// layers grow outward. The outward world direction is carried by outwardStep.
+	const int skinUpIdx = math::getIndexForAxis(voxel::faceToAxis(config.skinFace));
+	const int skinUIdx = (skinUpIdx + 1) % 3;
+	const int skinVIdx = (skinUpIdx + 2) % 3;
 
 	const glm::ivec3 &skinLo = skinRegion.getLowerCorner();
 	const glm::ivec3 &skinHi = skinRegion.getUpperCorner();
-	const int skinUExtent = skinHi[skinUIdx] - skinLo[skinUIdx] + 1; // tiling dim 1
-	const int skinVExtent = skinHi[skinVIdx] - skinLo[skinVIdx] + 1; // tiling dim 2
-	const int skinDExtent = skinHi[skinUpIdx] - skinLo[skinUpIdx] + 1; // depth dim
+	const int skinUExtent = skinHi[skinUIdx] - skinLo[skinUIdx] + 1;
+	const int skinVExtent = skinHi[skinVIdx] - skinLo[skinVIdx] + 1;
+	const int skinDExtent = skinHi[skinUpIdx] - skinLo[skinUpIdx] + 1;
 
 	const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(face));
 	const int perp1 = (axisIdx + 1) % 3; // U axis
@@ -1140,6 +1797,15 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 	} else {
 		tileW = skinVExtent;
 		tileH = skinUExtent;
+	}
+
+	// In preview mode, limit the applied area to 2x2 tiles
+	int effectiveSelW = selW;
+	int effectiveSelH = selH;
+	if (config.preview) {
+		static constexpr int PreviewTiles = 2;
+		effectiveSelW = glm::min(selW, tileW * PreviewTiles);
+		effectiveSelH = glm::min(selH, tileH * PreviewTiles);
 	}
 
 	// Build surface height map per (u,v) column
@@ -1172,41 +1838,149 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 		}
 	}
 
-	// Compute reference height for None/Median modes
+	// Compute reference height for None mode (flat plane at max/min). Median mode samples
+	// the per-tile footprint locally in the column loop below so each tile sits at its
+	// own local surface median rather than one global plane.
 	int referenceHeight = 0;
-	if (config.follow == ReskinFollow::None || config.follow == ReskinFollow::Median) {
-		core::DynamicArray<int> heights;
-		heights.reserve(numCols);
+	if (config.follow == ReskinFollow::None) {
+		bool anyValid = false;
 		for (int i = 0; i < numCols; ++i) {
-			if (surfaceHeight[i] != EMPTY) {
-				heights.push_back(surfaceHeight[i]);
+			if (surfaceHeight[i] == EMPTY) {
+				continue;
+			}
+			if (!anyValid) {
+				referenceHeight = surfaceHeight[i];
+				anyValid = true;
+			} else if (positiveUp) {
+				referenceHeight = glm::max(referenceHeight, surfaceHeight[i]);
+			} else {
+				referenceHeight = glm::min(referenceHeight, surfaceHeight[i]);
 			}
 		}
-		if (heights.empty()) {
+		if (!anyValid) {
 			return;
 		}
+	}
 
-		if (config.follow == ReskinFollow::None) {
-			referenceHeight = heights[0];
-			for (size_t i = 1; i < heights.size(); ++i) {
-				if (positiveUp) {
-					referenceHeight = glm::max(referenceHeight, heights[i]);
-				} else {
-					referenceHeight = glm::min(referenceHeight, heights[i]);
+	// Corner median: sample the surface depth map in a tile-sized neighborhood centered
+	// on (uCenter, vCenter) and return its median. Used at tile corners - adjacent tiles
+	// share the same (clamped) corner position and thus the same median, so tile edges
+	// meet at the same height. A tile-sized window gives many samples for robust smoothing,
+	// far more than cornerAvgAt's 5x5 neighborhood. Returns false when every sample in the
+	// neighborhood is empty so the caller can substitute a per-column fallback.
+	core::DynamicArray<int> medianScratch;
+	auto cornerMedianAt = [&](int uCenter, int vCenter, float &out) -> bool {
+		medianScratch.clear();
+		const int halfU = tileW / 2;
+		const int halfV = tileH / 2;
+		medianScratch.reserve((2 * halfU + 1) * (2 * halfV + 1));
+		for (int du = -halfU; du <= halfU; ++du) {
+			const int u = uCenter + du;
+			if (u < 0 || u >= selW) {
+				continue;
+			}
+			for (int dv = -halfV; dv <= halfV; ++dv) {
+				const int v = vCenter + dv;
+				if (v < 0 || v >= selH) {
+					continue;
+				}
+				const int idx = u * selH + v;
+				if (surfaceHeight[idx] != EMPTY) {
+					medianScratch.push_back(surfaceHeight[idx]);
 				}
 			}
-		} else {
-			core::sort(heights.begin(), heights.end(), [](int a, int b) { return a < b; });
-			referenceHeight = heights[heights.size() / 2];
 		}
-	}
+		if (medianScratch.empty()) {
+			return false;
+		}
+		core::sort(medianScratch.begin(), medianScratch.end(), [](int a, int b) { return a < b; });
+		out = (float)medianScratch[medianScratch.size() / 2];
+		return true;
+	};
+
+	// Cache corner medians so the 4 corners of N tiles are each computed once.
+	// Key encodes the clamped (uCenter, vCenter) into 64 bits so that two tiles whose
+	// unclamped corners sit at different out-of-bounds positions but clamp to the same
+	// edge share a cache entry. Values can be negative. Only sample-derived medians are
+	// cached; if the neighborhood is empty the per-column fallback is applied at the
+	// caller so we don't leak one column's surface height to another.
+	using CornerMedianMap = core::DynamicMap<int64_t, float, 257, std::hash<int64_t>>;
+	CornerMedianMap cornerMedianCache;
+	auto cornerKey = [](int uCenter, int vCenter) -> int64_t {
+		return ((int64_t)(uint32_t)uCenter << 32) | (int64_t)(uint32_t)vCenter;
+	};
+	auto cornerMedianCached = [&](int uCenter, int vCenter, int fallbackHeight) -> float {
+		const int clampedU = glm::clamp(uCenter, 0, selW - 1);
+		const int clampedV = glm::clamp(vCenter, 0, selH - 1);
+		const int64_t key = cornerKey(clampedU, clampedV);
+		auto iter = cornerMedianCache.find(key);
+		if (iter != cornerMedianCache.end()) {
+			return iter->value;
+		}
+		float m;
+		if (!cornerMedianAt(clampedU, clampedV, m)) {
+			return (float)fallbackHeight;
+		}
+		cornerMedianCache.put(key, m);
+		return m;
+	};
+
+	// Helper to compute average surface height in a small neighborhood around a selection position.
+	// Corners at tile boundaries (including the tile at the far edge) can sit outside the selection.
+	// Individual out-of-bounds samples are skipped rather than clamped so a single tall edge outlier
+	// doesn't get over-weighted. The center itself is clamped into the selection so a corner that
+	// sits fully outside still anchors to the edge the skin actually lands on; if that neighborhood
+	// is still empty (sparse selection), fall back to the caller-supplied per-column surface height.
+	static constexpr int CornerSampleRadius = 2;
+	auto cornerAvgAt = [&](int uCenter, int vCenter, int fallbackHeight) -> float {
+		uCenter = glm::clamp(uCenter, 0, selW - 1);
+		vCenter = glm::clamp(vCenter, 0, selH - 1);
+		int sum = 0;
+		int count = 0;
+		for (int du = -CornerSampleRadius; du <= CornerSampleRadius; ++du) {
+			const int u = uCenter + du;
+			if (u < 0 || u >= selW) {
+				continue;
+			}
+			for (int dv = -CornerSampleRadius; dv <= CornerSampleRadius; ++dv) {
+				const int v = vCenter + dv;
+				if (v < 0 || v >= selH) {
+					continue;
+				}
+				const int idx = u * selH + v;
+				if (surfaceHeight[idx] != EMPTY) {
+					sum += surfaceHeight[idx];
+					++count;
+				}
+			}
+		}
+		if (count == 0) {
+			return (float)fallbackHeight;
+		}
+		return (float)sum / (float)count;
+	};
 
 	// Process each (u,v) column
 	const int maxDepth = glm::min(config.skinDepth, skinDExtent);
 	const voxel::Voxel air;
 
-	for (int uIdx = 0; uIdx < selW; ++uIdx) {
-		for (int vIdx = 0; vIdx < selH; ++vIdx) {
+	// Anchor re-orients the local tile coordinate so that skin(0,0) lands at the chosen
+	// corner of the selection and the tile reads inward from there. distU/distV are the
+	// distance from the anchored corner, based on the true selection size (selW/selH) so
+	// preview and final output agree on where the skin lands.
+	const bool anchorRight =
+		(config.anchor == ReskinAnchor::TopRight || config.anchor == ReskinAnchor::BottomRight);
+	const bool anchorBottom =
+		(config.anchor == ReskinAnchor::BottomLeft || config.anchor == ReskinAnchor::BottomRight);
+	// Shift the preview window toward the anchored corner so the user sees the part of
+	// the selection where the skin actually lands, not a blank area far from the anchor.
+	const int uStart = anchorRight ? (selW - effectiveSelW) : 0;
+	const int vStart = anchorBottom ? (selH - effectiveSelH) : 0;
+	const int uEnd = uStart + effectiveSelW;
+	const int vEnd = vStart + effectiveSelH;
+
+	for (int uIdx = uStart; uIdx < uEnd; ++uIdx) {
+		for (int vIdx = vStart; vIdx < vEnd; ++vIdx) {
 			const int colIdx = uIdx * selH + vIdx;
 			if (surfaceHeight[colIdx] == EMPTY) {
 				continue;
@@ -1217,45 +1991,17 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 			const int surface = surfaceHeight[colIdx];
 
 			// Start height for skin application, with z offset
-			// Positive zOffset = outward (above surface), negative = inward (below surface)
 			const int outwardStep = -inwardStep;
-			int startHeight;
-			if (config.follow == ReskinFollow::Voxel) {
-				startHeight = surface + config.zOffset * outwardStep;
-			} else {
-				startHeight = referenceHeight + config.zOffset * outwardStep;
-			}
 
-			// Map (u,v) to skin coordinates
-			int localU;
-			int localV;
-			switch (config.anchor) {
-			case ReskinAnchor::MinMin:
-				localU = uIdx;
-				localV = vIdx;
-				break;
-			case ReskinAnchor::MinMax:
-				localU = uIdx;
-				localV = selH - 1 - vIdx;
-				break;
-			case ReskinAnchor::MaxMin:
-				localU = selW - 1 - uIdx;
-				localV = vIdx;
-				break;
-			case ReskinAnchor::MaxMax:
-				localU = selW - 1 - uIdx;
-				localV = selH - 1 - vIdx;
-				break;
-			default:
-				localU = uIdx;
-				localV = vIdx;
-				break;
-			}
+			const int distU = anchorRight ? (selW - 1 - uIdx) : uIdx;
+			const int distV = anchorBottom ? (selH - 1 - vIdx) : vIdx;
+			int localU = distU + config.offsetU;
+			int localV = distV + config.offsetV;
 
 			// Apply offset (not for Stretch mode)
-			if (config.tile != ReskinTile::Stretch) {
-				localU += config.offsetU;
-				localV += config.offsetV;
+			if (config.tile == ReskinTile::Stretch) {
+				localU = uIdx;
+				localV = vIdx;
 			}
 
 			// Apply tiling to get position in effective skin space [0, tileW) x [0, tileH)
@@ -1271,20 +2017,21 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 				tV = localV;
 				break;
 			case ReskinTile::Repeat: {
+				// Check max repeat limits
+				if (tileW > 0 && config.maxRepeatU > 0) {
+					const int tileIdxU = localU >= 0 ? localU / tileW : -1;
+					if (tileIdxU >= config.maxRepeatU || tileIdxU < 0) {
+						skipColumn = true;
+					}
+				}
+				if (tileH > 0 && config.maxRepeatV > 0) {
+					const int tileIdxV = localV >= 0 ? localV / tileH : -1;
+					if (tileIdxV >= config.maxRepeatV || tileIdxV < 0) {
+						skipColumn = true;
+					}
+				}
 				tU = ((localU % tileW) + tileW) % tileW;
 				tV = ((localV % tileH) + tileH) % tileH;
-				if (config.mirrorU) {
-					const int tileIdxU = localU >= 0 ? localU / tileW : (localU - tileW + 1) / tileW;
-					if (glm::abs(tileIdxU) % 2 == 1) {
-						tU = tileW - 1 - tU;
-					}
-				}
-				if (config.mirrorV) {
-					const int tileIdxV = localV >= 0 ? localV / tileH : (localV - tileH + 1) / tileH;
-					if (glm::abs(tileIdxV) % 2 == 1) {
-						tV = tileH - 1 - tV;
-					}
-				}
 				break;
 			}
 			case ReskinTile::Stretch:
@@ -1305,8 +2052,59 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 				continue;
 			}
 
+			// Tile corner positions in uIdx/vIdx space. uNear/vNear are the anchor-side
+			// edges (where fu=0 / fv=0), uFar/vFar the opposite edges (shared with the next
+			// tile inward). Adjacent tiles share these corner positions so heights match.
+			const int uNear = anchorRight ? (uIdx + tU) : (uIdx - tU);
+			const int uFar = anchorRight ? (uNear - tileW) : (uNear + tileW);
+			const int vNear = anchorBottom ? (vIdx + tV) : (vIdx - tV);
+			const int vFar = anchorBottom ? (vNear - tileH) : (vNear + tileH);
+			const float fu = (tileW > 1) ? (float)tU / (float)(tileW - 1) : 0.5f;
+			const float fv = (tileH > 1) ? (float)tV / (float)(tileH - 1) : 0.5f;
+
+			// Compute start height based on follow mode
+			int startHeight;
+			if (config.follow == ReskinFollow::Voxel) {
+				startHeight = surface + config.zOffset * outwardStep;
+			} else if (config.follow == ReskinFollow::CornerAverage) {
+				// Per-tile bilinear interpolation: sample surface height at this tile's 4 corners
+				// Adjacent tiles share corners, so they connect seamlessly. Pass the column's own
+				// surface as the fallback so an all-empty corner neighborhood resolves to a sane
+				// height instead of absolute 0.
+				const float h00 = cornerAvgAt(uNear, vNear, surface);
+				const float h10 = cornerAvgAt(uFar, vNear, surface);
+				const float h01 = cornerAvgAt(uNear, vFar, surface);
+				const float h11 = cornerAvgAt(uFar, vFar, surface);
+				const float interpH = h00 * (1.0f - fu) * (1.0f - fv) +
+									  h10 * fu * (1.0f - fv) +
+									  h01 * (1.0f - fu) * fv +
+									  h11 * fu * fv;
+				const int planeH = (int)glm::round(interpH);
+				// Clamp so texture never starts inside the wall
+				startHeight = (positiveUp ? glm::max(planeH, surface) : glm::min(planeH, surface))
+							  + config.zOffset * outwardStep;
+			} else if (config.follow == ReskinFollow::Median) {
+				// Hybrid: sample a tile-sized neighborhood median at each of the 4 tile
+				// corners, then bilinearly interpolate between them. Adjacent tiles share
+				// corners, so heights line up at tile edges; the wide median sampling
+				// smooths over uneven surfaces that would confuse a 4-voxel corner average.
+				// Column surface is the fallback when a corner neighborhood is empty.
+				const float h00 = cornerMedianCached(uNear, vNear, surface);
+				const float h10 = cornerMedianCached(uFar, vNear, surface);
+				const float h01 = cornerMedianCached(uNear, vFar, surface);
+				const float h11 = cornerMedianCached(uFar, vFar, surface);
+				const float interpH = h00 * (1.0f - fu) * (1.0f - fv) +
+									  h10 * fu * (1.0f - fv) +
+									  h01 * (1.0f - fu) * fv +
+									  h11 * fu * fv;
+				const int planeH = (int)glm::round(interpH);
+				startHeight = (positiveUp ? glm::max(planeH, surface) : glm::min(planeH, surface))
+							  + config.zOffset * outwardStep;
+			} else {
+				startHeight = referenceHeight + config.zOffset * outwardStep;
+			}
+
 			// Apply rotation: tiled coords -> skin tiling plane offsets
-			// skinSU/skinSV are 0-based offsets along the skin's U and V axes
 			int skinSU;
 			int skinSV;
 			switch (config.rotation) {
@@ -1332,38 +2130,53 @@ void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const 
 				break;
 			}
 
-			// Step 3: Apply skin layers.
-			// Skin BASE sits at startHeight, layers grow OUTWARD from surface.
-			// d=0 = base of skin (skinLo along up axis), d=N = peak (skinHi along up axis).
+			// Apply skin layers. Base at startHeight, layers grow outward from surface.
 			for (int d = 0; d < maxDepth; ++d) {
 				glm::ivec3 worldPos;
 				worldPos[perp1] = uCoord;
 				worldPos[perp2] = vCoord;
 				worldPos[axisIdx] = startHeight + d * outwardStep;
 
-				// Build skin sample position using axis-independent indexing
 				glm::ivec3 skinPos;
 				skinPos[skinUIdx] = skinLo[skinUIdx] + skinSU;
 				skinPos[skinVIdx] = skinLo[skinVIdx] + skinSV;
+				// Depth d is the distance outward from the surface; the world direction is
+				// already carried by outwardStep. Sample the skin from its base (skinLo) and
+				// grow outward by layer, so skin layer 0 lands on the surface for both
+				// positive and negative faces.
 				skinPos[skinUpIdx] = skinLo[skinUpIdx] + d;
-				const voxel::Voxel skinVoxel = skin.voxel(skinPos.x, skinPos.y, skinPos.z);
-				const bool skinIsSolid = voxel::isBlocked(skinVoxel.getMaterial());
+				const voxel::Voxel rawSkinVoxel = skin.voxel(skinPos.x, skinPos.y, skinPos.z);
+				const bool skinIsSolid = voxel::isBlocked(rawSkinVoxel.getMaterial());
+				// invertSkin flips skin presence: a solid skin cell is treated as absent and
+				// vice versa. The skin color only exists where the skin voxel is really solid,
+				// so an inverted "present" cell (skinIsSolid == false) carries no color and
+				// preserves the existing voxel instead of stamping one.
 				const bool effectiveSolid = config.invertSkin ? !skinIsSolid : skinIsSolid;
+
+				// Remap skin color to target palette if available
+				const voxel::Voxel skinVoxel = (hasRemap && skinIsSolid)
+					? voxel::createVoxel(rawSkinVoxel.getMaterial(), colorRemap[rawSkinVoxel.getColor()],
+										 rawSkinVoxel.getNormal(), rawSkinVoxel.getFlags(),
+										 rawSkinVoxel.getBoneIdx())
+					: rawSkinVoxel;
 
 				switch (config.mode) {
 				case ReskinMode::Replace:
 					if (effectiveSolid) {
-						voxel::Voxel v = skinVoxel;
-						v.setFlags(voxel::FlagOutline);
-						solid.setVoxel(worldPos, true);
-						voxelMap.setVoxel(worldPos, v);
+						if (skinIsSolid) {
+							solid.setVoxel(worldPos, true);
+							voxel::Voxel v = skinVoxel;
+							v.setFlags(voxel::FlagOutline);
+							voxelMap.setVoxel(worldPos, v);
+						}
+						// inverted present cell without a skin color: keep the existing voxel
 					} else {
 						solid.setVoxel(worldPos, false);
 						voxelMap.setVoxel(worldPos, air);
 					}
 					break;
 				case ReskinMode::Blend:
-					if (effectiveSolid) {
+					if (effectiveSolid && skinIsSolid) {
 						voxel::Voxel v = skinVoxel;
 						v.setFlags(voxel::FlagOutline);
 						solid.setVoxel(worldPos, true);
@@ -1573,6 +2386,22 @@ int sculptSmoothGaussian(voxel::RawVolume &volume, const voxel::Region &region, 
 	voxel::BitVolume anchors(anchorRegion);
 	buildFromVolume(volume, region, solid, voxelMap, anchors);
 	sculptSmoothGaussian(solid, voxelMap, anchors, face, kernelSize, sigma, iterations, fillVoxel);
+	return writeResultToVolume(volume, region, solid, voxelMap);
+}
+
+int sculptSmoothWall(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+					 int iterations, const voxel::Voxel &fillVoxel, int removeAboveDepth,
+					 SmoothWallInterp interp, bool fillHoles) {
+	core_trace_scoped(SculptSmoothWallVolume);
+	voxel::BitVolume solid(region);
+	voxel::SparseVolume voxelMap;
+	voxel::Region anchorRegion = region;
+	anchorRegion.grow(1);
+	anchorRegion.cropTo(volume.region());
+	voxel::BitVolume anchors(anchorRegion);
+	buildFromVolume(volume, region, solid, voxelMap, anchors);
+	core::DynamicArray<glm::ivec3> addedPositions;
+	sculptSmoothWall(solid, voxelMap, anchors, face, iterations, fillVoxel, removeAboveDepth, interp, fillHoles, addedPositions);
 	return writeResultToVolume(volume, region, solid, voxelMap);
 }
 

--- a/src/modules/voxelutil/VolumeSculpt.h
+++ b/src/modules/voxelutil/VolumeSculpt.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/collection/DynamicArray.h"
 #include "math/Axis.h"
 #include "voxel/BitVolume.h"
 #include "voxel/Face.h"
@@ -11,12 +12,24 @@
 
 #include <stdint.h>
 
+namespace palette {
+class Palette;
+}
+
 namespace voxel {
 class RawVolume;
 class Region;
 } // namespace voxel
 
 namespace voxelutil {
+
+enum class SmoothWallInterp : uint8_t {
+	Linear,           ///< Bilinear interpolation between opposite edges (constant slope)
+	InverseDistance,   ///< Inverse-distance weighting from 4 coplanar edge columns (smooth curves)
+	EdgeAware,         ///< IDW weighted by height similarity: flat coplanar edges dominate (sharp corners)
+
+	Max
+};
 
 enum class ReskinMode : uint8_t {
 	Replace, ///< Skin solid overwrites surface; skin air removes surface voxels
@@ -27,18 +40,10 @@ enum class ReskinMode : uint8_t {
 };
 
 enum class ReskinFollow : uint8_t {
-	None,   ///< Flat plane at max/min surface height
-	Median, ///< Flat plane at median surface height
-	Voxel,  ///< Per-column surface following
-
-	Max
-};
-
-enum class ReskinAnchor : uint8_t {
-	MinMin, ///< UV origin at min-U, min-V corner
-	MinMax, ///< UV origin at min-U, max-V corner
-	MaxMin, ///< UV origin at max-U, min-V corner
-	MaxMax, ///< UV origin at max-U, max-V corner
+	None,           ///< Flat plane at max/min surface height
+	Median,         ///< Flat plane at median surface height
+	Voxel,          ///< Per-column surface following
+	CornerAverage,  ///< Bilinear interpolation from 4 corner averages
 
 	Max
 };
@@ -60,25 +65,41 @@ enum class ReskinTile : uint8_t {
 	Max
 };
 
+enum class ReskinAnchor : uint8_t {
+	TopLeft,     ///< Skin (0,0) maps to selection min-U, min-V corner
+	TopRight,    ///< Skin (0,0) maps to selection max-U, min-V corner
+	BottomLeft,  ///< Skin (0,0) maps to selection min-U, max-V corner
+	BottomRight, ///< Skin (0,0) maps to selection max-U, max-V corner
+
+	Max
+};
+
 /**
  * @brief Configuration for the reskin sculpt operation.
  */
 struct ReskinConfig {
 	ReskinMode mode = ReskinMode::Blend;
 	ReskinFollow follow = ReskinFollow::Voxel;
-	ReskinAnchor anchor = ReskinAnchor::MinMin;
 	ReskinRotation rotation = ReskinRotation::R0;
 	ReskinTile tile = ReskinTile::Repeat;
-	bool mirrorU = false;
-	bool mirrorV = false;
 	int offsetU = 0;
 	int offsetV = 0;
 	int skinDepth = 1;
 	/// Vertical offset: positive = skin floats above surface, negative = sinks below
 	int zOffset = 0;
 	bool invertSkin = false;
-	/// Which axis of the skin volume is the outward direction (default Y = natural up in editor)
-	math::Axis skinUpAxis = math::Axis::Y;
+	/// Preview mode: only apply a 2x2 tile area for fast feedback
+	bool preview = true;
+	/// Max repeat count for U tiling (0 = unlimited)
+	int maxRepeatU = 0;
+	/// Max repeat count for V tiling (0 = unlimited)
+	int maxRepeatV = 0;
+	/// Which face of the skin volume points outward. Encodes both the depth axis
+	/// and the reading direction (positive = read hi-to-lo, negative = read lo-to-hi).
+	/// Auto-detected from the thinnest axis on load; user can cycle through all 6.
+	voxel::FaceNames skinFace = voxel::FaceNames::PositiveY;
+	/// Which corner of the selection the skin (0,0) maps to
+	ReskinAnchor anchor = ReskinAnchor::TopLeft;
 };
 
 /**
@@ -288,6 +309,54 @@ int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, v
 						int planeCoord);
 
 /**
+ * @brief Smooth wall: interpolate surface heights from edge columns inward.
+ *
+ * The face defines "up" (the surface normal). For each (U,V) column in the selection,
+ * computes a target height by bilinear interpolation from the edge column heights:
+ * - Line 1: interpolate between the heights at (u, v_min) and (u, v_max)
+ * - Line 2: interpolate between the heights at (u_min, v) and (u_max, v)
+ * - Target = average of both lines
+ *
+ * Edge columns (on the boundary) are never modified, ensuring seamless blending with
+ * surrounding geometry. Interior columns are trimmed or filled toward the target.
+ * Each iteration blends partway toward the target to allow gradual convergence.
+ * No gaps are created because column bases are preserved -- only the top is adjusted.
+ *
+ * @param[in,out] solid BitVolume marking solid positions.
+ * @param[in,out] voxelMap Color map kept in sync with @p solid.
+ * @param[in] anchors Immovable solid positions included in height computation.
+ * @param face The face direction that defines the surface normal ("up").
+ * @param iterations Number of smoothing passes. Each pass blends toward the interpolated target.
+ * @param fillVoxel Fallback voxel when no solid neighbor has a color entry.
+ * @param removeAboveDepth How many voxels above the target surface to clear. 0 means
+ *        don't clear anything above the target. Default 0.
+ * @param interp Interpolation mode: Linear, InverseDistance, or EdgeAware.
+ */
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles,
+					  core::DynamicArray<glm::ivec3> &addedPositions);
+
+/**
+ * @brief Smooth wall using RawVolume as color source (fast path -- no SparseVolume allocation).
+ */
+void sculptSmoothWall(voxel::BitVolume &solid, voxel::RawVolume &colorVolume, const voxel::BitVolume &anchors,
+					  voxel::FaceNames face, int iterations, const voxel::Voxel &fillVoxel,
+					  int removeAboveDepth, SmoothWallInterp interp, bool fillHoles,
+					  core::DynamicArray<glm::ivec3> &addedPositions);
+
+
+/**
+ * @brief Smooth wall on a volume region along a face normal.
+ *
+ * @return The number of voxels changed.
+ */
+int sculptSmoothWall(voxel::RawVolume &volume, const voxel::Region &region, voxel::FaceNames face,
+					 int iterations, const voxel::Voxel &fillVoxel, int removeAboveDepth = 0,
+					 SmoothWallInterp interp = SmoothWallInterp::InverseDistance,
+					 bool fillHoles = true);
+
+/**
  * @brief Reskin: apply a skin volume (texture pattern) onto the selected surface.
  *
  * The face defines the surface normal ("up"). The skin volume's +Z axis maps to the
@@ -306,7 +375,9 @@ int sculptSquashToPlane(voxel::RawVolume &volume, const voxel::Region &region, v
  * @param config Reskin configuration parameters.
  */
 void sculptReskin(voxel::BitVolume &solid, voxel::SparseVolume &voxelMap, const voxel::RawVolume &skin,
-				  voxel::FaceNames face, const ReskinConfig &config);
+				  voxel::FaceNames face, const ReskinConfig &config,
+				  const palette::Palette *skinPalette = nullptr,
+				  palette::Palette *targetPalette = nullptr);
 
 /**
  * @brief Reskin on a volume region.

--- a/src/modules/voxelutil/tests/VolumeSculptTest.cpp
+++ b/src/modules/voxelutil/tests/VolumeSculptTest.cpp
@@ -1015,20 +1015,20 @@ TEST_F(VolumeSculptTest, testReskinBlendTiling) {
 		}
 	}
 
-	// 2x2x1 skin: checkerboard pattern
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	// 2x2x1 skin: checkerboard pattern (Y=depth, X=U, Z=V)
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
 	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
-	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
-	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+	skin.setVoxel(0, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 13));
 
 	ReskinConfig config;
 	config.mode = ReskinMode::Blend;
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
-	config.skinUpAxis = math::Axis::Z;
+	config.preview = false;
 
 	const int changed = sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	EXPECT_GT(changed, 0);
@@ -1053,12 +1053,12 @@ TEST_F(VolumeSculptTest, testReskinBlendWithOffset) {
 		}
 	}
 
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
 	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
-	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
-	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+	skin.setVoxel(0, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 13));
 
 	// First apply without offset
 	ReskinConfig config;
@@ -1066,6 +1066,7 @@ TEST_F(VolumeSculptTest, testReskinBlendWithOffset) {
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
+	config.preview = false;
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	const uint8_t colorAtOriginNoOffset = volume.voxel(0, 0, 0).getColor();
 
@@ -1100,16 +1101,16 @@ TEST_F(VolumeSculptTest, testReskinNegateCarves) {
 	}
 
 	// 2x2x1 skin: only one voxel solid (at 0,0,0), rest air
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Negate;
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
+	config.preview = false;
 
 	const int before = countSolid(volume);
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
@@ -1130,17 +1131,17 @@ TEST_F(VolumeSculptTest, testReskinReplaceRemovesWhereAir) {
 	}
 
 	// 2x2x1 skin: only top-left is solid
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
-	// (1,0,0), (0,1,0), (1,1,0) are air
+	// (1,0,0), (0,0,1), (1,0,1) are air
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Replace;
 	config.tile = ReskinTile::Once;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
+	config.preview = false;
 
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	// Only 1 voxel should remain (where skin had solid)
@@ -1159,21 +1160,21 @@ TEST_F(VolumeSculptTest, testReskinFollowSurface) {
 	volume.setVoxel(1, 0, 0, surface);
 	volume.setVoxel(1, 1, 0, surface);
 
-	// 1x1x2 skin: 2 layers deep, both solid with different colors
-	voxel::Region skinRegion(0, 0, 0, 0, 0, 1);
+	// 1x1x2 skin: 2 layers deep, both solid with different colors (Y=depth)
+	voxel::Region skinRegion(0, 0, 0, 0, 1, 0);
 	voxel::RawVolume skin(skinRegion);
-	skin.setVoxel(0, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 20)); // top layer
+	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 20)); // top layer
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 21)); // deeper layer
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Blend;
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 2;
+	config.preview = false;
 
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
-	// Skin base (Z=0, color 21) placed at surface, peak (Z=1, color 20) one layer above.
+	// Skin base (Y=0, color 21) placed at surface, peak (Y=1, color 20) one layer above.
 	// Low column surface at y=0: base goes to y=0
 	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), 21);
 	// High column surface at y=1: base goes to y=1
@@ -1202,12 +1203,12 @@ TEST_F(VolumeSculptTest, testReskinZOffsetNegative) {
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 30));
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Blend;
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
 	config.zOffset = -1;
+	config.preview = false;
 
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	// Surface is y=1. zOffset=-1 shifts down: skin applies at y=0.
@@ -1237,12 +1238,12 @@ TEST_F(VolumeSculptTest, testReskinZOffsetPositive) {
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 30));
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Blend;
 	config.tile = ReskinTile::Repeat;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
 	config.zOffset = 1;
+	config.preview = false;
 
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	// Surface is y=0. zOffset=+1 shifts up: skin applies at y=1 (above surface).
@@ -1266,24 +1267,63 @@ TEST_F(VolumeSculptTest, testReskinInvertSkin) {
 	}
 
 	// 2x2x1 skin: only (0,0,0) is solid
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
 
-	// Negate + Invert: where skin is solid → treated as air → keep. Where air → treated as solid → remove.
+	// Negate + Invert: where skin is solid -> treated as air -> keep. Where air -> treated as solid -> remove.
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Negate;
 	config.tile = ReskinTile::Once;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
 	config.invertSkin = true;
+	config.preview = false;
 
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	// Position (0,0,0) had skin solid → inverted to air → Negate keeps it
 	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial()));
 	// Position (1,0,0) had skin air → inverted to solid → Negate removes it
 	EXPECT_TRUE(voxel::isAir(volume.voxel(1, 0, 0).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testReskinInvertSkinReplace) {
+	// Replace + Invert: skin solid positions are removed, skin air positions keep existing voxels.
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x < 2; ++x) {
+		for (int z = 0; z < 2; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 2x2x1 skin: only (0,0,0) is solid
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
+	voxel::RawVolume skin(skinRegion);
+	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+
+	// Replace + Invert: skin solid → effectiveSolid=false → removed.
+	// Skin air → effectiveSolid=true → existing voxel preserved (no skin color to apply).
+	ReskinConfig config;
+	config.mode = ReskinMode::Replace;
+	config.tile = ReskinTile::Once;
+	config.follow = ReskinFollow::Voxel;
+	config.skinDepth = 1;
+	config.invertSkin = true;
+	config.preview = false;
+
+	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
+	// Position (0,0,0) had skin solid → inverted to air → Replace removes it
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 0, 0).getMaterial()));
+	// Position (1,0,0) had skin air → inverted to solid → existing surface voxel preserved
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 0).getMaterial()));
+	EXPECT_EQ(1, volume.voxel(1, 0, 0).getColor());
+	// Position (0,0,1) had skin air → inverted to solid → existing surface voxel preserved
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 1).getMaterial()));
+	// Position (1,0,1) had skin air → inverted to solid → existing surface voxel preserved
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(1, 0, 1).getMaterial()));
 }
 
 TEST_F(VolumeSculptTest, testReskinNoClipboardNoChange) {
@@ -1303,7 +1343,7 @@ TEST_F(VolumeSculptTest, testReskinNoClipboardNoChange) {
 	voxel::RawVolume skin(skinRegion);
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
+	config.preview = false;
 	const int before = countSolid(volume);
 	sculptReskin(volume, region, skin, voxel::FaceNames::PositiveY, config);
 	EXPECT_EQ(countSolid(volume), before);
@@ -1324,23 +1364,23 @@ TEST_F(VolumeSculptTest, testReskinStretchMode) {
 		}
 	}
 
-	// 2x2x1 skin: quadrants with different colors
-	voxel::Region skinRegion(0, 0, 0, 1, 1, 0);
+	// 2x2x1 skin: quadrants with different colors (Y=depth, X=U, Z=V)
+	voxel::Region skinRegion(0, 0, 0, 1, 0, 1);
 	voxel::RawVolume skin(skinRegion);
 	skin.setVoxel(0, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
 	skin.setVoxel(1, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 11));
-	skin.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 12));
-	skin.setVoxel(1, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+	skin.setVoxel(0, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+	skin.setVoxel(1, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 13));
 
 	ReskinConfig config;
-	config.skinUpAxis = math::Axis::Z;
 	config.mode = ReskinMode::Blend;
 	config.tile = ReskinTile::Stretch;
 	config.follow = ReskinFollow::Voxel;
 	config.skinDepth = 1;
+	config.preview = false;
 
 	sculptReskin(solid, voxelMap, skin, voxel::FaceNames::PositiveY, config);
-	// With PositiveY face: U=Z, V=X. Stretch maps V(X) 0..3 to skin V(Y) 0..1.
+	// With PositiveY face: U=Z, V=X. Stretch maps V(X) 0..3 to skin V(Z) 0..1.
 	// Nearest-neighbor: X=0,1,2 -> skinV=0, X=3 -> skinV=1.
 	// Corner (X=0,Z=0) and corner (X=3,Z=3) should have different colors.
 	const voxel::Voxel v00 = voxelMap.voxel(glm::ivec3(0, 0, 0));
@@ -1353,6 +1393,497 @@ TEST_F(VolumeSculptTest, testReskinStretchMode) {
 	EXPECT_NE(v00.getColor(), v03.getColor());
 	// Opposite corners should differ
 	EXPECT_NE(v00.getColor(), v33.getColor());
+}
+
+TEST_F(VolumeSculptTest, testReskinFollowMedianSharedCorners) {
+	// 8x8 bumpy surface with a tall outlier column. Median follow should smooth the
+	// outlier into a plane rather than spike one column up like Voxel follow would.
+	// PositiveY face: perp1=Z(U), perp2=X(V).
+	voxel::Region region(0, 10);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat 8x8 surface at y=0
+	for (int x = 0; x < 8; ++x) {
+		for (int z = 0; z < 8; ++z) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+	// Single outlier column much higher
+	volume.setVoxel(0, 1, 0, surface);
+	volume.setVoxel(0, 2, 0, surface);
+	volume.setVoxel(0, 3, 0, surface);
+
+	// 4x4 skin, 1 layer deep, single color
+	voxel::Region skinRegion(0, 0, 0, 3, 0, 3);
+	voxel::RawVolume skin(skinRegion);
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			skin.setVoxel(x, 0, z, voxel::createVoxel(voxel::VoxelType::Generic, 50));
+		}
+	}
+
+	ReskinConfig config;
+	config.mode = ReskinMode::Replace;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::Median;
+	config.skinDepth = 1;
+	config.preview = false;
+
+	voxel::Region selRegion(0, 0, 0, 7, 3, 7);
+	sculptReskin(volume, selRegion, skin, voxel::FaceNames::PositiveY, config);
+
+	// The outlier column contributes one sample (out of tileW*tileH=16) to the corner
+	// medians around (0,0), so the median there stays at y=0. The skin should land at
+	// y=0 for most columns, NOT be pulled up to y=3 by the outlier.
+	int skinAtY0 = 0;
+	for (int x = 0; x < 8; ++x) {
+		for (int z = 0; z < 8; ++z) {
+			if (volume.voxel(x, 0, z).getColor() == 50) {
+				++skinAtY0;
+			}
+		}
+	}
+	// Most non-outlier columns should have skin at y=0 (on the median plane).
+	// (There are 63 non-outlier columns out of 64; the outlier column at (0,0) has
+	// surface at y=3 so it clamps upward and won't appear at y=0.)
+	EXPECT_GT(skinAtY0, 50);
+
+	// Adjacent tiles share corners: at the boundary between tile origin (0,0) and
+	// tile origin (0,4) in V (X direction), both tiles sample the same corner at v=4.
+	// So the interpolated height at v=3 (end of tile 0) and v=4 (start of tile 1)
+	// should be very close - no seam.
+	int heightV3 = -1;
+	int heightV4 = -1;
+	for (int y = 0; y < 10; ++y) {
+		if (volume.voxel(3, y, 2).getColor() == 50) {
+			heightV3 = y;
+		}
+		if (volume.voxel(4, y, 2).getColor() == 50) {
+			heightV4 = y;
+		}
+	}
+	EXPECT_GE(heightV3, 0);
+	EXPECT_GE(heightV4, 0);
+	EXPECT_LE(glm::abs(heightV3 - heightV4), 1);
+}
+
+TEST_F(VolumeSculptTest, testReskinAnchorTopRightCorner) {
+	// TopRight anchor + Once tile must place skin(0,0) at the max-U, min-V corner of the
+	// selection in the SAME world position whether in preview or final mode.
+	// Regression: the anchor offset formerly used effectiveSelW-1 which differs between preview
+	// and final, causing the texture to shift between modes.
+	// PositiveY face: perp1=Z(U), perp2=X(V). Selection Z=[0..19] is U axis, X=[0..3] is V axis.
+	voxel::Region region(0, 21);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surface = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int z = 0; z < 20; ++z) {
+		for (int x = 0; x < 4; ++x) {
+			volume.setVoxel(x, 0, z, surface);
+		}
+	}
+
+	// 4x4x1 skin. Rows in skin's U axis (Z) carry distinct colors.
+	voxel::Region skinRegion(0, 0, 0, 3, 0, 3);
+	voxel::RawVolume skin(skinRegion);
+	for (int x = 0; x < 4; ++x) {
+		skin.setVoxel(x, 0, 0, voxel::createVoxel(voxel::VoxelType::Generic, 10));
+		skin.setVoxel(x, 0, 1, voxel::createVoxel(voxel::VoxelType::Generic, 11));
+		skin.setVoxel(x, 0, 2, voxel::createVoxel(voxel::VoxelType::Generic, 12));
+		skin.setVoxel(x, 0, 3, voxel::createVoxel(voxel::VoxelType::Generic, 13));
+	}
+
+	ReskinConfig config;
+	config.mode = ReskinMode::Replace;
+	config.tile = ReskinTile::Once;
+	config.follow = ReskinFollow::Voxel;
+	config.anchor = ReskinAnchor::TopRight;
+	config.skinDepth = 1;
+	config.preview = false;
+
+	voxel::Region selRegion(0, 0, 0, 3, 0, 19);
+	sculptReskin(volume, selRegion, skin, voxel::FaceNames::PositiveY, config);
+
+	// TopRight anchor: skin(0,0) lands at uIdx=selW-1=19 (Z=19), vIdx=0 (X=0).
+	// Skin covers Z=[16..19]. skin col 0 at Z=19, col 3 at Z=16.
+	EXPECT_EQ(volume.voxel(0, 0, 19).getColor(), 10);
+	EXPECT_EQ(volume.voxel(0, 0, 18).getColor(), 11);
+	EXPECT_EQ(volume.voxel(0, 0, 17).getColor(), 12);
+	EXPECT_EQ(volume.voxel(0, 0, 16).getColor(), 13);
+	// Outside the tile footprint (Z<16), surface stays untouched
+	EXPECT_EQ(volume.voxel(0, 0, 0).getColor(), 1);
+	EXPECT_EQ(volume.voxel(0, 0, 15).getColor(), 1);
+
+	// Now repeat in preview mode and verify preview puts skin at the SAME world positions.
+	voxel::RawVolume volume2(region);
+	for (int z = 0; z < 20; ++z) {
+		for (int x = 0; x < 4; ++x) {
+			volume2.setVoxel(x, 0, z, surface);
+		}
+	}
+	config.preview = true;
+	sculptReskin(volume2, selRegion, skin, voxel::FaceNames::PositiveY, config);
+	EXPECT_EQ(volume2.voxel(0, 0, 19).getColor(), 10);
+	EXPECT_EQ(volume2.voxel(0, 0, 18).getColor(), 11);
+	EXPECT_EQ(volume2.voxel(0, 0, 17).getColor(), 12);
+	EXPECT_EQ(volume2.voxel(0, 0, 16).getColor(), 13);
+}
+
+TEST_F(VolumeSculptTest, testReskinCornerOutsideSelectionStaysOnSurface) {
+	// Regression: tile corners that fall outside the selection used to return an absolute-zero
+	// fallback from cornerAvgAt/cornerMedianAt. For a selection at non-zero world Y, that zero
+	// pulled the bilinear interpolation off the surface, making the skin visibly float above
+	// (or below) the actual wall.
+	// Setup: flat surface at y=-5 (so absolute 0 disagrees with the real surface by 5 voxels),
+	// selection width 11 is not a multiple of tileW=4, and offsetU=3 pushes the last tile's
+	// far corner well past the selection edge so the sample neighborhood is entirely OOB.
+	// PositiveY face: perp1=Z(U), perp2=X(V).
+	voxel::Region region(-1, -10, -1, 12, 5, 12);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel surfaceVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	for (int x = 0; x <= 10; ++x) {
+		for (int z = 0; z <= 10; ++z) {
+			volume.setVoxel(x, -5, z, surfaceVoxel);
+		}
+	}
+
+	voxel::Region skinRegion(0, 0, 0, 3, 0, 3);
+	voxel::RawVolume skin(skinRegion);
+	const voxel::Voxel skinVoxel = voxel::createVoxel(voxel::VoxelType::Generic, 50);
+	for (int x = 0; x < 4; ++x) {
+		for (int z = 0; z < 4; ++z) {
+			skin.setVoxel(x, 0, z, skinVoxel);
+		}
+	}
+
+	ReskinConfig config;
+	config.mode = ReskinMode::Replace;
+	config.tile = ReskinTile::Repeat;
+	config.follow = ReskinFollow::CornerAverage;
+	config.anchor = ReskinAnchor::TopLeft;
+	config.offsetU = 3;
+	config.skinDepth = 1;
+	config.zOffset = 0;
+	config.preview = false;
+
+	voxel::Region selRegion(0, -10, 0, 10, 5, 10);
+	sculptReskin(volume, selRegion, skin, voxel::FaceNames::PositiveY, config);
+
+	// The surface is flat at y=-5, so every skin voxel must land exactly there. Before the fix,
+	// columns where the far tile corner was entirely outside the selection saw an interpolated
+	// height pulled toward y=0 and the skin floated above the wall.
+	int skinAtSurface = 0;
+	int skinFloating = 0;
+	for (int x = 0; x <= 10; ++x) {
+		for (int z = 0; z <= 10; ++z) {
+			for (int y = -10; y <= 5; ++y) {
+				if (volume.voxel(x, y, z).getColor() == 50) {
+					if (y == -5) {
+						++skinAtSurface;
+					} else {
+						++skinFloating;
+					}
+				}
+			}
+		}
+	}
+	EXPECT_GT(skinAtSurface, 0);
+	EXPECT_EQ(skinFloating, 0);
+
+	// Same scenario but with Median follow: wider neighborhood, same OOB failure mode.
+	voxel::RawVolume volume2(region);
+	for (int x = 0; x <= 10; ++x) {
+		for (int z = 0; z <= 10; ++z) {
+			volume2.setVoxel(x, -5, z, surfaceVoxel);
+		}
+	}
+	config.follow = ReskinFollow::Median;
+	sculptReskin(volume2, selRegion, skin, voxel::FaceNames::PositiveY, config);
+
+	int medianAtSurface = 0;
+	int medianFloating = 0;
+	for (int x = 0; x <= 10; ++x) {
+		for (int z = 0; z <= 10; ++z) {
+			for (int y = -10; y <= 5; ++y) {
+				if (volume2.voxel(x, y, z).getColor() == 50) {
+					if (y == -5) {
+						++medianAtSurface;
+					} else {
+						++medianFloating;
+					}
+				}
+			}
+		}
+	}
+	EXPECT_GT(medianAtSurface, 0);
+	EXPECT_EQ(medianFloating, 0);
+}
+
+// ---- SmoothWall tests ----
+
+TEST_F(VolumeSculptTest, testSmoothWallFlatWallUnchanged) {
+	// A flat wall should not be modified since edge heights match interior heights
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill a flat slab: X=[1,6], Z=[1,6], Y=3 (face=PositiveY, height is uniform)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+
+	const int beforeCount = countSolid(volume);
+	const int changed = sculptSmoothWall(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)),
+										 voxel::FaceNames::PositiveY, 1, solid);
+	EXPECT_EQ(changed, 0);
+	EXPECT_EQ(countSolid(volume), beforeCount);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallTrimsProtrusion) {
+	// A flat wall with a single column bump in the center should be trimmed
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat slab at Y=3, X=[1,8], Z=[1,8]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 3, 8)), solid);
+	// Add a bump at center (4,4,4) and (4,5,4) -- 2 voxels high above the slab
+	volume.setVoxel(4, 4, 4, solid);
+	volume.setVoxel(4, 5, 4, solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8));
+	const int clearDepth = 256;
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid, clearDepth);
+	EXPECT_GT(changed, 0);
+	// The bump should be trimmed -- the center column should no longer protrude
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 5, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallFillsValley) {
+	// Edges are high, center is low -- center should be filled up toward edge height
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill full slab at Y=[3,5], X=[1,8], Z=[1,8] (height 3 everywhere)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8)), solid);
+	// Dig a valley at center columns: remove Y=5 and Y=4 at (4,*,4)
+	volume.setVoxel(4, 5, 4, voxel::Voxel());
+	volume.setVoxel(4, 4, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 5, 8));
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid);
+	EXPECT_GT(changed, 0);
+	// Center column should have been filled back up toward Y=5
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 5, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallPreservesEdges) {
+	// Edge columns should never be modified even when they differ
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill slab Y=[3,5], X=[1,5], Z=[1,5]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(5, 5, 5)), solid);
+
+	// Record edge column heights before smoothing
+	const bool edgeTopBefore = voxel::isBlocked(volume.voxel(1, 5, 1).getMaterial());
+	const bool edgeBotBefore = voxel::isBlocked(volume.voxel(1, 3, 1).getMaterial());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(5, 5, 5));
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 10, solid);
+
+	// Edge columns (1,*,1) should be unchanged
+	EXPECT_EQ(voxel::isBlocked(volume.voxel(1, 5, 1).getMaterial()), edgeTopBefore);
+	EXPECT_EQ(voxel::isBlocked(volume.voxel(1, 3, 1).getMaterial()), edgeBotBefore);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallClearsFloatingVoxels) {
+	// Floating voxels above the smooth surface should be removed
+	voxel::Region region(0, 9);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Flat slab at Y=3, X=[1,8], Z=[1,8]
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(8, 3, 8)), solid);
+	// Add floating voxels at Y=6 in the center (disconnected from the slab)
+	volume.setVoxel(4, 6, 4, solid);
+	volume.setVoxel(5, 6, 5, solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(8, 7, 8));
+	const int clearDepth = 256;
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, clearDepth);
+	EXPECT_GT(changed, 0);
+	// Floating voxels should be gone -- they are above the smooth target
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 6, 4).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(5, 6, 5).getMaterial()));
+	// Slab should still exist
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallInverseDistanceReducesEdgeJump) {
+	// With a height difference between edges, IDW should produce a smaller
+	// jump at the first interior column compared to linear interpolation.
+	// IDW gives nearby edges much stronger influence (1/dist weighting).
+	voxel::Region region(0, 11);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Linear test: slab X=[1,10], Z=[1,10], left edge Y=3, right edge Y=8
+	voxel::RawVolume volumeLinear(region);
+	for (int zz = 1; zz <= 10; ++zz) {
+		for (int xx = 1; xx <= 10; ++xx) {
+			// Base height at Y=1..3 everywhere
+			fillRegion(volumeLinear, voxel::Region(glm::ivec3(xx, 1, zz), glm::ivec3(xx, 3, zz)), solid);
+		}
+		// Right edge columns taller (Y up to 8)
+		fillRegion(volumeLinear, voxel::Region(glm::ivec3(10, 1, zz), glm::ivec3(10, 8, zz)), solid);
+	}
+	// Copy for IDW test
+	voxel::RawVolume volumeIDW(volumeLinear);
+
+	const voxel::Region selRegion(glm::ivec3(1, 1, 1), glm::ivec3(10, 9, 10));
+	sculptSmoothWall(volumeLinear, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::Linear);
+	sculptSmoothWall(volumeIDW, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance);
+
+	// Find the height of column (X=2, Z=5) -- first interior column near the low edge.
+	// IDW should ease in, producing a height closer to the low edge (3)
+	// than linear interpolation does.
+	int linearHeight = 0;
+	int idwHeight = 0;
+	for (int yy = 9; yy >= 1; --yy) {
+		if (linearHeight == 0 && voxel::isBlocked(volumeLinear.voxel(2, yy, 5).getMaterial())) {
+			linearHeight = yy;
+		}
+		if (idwHeight == 0 && voxel::isBlocked(volumeIDW.voxel(2, yy, 5).getMaterial())) {
+			idwHeight = yy;
+		}
+	}
+	EXPECT_GT(linearHeight, 0);
+	EXPECT_GT(idwHeight, 0);
+	// IDW near the low edge should produce equal or lower height than linear
+	EXPECT_LE(idwHeight, linearHeight);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallEdgeAwareFlatWallUnchanged) {
+	// On a flat wall, all edge heights match interior heights, so EdgeAware
+	// should produce zero changes (same as other modes).
+	voxel::Region region(0, 7);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+
+	const int changed = sculptSmoothWall(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)),
+										 voxel::FaceNames::PositiveY, 1, solid, 0,
+										 voxelutil::SmoothWallInterp::EdgeAware);
+	EXPECT_EQ(changed, 0);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallEdgeAwareFollowsCorner) {
+	// L-shaped wall: left half at Y=3, right half at Y=6.
+	// At the corner column, EdgeAware should favor the coplanar edge that has
+	// the same height, while IDW would average more freely.
+	voxel::Region region(0, 11);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Left half: X=[1,5], Z=[1,10], height Y=1..3
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 1, 1), glm::ivec3(5, 3, 10)), solid);
+	// Right half: X=[6,10], Z=[1,10], height Y=1..6
+	fillRegion(volume, voxel::Region(glm::ivec3(6, 1, 1), glm::ivec3(10, 6, 10)), solid);
+
+	voxel::RawVolume volumeIDW(volume);
+
+	const voxel::Region selRegion(glm::ivec3(1, 1, 1), glm::ivec3(10, 7, 10));
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::EdgeAware);
+	sculptSmoothWall(volumeIDW, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance);
+
+	// Column at (3, *, 5) is interior, left half. Its coplanar left edge (1,*,5)
+	// is at height 3, which matches. EdgeAware should keep it closer to 3.
+	int edgeAwareHeight = 0;
+	int idwHeight = 0;
+	for (int yy = 7; yy >= 1; --yy) {
+		if (edgeAwareHeight == 0 && voxel::isBlocked(volume.voxel(3, yy, 5).getMaterial())) {
+			edgeAwareHeight = yy;
+		}
+		if (idwHeight == 0 && voxel::isBlocked(volumeIDW.voxel(3, yy, 5).getMaterial())) {
+			idwHeight = yy;
+		}
+	}
+	EXPECT_GT(edgeAwareHeight, 0);
+	EXPECT_GT(idwHeight, 0);
+	// EdgeAware should stay closer to the matching edge (height 3)
+	EXPECT_LE(edgeAwareHeight, idwHeight);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallTooSmallSelection) {
+	// Selection smaller than 3x3 in UV should return 0 changes
+	voxel::Region region(0, 5);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// 2-wide slab (too narrow for interior columns)
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(2, 5, 2)), solid);
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(2, 5, 2));
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 5, solid);
+	EXPECT_EQ(changed, 0);
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallFillHolesFilledInteriorHole) {
+	// A ring of solid columns surrounding an empty interior hole.
+	// With fillHoles=true the hole should be filled with interpolated heights.
+	// Layout (top view, face=PositiveY, Y=3):
+	//   X=[1,6], Z=[1,6] ring is solid at Y=3. Center (3,4) empty.
+	voxel::Region region(0, 8);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	// Fill the full slab first, then punch a 2x2 hole in the middle
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+	volume.setVoxel(3, 3, 4, voxel::Voxel());
+	volume.setVoxel(4, 3, 3, voxel::Voxel());
+	volume.setVoxel(4, 3, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6));
+	// fillHoles=true: hole should be filled
+	const int changed = sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+										 voxelutil::SmoothWallInterp::InverseDistance, true);
+	EXPECT_GT(changed, 0);
+	// All four hole positions should now be solid
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(3, 3, 4).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 3).getMaterial()));
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
+}
+
+TEST_F(VolumeSculptTest, testSmoothWallSkipHolesLeavesInteriorHole) {
+	// Same ring setup as above, but with fillHoles=false.
+	// The hole should remain empty -- only solid columns are smoothed.
+	voxel::Region region(0, 8);
+	voxel::RawVolume volume(region);
+	const voxel::Voxel solid = voxel::createVoxel(voxel::VoxelType::Generic, 1);
+
+	fillRegion(volume, voxel::Region(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6)), solid);
+	volume.setVoxel(3, 3, 3, voxel::Voxel());
+	volume.setVoxel(3, 3, 4, voxel::Voxel());
+	volume.setVoxel(4, 3, 3, voxel::Voxel());
+	volume.setVoxel(4, 3, 4, voxel::Voxel());
+
+	const voxel::Region selRegion(glm::ivec3(1, 3, 1), glm::ivec3(6, 3, 6));
+	// fillHoles=false: hole positions must stay empty
+	sculptSmoothWall(volume, selRegion, voxel::FaceNames::PositiveY, 1, solid, 0,
+					 voxelutil::SmoothWallInterp::InverseDistance, false);
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(3, 3, 3).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(3, 3, 4).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 3, 3).getMaterial()));
+	EXPECT_FALSE(voxel::isBlocked(volume.voxel(4, 3, 4).getMaterial()));
 }
 
 } // namespace voxelutil

--- a/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
+++ b/src/tools/voxedit/modules/voxedit-mcp/SculptBrushTool.cpp
@@ -42,12 +42,15 @@ static SculptMode parseSculptMode(const core::String &mode) {
 	if (mode == "reskin") {
 		return SculptMode::Reskin;
 	}
+	if (mode == "smoothwall") {
+		return SculptMode::SmoothWall;
+	}
 	return SculptMode::Erode;
 }
 
 SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	_tool.set("description",
-			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane, Reskin). "
+			  "Sculpt selected voxels with various modes (Erode, Grow, Flatten, SmoothAdditive, SmoothErode, SmoothGaussian, BridgeGap, SquashToPlane, Reskin, SmoothWall). "
 			  "Requires a selection first (use voxedit_select_brush to select voxels before sculpting). "
 			  "Reskin mode applies a skin pattern from the clipboard onto the selected surface.");
 
@@ -69,7 +72,8 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 					   "'smootherode' (smooth by removing), 'smoothgaussian' (Gaussian height blur), "
 				   "'bridgegap' (connect boundary voxels with lines to bridge gaps), "
 				   "'squashtoplane' (project all voxels onto the clicked plane), "
-				   "'reskin' (apply skin pattern from clipboard onto surface)");
+				   "'reskin' (apply skin pattern from clipboard onto surface), "
+				   "'smoothwall' (interpolate surface heights from edge columns to smooth a wall)");
 	json::Json enumArr = json::Json::array();
 	enumArr.push("erode");
 	enumArr.push("grow");
@@ -80,6 +84,7 @@ SculptBrushTool::SculptBrushTool() : BrushTool("voxedit_sculpt_brush") {
 	enumArr.push("bridgegap");
 	enumArr.push("squashtoplane");
 	enumArr.push("reskin");
+	enumArr.push("smoothwall");
 	sculptModeProp.set("enum", enumArr);
 	sculptModeProp.set("default", "erode");
 	properties.set("sculptMode", sculptModeProp);

--- a/src/tools/voxedit/modules/voxedit-ui/BrushPanelCommon.h
+++ b/src/tools/voxedit/modules/voxedit-ui/BrushPanelCommon.h
@@ -25,7 +25,8 @@ inline constexpr const char *ReskinModeStr[] = {NC_("Reskin Modes", "Replace"), 
 static_assert(lengthof(ReskinModeStr) == (int)voxelutil::ReskinMode::Max, "ReskinModeStr size mismatch");
 
 inline constexpr const char *ReskinFollowStr[] = {NC_("Reskin Follow", "None"), NC_("Reskin Follow", "Median"),
-												  NC_("Reskin Follow", "Voxel")};
+												  NC_("Reskin Follow", "Voxel"),
+												  NC_("Reskin Follow", "Corner Average")};
 static_assert(lengthof(ReskinFollowStr) == (int)voxelutil::ReskinFollow::Max, "ReskinFollowStr size mismatch");
 
 inline constexpr const char *ReskinAnchorStr[] = {NC_("Reskin Anchor", "Min/Min"), NC_("Reskin Anchor", "Min/Max"),
@@ -47,6 +48,11 @@ static_assert(lengthof(ReskinSkinAxisStr) == 3, "ReskinSkinAxisStr size mismatch
 inline constexpr const char *VoxelSamplingStr[] = {NC_("Scale Sampling", "Nearest"), NC_("Scale Sampling", "Linear"),
 												   NC_("Scale Sampling", "Cubic")};
 static_assert(lengthof(VoxelSamplingStr) == (int)voxel::VoxelSampling::Max, "VoxelSamplingStr size mismatch");
+
+inline constexpr const char *SmoothWallInterpStr[] = {NC_("Smooth Wall Interp", "Linear"),
+													  NC_("Smooth Wall Interp", "Inverse Distance"),
+													  NC_("Smooth Wall Interp", "Edge Aware")};
+static_assert(lengthof(SmoothWallInterpStr) == (int)voxelutil::SmoothWallInterp::Max, "SmoothWallInterpStr size mismatch");
 
 inline constexpr size_t BrushPanelDeferredTransformThreshold = 10000;
 

--- a/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSculpt.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/brush/BrushPanelSculpt.cpp
@@ -168,6 +168,47 @@ void BrushPanelSculpt::update(BrushPanelContext &ctx, command::CommandExecutionL
 			brush.setSigma(sigma);
 			executeSculptBrush(ctx);
 		}
+	} else if (currentMode == SculptMode::SmoothWall) {
+		// Interpolation mode
+		const voxelutil::SmoothWallInterp interp = brush.smoothWallInterp();
+		if (ImGui::BeginCombo(_("Interpolation"), _(SmoothWallInterpStr[(int)interp]), ImGuiComboFlags_None)) {
+			for (int i = 0; i < (int)voxelutil::SmoothWallInterp::Max; ++i) {
+				const bool selected = i == (int)interp;
+				if (ImGui::Selectable(_(SmoothWallInterpStr[i]), selected)) {
+					brush.setSmoothWallInterp((voxelutil::SmoothWallInterp)i);
+					executeSculptBrush(ctx);
+				}
+				if (selected) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		bool fillHoles = brush.smoothWallFillHoles();
+		if (ImGui::Checkbox(_("Fill holes"), &fillHoles)) {
+			brush.setSmoothWallFillHoles(fillHoles);
+			executeSculptBrush(ctx);
+		}
+		ImGui::SetItemTooltipUnformatted(_("Fill enclosed empty areas with interpolated heights"));
+
+		int clearDepth = brush.smoothWallClearDepth();
+		ImGui::TextUnformatted(_("Clear depth"));
+		if (ImGui::Button("-##smoothwall_clear")) {
+			brush.setSmoothWallClearDepth(clearDepth - 1);
+			executeSculptBrush(ctx);
+		}
+		ImGui::SameLine();
+		if (ImGui::SliderInt("##smoothwall_clear_slider", &clearDepth, 0, SculptBrush::MaxSmoothWallClearDepth)) {
+			brush.setSmoothWallClearDepth(clearDepth);
+			executeSculptBrush(ctx);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("+##smoothwall_clear")) {
+			brush.setSmoothWallClearDepth(clearDepth + 1);
+			executeSculptBrush(ctx);
+		}
+		ImGui::SetItemTooltipUnformatted(_("How many voxels above the smoothed surface to clear (0 = none)"));
 	} else if (currentMode == SculptMode::Reskin) {
 		if (brush.skinVolume() == nullptr) {
 			const glm::vec4 &warningTextColor = style::color(style::StyleColor::ColorWarningText);
@@ -191,27 +232,6 @@ void BrushPanelSculpt::update(BrushPanelContext &ctx, command::CommandExecutionL
 
 		const voxelutil::ReskinConfig &cfg = brush.reskinConfig();
 
-		// Skin up axis combo (which axis of the skin is outward)
-		{
-			static constexpr math::Axis skinAxisValues[] = {math::Axis::X, math::Axis::Y, math::Axis::Z};
-			const int currentAxisIdx = math::getIndexForAxis(cfg.skinUpAxis);
-			if (ImGui::BeginCombo(_("Skin up axis"), _(ReskinSkinAxisStr[currentAxisIdx]), ImGuiComboFlags_None)) {
-				for (int i = 0; i < 3; ++i) {
-					const bool selected = i == currentAxisIdx;
-					if (ImGui::Selectable(_(ReskinSkinAxisStr[i]), selected)) {
-						brush.setReskinSkinUpAxis(skinAxisValues[i]);
-						executeSculptBrush(ctx);
-					}
-					if (selected) {
-						ImGui::SetItemDefaultFocus();
-					}
-				}
-				ImGui::EndCombo();
-			}
-		}
-		ImGui::SetItemTooltipUnformatted(_("Which axis of the skin points outward from the surface. "
-										   "Set to Y if your skin was built with the pattern facing up."));
-
 		// Reskin mode combo
 		if (ImGui::BeginCombo(_("Reskin mode"), _(ReskinModeStr[(int)cfg.mode]), ImGuiComboFlags_None)) {
 			for (int i = 0; i < (int)voxelutil::ReskinMode::Max; ++i) {
@@ -233,21 +253,6 @@ void BrushPanelSculpt::update(BrushPanelContext &ctx, command::CommandExecutionL
 				const bool selected = i == (int)cfg.follow;
 				if (ImGui::Selectable(_(ReskinFollowStr[i]), selected)) {
 					brush.setReskinFollow((voxelutil::ReskinFollow)i);
-					executeSculptBrush(ctx);
-				}
-				if (selected) {
-					ImGui::SetItemDefaultFocus();
-				}
-			}
-			ImGui::EndCombo();
-		}
-
-		// Anchor combo
-		if (ImGui::BeginCombo(_("Anchor"), _(ReskinAnchorStr[(int)cfg.anchor]), ImGuiComboFlags_None)) {
-			for (int i = 0; i < (int)voxelutil::ReskinAnchor::Max; ++i) {
-				const bool selected = i == (int)cfg.anchor;
-				if (ImGui::Selectable(_(ReskinAnchorStr[i]), selected)) {
-					brush.setReskinAnchor((voxelutil::ReskinAnchor)i);
 					executeSculptBrush(ctx);
 				}
 				if (selected) {
@@ -285,21 +290,6 @@ void BrushPanelSculpt::update(BrushPanelContext &ctx, command::CommandExecutionL
 				}
 			}
 			ImGui::EndCombo();
-		}
-
-		// Mirror checkboxes (only for Repeat tile mode)
-		if (cfg.tile == voxelutil::ReskinTile::Repeat) {
-			bool mirrorU = cfg.mirrorU;
-			if (ImGui::Checkbox(_("Mirror U"), &mirrorU)) {
-				brush.setReskinMirrorU(mirrorU);
-				executeSculptBrush(ctx);
-			}
-			ImGui::SameLine();
-			bool mirrorV = cfg.mirrorV;
-			if (ImGui::Checkbox(_("Mirror V"), &mirrorV)) {
-				brush.setReskinMirrorV(mirrorV);
-				executeSculptBrush(ctx);
-			}
 		}
 
 		// Offset sliders (not for Stretch)
@@ -400,6 +390,13 @@ void BrushPanelSculpt::update(BrushPanelContext &ctx, command::CommandExecutionL
 		if (ImGui::Checkbox(_("Extend only"), &extendOnly)) {
 			brush.setExtendOnly(extendOnly);
 		}
+		ImGui::TooltipTextUnformatted(_("Only place voxels adjacent to existing solid voxels"));
+		bool removeOnly = brush.removeOnly();
+		if (ImGui::Checkbox(_("Remove only"), &removeOnly)) {
+			brush.setRemoveOnly(removeOnly);
+		}
+		ImGui::TooltipTextUnformatted(
+			_("Do not place any voxels - only carve away the voxels above the plane (set the Remove above depth)"));
 		int removeDepth = brush.removeAboveDepth();
 		ImGui::TextUnformatted(_("Remove above"));
 		if (ImGui::Button("-##remove_depth")) {

--- a/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/Modifier.cpp
@@ -20,6 +20,7 @@
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxedit-util/modifier/brush/AABBBrush.h"
 #include "voxedit-util/modifier/brush/BrushType.h"
+#include "voxedit-util/modifier/brush/SculptBrush.h"
 #include "voxedit-util/modifier/SceneModifiedFlags.h"
 #include "voxel/Face.h"
 #include "voxel/RawVolume.h"

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/AABBBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/AABBBrush.cpp
@@ -53,7 +53,10 @@ void AABBBrush::reset() {
 	Super::reset();
 	_secondPosValid = false;
 	_boxMode = false;
-	_mode = 0u;
+	// Preserve _mode (AABB/Single/Center) - it is a user preference set via UI commands
+	// (e.g., SelectBrush::setSelectMode(Paint) calls setSingleMode()). Resetting it here
+	// causes a mismatch: the derived brush still shows its mode in the UI, but the
+	// underlying AABBBrush reverts to AABB behavior after a brush type round-trip.
 	_aabbFace = voxel::FaceNames::Max;
 	_aabbFirstPos = glm::ivec3(0);
 	_aabbSecondPos = glm::ivec3(0);

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.cpp
@@ -4,24 +4,35 @@
 
 #include "SculptBrush.h"
 #include "core/GLM.h"
+#include "core/Log.h"
 #include "core/Trace.h"
+#include "core/collection/DynamicArray.h"
 #include "core/collection/DynamicMap.h"
 #include "math/Axis.h"
+#include "palette/Palette.h"
+#include "scenegraph/SceneGraphNode.h"
 #include "voxedit-util/modifier/ModifierVolumeWrapper.h"
 #include "voxel/BitVolume.h"
 #include "voxel/Connectivity.h"
 #include "voxel/DynamicVoxelArray.h"
 #include "voxel/RawVolume.h"
+#include "voxel/RawVolumeWrapper.h"
 #include "voxel/Region.h"
+#include "voxel/SparseVolume.h"
 #include "voxel/Voxel.h"
 #include "voxelutil/VolumeSculpt.h"
+#include "voxelutil/VolumeVisitor.h"
 
 namespace voxedit {
 
 void SculptBrush::onSceneChange() {
 	Super::onSceneChange();
 	_active = false;
-	_snapshotHelper.clear();
+	_hasSnapshot = false;
+	_snapshotEntries.clear();
+	_historyEntries.clear();
+	_historyRegion = voxel::Region::InvalidRegion;
+	_snapshotRegion = voxel::Region::InvalidRegion;
 	_cachedRegion = voxel::Region::InvalidRegion;
 	_cachedRegionValid = false;
 	_planeFitted = false;
@@ -30,16 +41,24 @@ void SculptBrush::onSceneChange() {
 
 void SculptBrush::onActivated() {
 	reset();
-	// Suppress undo registration during preview - only the final commit should create an undo entry
-	_sceneModifiedFlags = SceneModifiedFlags::NoUndo;
+	// Suppress undo registration during preview - only the final commit should create an undo entry.
+	// Also skip InvalidateNodeCache: selection bounding box does not change during sculpt preview,
+	// and regionForFlag() scans the full volume which is very expensive on large models.
+	_sceneModifiedFlags = SceneModifiedFlags::NoUndo & ~SceneModifiedFlags::InvalidateNodeCache;
 }
 
 bool SculptBrush::hasPendingChanges() const {
-	return _snapshotHelper.hasSnapshot();
+	return _hasSnapshot;
 }
 
 voxel::Region SculptBrush::revertChanges(voxel::RawVolume *volume) {
-	return _snapshotHelper.revertChanges(volume);
+	voxel::RawVolumeWrapper wrapper(volume);
+	for (const voxel::VoxelPosition &entry : _historyEntries) {
+		wrapper.setVoxel(entry.pos.x, entry.pos.y, entry.pos.z, entry.voxel);
+	}
+	_historyEntries.clear();
+	_historyRegion = voxel::Region::InvalidRegion;
+	return wrapper.dirtyRegion();
 }
 
 bool SculptBrush::onDeactivated() {
@@ -47,6 +66,8 @@ bool SculptBrush::onDeactivated() {
 	_sceneModifiedFlags = SceneModifiedFlags::All;
 	// Force re-apply so generate() runs and creates a dirty region for the undo entry
 	_paramsDirty = true;
+	// Clear _active so commit()'s beginBrushFromPanel() can succeed
+	_active = false;
 	return hasPendingChanges();
 }
 
@@ -54,10 +75,17 @@ void SculptBrush::reset() {
 	Super::reset();
 	_sceneModifiedFlags = SceneModifiedFlags::All;
 	_active = false;
-	_paramsDirty = true;
-	_snapshotHelper.clear();
+	_paramsDirty = false;
+	_hasSnapshot = false;
+	_snapshotEntries.clear();
+	_historyEntries.clear();
+	_historyRegion = voxel::Region::InvalidRegion;
+	_cachedBitVolumeValid = false;
+	_cachedVoxelMapValid = false;
+	_snapshotRegion = voxel::Region::InvalidRegion;
 	_cachedRegion = voxel::Region::InvalidRegion;
 	_cachedRegionValid = false;
+	_capturedVolumeLower = glm::ivec3(0);
 	_strength = 0.5f;
 	_iterations = 1;
 	_heightThreshold = 1;
@@ -67,13 +95,18 @@ void SculptBrush::reset() {
 	_sigma = 4.0f;
 	_sculptMode = SculptMode::Erode;
 	_flattenFace = voxel::FaceNames::Max;
+	_smoothWallClearDepth = MaxSmoothWallClearDepth;
+	_smoothWallInterp = voxelutil::SmoothWallInterp::InverseDistance;
+	_smoothWallFillHoles = true;
 	_removeAboveDepth = 0;
 	_extendOnly = true;
+	_removeOnly = false;
 	_brushRadius = 3;
 	_planeFitted = false;
 	_planeGradU = 0.0f;
 	_planeGradV = 0.0f;
 	_lastPaintPos = glm::ivec3(INT_MIN);
+	_reskinConfig.preview = true;
 }
 
 bool SculptBrush::beginBrush(const BrushContext &ctx) {
@@ -82,12 +115,17 @@ bool SculptBrush::beginBrush(const BrushContext &ctx) {
 	}
 	const bool needsFace = modeNeedsFace(_sculptMode);
 	if (needsFace && ctx.cursorFace != voxel::FaceNames::Max) {
-		_flattenFace = ctx.cursorFace;
-		if (_sculptMode == SculptMode::SquashToPlane) {
-			const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(ctx.cursorFace));
-			_squashPlaneCoord = ctx.cursorPosition[axisIdx];
+		// Only capture face on first click (when no face is set yet).
+		// Subsequent clicks should not re-trigger the full sculpt calculation.
+		if (_flattenFace == voxel::FaceNames::Max) {
+			_flattenFace = ctx.cursorFace;
+			_paramsDirty = true;
 		}
-		_paramsDirty = true;
+		if (_sculptMode == SculptMode::SquashToPlane) {
+			const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
+			_squashPlaneCoord = ctx.cursorPosition[axisIdx];
+			_paramsDirty = true;
+		}
 	}
 	_active = true;
 	return true;
@@ -99,26 +137,28 @@ void SculptBrush::endBrush(BrushContext &) {
 }
 
 bool SculptBrush::active() const {
-	return _active || _snapshotHelper.hasSnapshot();
+	return _active || _hasSnapshot;
 }
 
 void SculptBrush::preExecute(const BrushContext &ctx, const voxel::RawVolume *volume) {
-	if (!_snapshotHelper.hasSnapshot() && volume != nullptr) {
-		_snapshotHelper.captureSnapshot(volume, ctx.targetVolumeRegion);
-	} else if (_snapshotHelper.hasSnapshot()) {
-		// TODO: this should be handled in the _snapshotHelper - just call setRegion(ctx.targetVolumeRegion) and hide everything else in the class
-		const glm::ivec3 delta = ctx.targetVolumeRegion.getLowerCorner() - _snapshotHelper.capturedVolumeLower();
+	if (!_hasSnapshot && volume != nullptr) {
+		// Defer snapshot capture until there is actually work to do.
+		if (_paramsDirty) {
+			captureSnapshot(volume, ctx.targetVolumeRegion);
+		}
+	} else if (_hasSnapshot) {
+		const glm::ivec3 delta = ctx.targetVolumeRegion.getLowerCorner() - _capturedVolumeLower;
 		if (delta != glm::ivec3(0)) {
-			_snapshotHelper.adjustForRegionShift(delta);
+			adjustSnapshotForRegionShift(delta);
 		}
 	}
-	if (_snapshotHelper.hasSnapshot() && _sculptMode == SculptMode::ExtendPlane && _planeFitted) {
+	if (_hasSnapshot && _sculptMode == SculptMode::ExtendPlane && _planeFitted) {
 		if (_active && ctx.cursorPosition != _lastPaintPos) {
 			_paramsDirty = true;
 		}
 	}
-	if (_snapshotHelper.hasSnapshot()) {
-		_cachedRegion = _snapshotHelper.snapshotRegion();
+	if (_hasSnapshot) {
+		_cachedRegion = _snapshotRegion;
 		if (_sculptMode == SculptMode::Reskin) {
 			// Expand along face normal for z offset + skin layers growing outward
 			const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
@@ -165,89 +205,355 @@ voxel::Region SculptBrush::calcRegion(const BrushContext &ctx) const {
 	if (_cachedRegionValid) {
 		return _cachedRegion;
 	}
+	if (!_hasSnapshot) {
+		return voxel::Region::InvalidRegion;
+	}
 	return ctx.targetVolumeRegion;
+}
+
+void SculptBrush::captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion) {
+	core_trace_scoped(SculptBrushCaptureSnapshot);
+	_snapshotEntries.clear();
+
+	// Use regionForFlag to get tight bounding box of selected voxels first.
+	// This avoids scanning the entire volume (e.g. 256^3 = 16M voxels) when the
+	// selection is a small fraction of the volume (e.g. 100x100x5 = 50K voxels).
+	const voxel::Region selectionBounds = volume->regionForFlag(voxel::FlagOutline);
+	if (!selectionBounds.isValid()) {
+		_hasSnapshot = false;
+		return;
+	}
+
+	// Scan only the tight selection bounding box
+	voxel::Region scanRegion = selectionBounds;
+	scanRegion.cropTo(volRegion);
+
+	// Pre-allocate to avoid repeated reallocations during push_back.
+	// The actual count will be <= voxels in the scan region.
+	_snapshotEntries.reserve(scanRegion.voxels());
+
+	glm::ivec3 selLo(scanRegion.getUpperCorner());
+	glm::ivec3 selHi(scanRegion.getLowerCorner());
+
+	voxelutil::visitVolume(
+		*volume, scanRegion,
+		[&](int x, int y, int z, const voxel::Voxel &voxel) {
+			const glm::ivec3 pos(x, y, z);
+			_snapshotEntries.push_back({pos, voxel});
+			selLo = glm::min(selLo, pos);
+			selHi = glm::max(selHi, pos);
+		},
+		voxelutil::VisitSolidOutline());
+
+	if (_snapshotEntries.empty()) {
+		_hasSnapshot = false;
+		return;
+	}
+
+	_snapshotRegion = voxel::Region(selLo, selHi);
+	_capturedVolumeLower = volRegion.getLowerCorner();
+	_hasSnapshot = true;
+	_cachedBitVolumeValid = false;
+	_cachedVoxelMapValid = false;
+}
+
+void SculptBrush::adjustSnapshotForRegionShift(const glm::ivec3 &delta) {
+	core_trace_scoped(SculptBrushAdjustSnapshotForRegionShift);
+
+	// Shift all snapshot entries in-place
+	for (voxel::VoxelPosition &entry : _snapshotEntries) {
+		entry.pos += delta;
+	}
+
+	_snapshotRegion.shift(delta.x, delta.y, delta.z);
+	_capturedVolumeLower += delta;
+
+	// Shift history entries in-place (flat array, no hash rebuild needed)
+	for (voxel::VoxelPosition &entry : _historyEntries) {
+		entry.pos += delta;
+	}
+	if (_historyRegion.isValid()) {
+		_historyRegion.shift(delta.x, delta.y, delta.z);
+	}
+	_cachedBitVolumeValid = false;
+	_cachedVoxelMapValid = false;
+}
+
+void SculptBrush::saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos) {
+	// O(1) bit test instead of O(N/buckets) hash chain traversal
+	if (_historyRegion.containsPoint(pos) && _historyBits.hasValue(pos.x, pos.y, pos.z)) {
+		return;
+	}
+	if (_historyRegion.containsPoint(pos)) {
+		_historyBits.setVoxel(pos.x, pos.y, pos.z, true);
+	}
+	_historyEntries.push_back({pos, vol->voxel(pos)});
+}
+
+void SculptBrush::writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &newVoxel) {
+	voxel::RawVolume *volume = wrapper.volume();
+	if (!volume->region().containsPoint(pos)) {
+		return;
+	}
+	saveToHistory(volume, pos);
+	if (volume->setVoxel(pos, newVoxel)) {
+		wrapper.addToDirtyRegion(pos);
+	}
+}
+
+void SculptBrush::rebuildCachedBitVolume() {
+	if (_cachedBitVolumeValid) {
+		return;
+	}
+	core_trace_scoped(SculptBrushRebuildBitVolume);
+	_cachedBitVolume = voxel::BitVolume(_snapshotRegion);
+	for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+		_cachedBitVolume.setVoxel(entry.pos.x, entry.pos.y, entry.pos.z, true);
+	}
+	_cachedBitVolumeValid = true;
+	_cachedVoxelMapValid = false;
+}
+
+void SculptBrush::rebuildCachedVoxelMap() {
+	if (_cachedVoxelMapValid) {
+		return;
+	}
+	core_trace_scoped(SculptBrushRebuildVoxelMap);
+	_cachedVoxelMap.clear();
+	for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+		_cachedVoxelMap.setVoxel(entry.pos, entry.voxel);
+	}
+	_cachedVoxelMapValid = true;
 }
 
 void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx) {
 	core_trace_scoped(SculptBrushApplySculpt);
 
-	// For Reskin mode, expand the working region along the face normal to accommodate
-	// the z offset and skin layers growing outward from the surface.
-	voxel::Region workRegion = _snapshotHelper.snapshotRegion();
-	if (_sculptMode == SculptMode::Reskin && _flattenFace != voxel::FaceNames::Max) {
-		const int axisIdx = math::getIndexForAxis(voxel::faceToAxis(_flattenFace));
-		const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
-		glm::ivec3 lo = workRegion.getLowerCorner();
-		glm::ivec3 hi = workRegion.getUpperCorner();
-		lo[axisIdx] -= expand;
-		hi[axisIdx] += expand;
-		// Clamp to volume bounds
-		const voxel::Region &volRegion = wrapper.volume()->region();
-		lo = glm::max(lo, volRegion.getLowerCorner());
-		hi = glm::min(hi, volRegion.getUpperCorner());
-		workRegion = voxel::Region(lo, hi);
+	// Ensure the cached BitVolume is up to date (built from flat _snapshotEntries).
+	rebuildCachedBitVolume();
+
+	// ---- Reskin fast path ----
+	// sculptReskin never reads from voxelMap, only writes. So we skip the expensive O(N)
+	// SparseVolume construction and full write-back. Instead: copy cached BitVolume (cheap
+	// bit memcpy), pass empty voxelMap, and write back only the entries sculptReskin modified.
+	// ---- Reskin: early return when no skin loaded ----
+	if (_sculptMode == SculptMode::Reskin && _skinVolume == nullptr) {
+		return;
 	}
 
-	voxel::BitVolume currentSolid(workRegion);
-	voxel::SparseVolume voxelMap;
-
-	const glm::ivec3 &snapLo = _snapshotHelper.snapshotRegion().getLowerCorner();
-	const glm::ivec3 &snapHi = _snapshotHelper.snapshotRegion().getUpperCorner();
-
-	// Collect snapshot entries: positions + voxels for reuse in write-back phase
-	voxel::DynamicVoxelArray snapshotEntries;
-	snapshotEntries.reserve(_snapshotHelper.snapshotVoxelCount());
-
-	struct SnapshotLoader {
-		voxel::BitVolume *solid;
-		voxel::SparseVolume *voxelMap;
-		voxel::DynamicVoxelArray *entries;
-		bool setVoxel(int x, int y, int z, const voxel::Voxel &v) {
-			const glm::ivec3 pos(x, y, z);
-			solid->setVoxel(x, y, z, true);
-			voxelMap->setVoxel(pos, v);
-			entries->push_back({pos, v});
-			return true;
+	if (_sculptMode == SculptMode::Reskin && _skinVolume != nullptr && _flattenFace != voxel::FaceNames::Max) {
+		// Expand the working BitVolume to accommodate skin layers that protrude
+		// beyond the selection. Without this, out-of-region setVoxel calls are
+		// silently dropped and protruding skin voxels never appear.
+		const int expand = glm::abs(_reskinConfig.zOffset) + _reskinConfig.skinDepth;
+		voxel::Region expandedRegion = _snapshotRegion;
+		expandedRegion.grow(expand);
+		voxel::BitVolume workSolid(expandedRegion);
+		// Copy snapshot bits into the expanded volume
+		for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+			workSolid.setVoxel(entry.pos.x, entry.pos.y, entry.pos.z, true);
 		}
-	};
-	SnapshotLoader loader{&currentSolid, &voxelMap, &snapshotEntries};
-	_snapshotHelper.snapshot().copyTo(loader);
+		voxel::SparseVolume voxelMap;
+
+		const palette::Palette *skinPal = skinPalette();
+		palette::Palette &nodePal = wrapper.node().palette();
+		voxelutil::sculptReskin(workSolid, voxelMap, *_skinVolume, _flattenFace, _reskinConfig,
+							   skinPal, skinPal != nullptr ? &nodePal : nullptr);
+
+		// Write back directly to volume, bypassing per-voxel writeVoxel/saveToHistory overhead.
+		// SparseVolume iteration has no duplicates, so no dedup check needed.
+		// Pre-allocate history to avoid repeated reallocations for large entries.
+		voxel::RawVolume *vol = wrapper.volume();
+		const voxel::Region &volRegion = vol->region();
+		_historyEntries.reserve(voxelMap.size());
+		voxel::Region dirtyRegion;
+		struct ReskinWriter {
+			voxel::RawVolume *vol;
+			const voxel::Region *volRegion;
+			voxel::DynamicVoxelArray *historyEntries;
+			voxel::Region *dirtyRegion;
+			bool setVoxel(int x, int y, int z, const voxel::Voxel &voxel) {
+				if (!volRegion->containsPoint(x, y, z)) {
+					return true;
+				}
+				// Save original voxel to history (flat array, no hash)
+				historyEntries->push_back({glm::ivec3(x, y, z), vol->voxel(x, y, z)});
+				// Write new voxel directly to volume
+				voxel::Voxel v = voxel;
+				if (voxel::isBlocked(v.getMaterial())) {
+					v.setFlags(voxel::FlagOutline);
+				}
+				vol->setVoxel(x, y, z, v);
+				if (dirtyRegion->isValid()) {
+					dirtyRegion->accumulate(x, y, z);
+				} else {
+					*dirtyRegion = voxel::Region(x, y, z, x, y, z);
+				}
+				return true;
+			}
+		};
+		ReskinWriter writer{vol, &volRegion, &_historyEntries, &dirtyRegion};
+		voxelMap.copyTo(writer);
+		// Accumulate dirty bounding box via two corner points (no Region overload exists)
+		if (dirtyRegion.isValid()) {
+			wrapper.addToDirtyRegion(dirtyRegion.getLowerCorner());
+			wrapper.addToDirtyRegion(dirtyRegion.getUpperCorner());
+		}
+		return;
+	}
+
+	// ---- SmoothWall fast path ----
+	// Use a temporary RawVolume (flat array) instead of SparseVolume (hash map).
+	// Population is O(N) array-index writes vs O(N) hash insertions - orders of magnitude faster.
+	if (_sculptMode == SculptMode::SmoothWall && _flattenFace != voxel::FaceNames::Max) {
+		rebuildCachedBitVolume();
+		voxel::BitVolume currentSolid(_cachedBitVolume);
+
+		voxel::RawVolume *vol = wrapper.volume();
+		const voxel::Region &volRegion = vol->region();
+
+		// Build anchors from snapshot entries (O(N) where N = selected voxels)
+		voxel::Region anchorRegion = _snapshotRegion;
+		anchorRegion.grow(1);
+		anchorRegion.cropTo(volRegion);
+		voxel::BitVolume anchorSolid(anchorRegion);
+		for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+			for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+				const glm::ivec3 neighbor = entry.pos + offset;
+				if (currentSolid.hasValue(neighbor.x, neighbor.y, neighbor.z)) {
+					continue;
+				}
+				if (!volRegion.containsPoint(neighbor)) {
+					continue;
+				}
+				const voxel::Voxel &v = vol->voxel(neighbor);
+				if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
+					anchorSolid.setVoxel(neighbor, true);
+				}
+			}
+		}
+		// RawVolume for color data inside the sculpt algorithm: fillSmoothWallVoxel
+		// does 6 neighbor lookups per voxel, O(1) array access vs O(1) amortized hash.
+		// The dense allocation is large but the random-access speed is critical for
+		// step 3 which can do 100M+ lookups.
+		voxel::RawVolume colorVolume(_snapshotRegion);
+		for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+			colorVolume.setVoxel(entry.pos, entry.voxel);
+		}
+		voxel::Voxel fillVoxel = ctx.cursorVoxel;
+		fillVoxel.setFlags(voxel::FlagOutline);
+		static constexpr int smoothWallIterations = 1;
+		core::DynamicArray<glm::ivec3> addedPositions;
+		voxelutil::sculptSmoothWall(currentSolid, colorVolume, anchorSolid, _flattenFace, smoothWallIterations,
+									fillVoxel, _smoothWallClearDepth, _smoothWallInterp, _smoothWallFillHoles,
+									addedPositions);
+		const voxel::Voxel air;
+		voxel::Region dirtyRegion;
+		_historyEntries.reserve(_snapshotEntries.size() + addedPositions.size());
+
+		// Removed entries (was in snapshot, no longer in currentSolid)
+		for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+			if (!currentSolid.hasValue(entry.pos.x, entry.pos.y, entry.pos.z)) {
+				if (!volRegion.containsPoint(entry.pos)) {
+					continue;
+				}
+				saveToHistory(vol, entry.pos);
+				if (vol->setVoxel(entry.pos, air)) {
+					if (dirtyRegion.isValid()) {
+						dirtyRegion.accumulate(entry.pos);
+					} else {
+						dirtyRegion = voxel::Region(entry.pos, entry.pos);
+					}
+				}
+			}
+		}
+		// Added entries: collected during sculptSmoothWall
+		for (const glm::ivec3 &pos : addedPositions) {
+			if (!volRegion.containsPoint(pos)) {
+				continue;
+			}
+			if (!currentSolid.hasValue(pos.x, pos.y, pos.z)) {
+				continue;
+			}
+			const voxel::Voxel &cv = colorVolume.voxel(pos);
+			if (!voxel::isBlocked(cv.getMaterial())) {
+				continue;
+			}
+			voxel::Voxel v = cv;
+			v.setFlags(voxel::FlagOutline);
+			saveToHistory(vol, pos);
+			if (vol->setVoxel(pos, v)) {
+				if (dirtyRegion.isValid()) {
+					dirtyRegion.accumulate(pos);
+				} else {
+					dirtyRegion = voxel::Region(pos, pos);
+				}
+			}
+		}
+		// Single bulk dirty-region update (2 calls instead of N)
+		if (dirtyRegion.isValid()) {
+			wrapper.addToDirtyRegion(dirtyRegion.getLowerCorner());
+			wrapper.addToDirtyRegion(dirtyRegion.getUpperCorner());
+		}
+		return;
+	}
+
+	// ---- Generic path for all other sculpt modes ----
+	voxel::Region workRegion = _snapshotRegion;
+
+	// Erode only writes air to removed positions - it never reads voxel data from voxelMap.
+	// Skip the expensive O(N) SparseVolume construction for it.
+	const bool needsVoxelMap = _sculptMode != SculptMode::Erode;
+
+	// Reuse cached BitVolume (copy is cheap bit memcpy, since sculpt mutates it).
+	// Build cached SparseVolume once and deep-copy on each call.
+	rebuildCachedBitVolume();
+	voxel::BitVolume currentSolid(_cachedBitVolume);
+	voxel::SparseVolume voxelMap;
+	if (needsVoxelMap) {
+		rebuildCachedVoxelMap();
+		_cachedVoxelMap.copyTo(voxelMap);
+	}
 
 	voxel::RawVolume *vol = wrapper.volume();
 	const voxel::Region &volRegion = vol->region();
 
-	// Build anchor set: non-selected solid neighbors that act as immovable constraints.
-	voxel::Region anchorRegion = _snapshotHelper.snapshotRegion();
+	// Build anchor set only for modes that use it
+	const bool needsAnchors = _sculptMode == SculptMode::Erode || _sculptMode == SculptMode::Grow ||
+							  _sculptMode == SculptMode::SmoothAdditive || _sculptMode == SculptMode::SmoothErode ||
+							  _sculptMode == SculptMode::SmoothGaussian || _sculptMode == SculptMode::BridgeGap;
+	voxel::Region anchorRegion = _snapshotRegion;
 	anchorRegion.grow(1);
 	anchorRegion.cropTo(volRegion);
 	voxel::BitVolume anchorSolid(anchorRegion);
-	for (int z = snapLo.z; z <= snapHi.z; ++z) {
-		for (int y = snapLo.y; y <= snapHi.y; ++y) {
-			for (int x = snapLo.x; x <= snapHi.x; ++x) {
-				if (!currentSolid.hasValue(x, y, z)) {
-					continue;
-				}
-				for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-					const glm::ivec3 neighbor = glm::ivec3(x, y, z) + offset;
-					if (currentSolid.hasValue(neighbor.x, neighbor.y, neighbor.z)) {
+	if (needsAnchors) {
+		const glm::ivec3 &snapLo = _snapshotRegion.getLowerCorner();
+		const glm::ivec3 &snapHi = _snapshotRegion.getUpperCorner();
+		for (int z = snapLo.z; z <= snapHi.z; ++z) {
+			for (int y = snapLo.y; y <= snapHi.y; ++y) {
+				for (int x = snapLo.x; x <= snapHi.x; ++x) {
+					if (!currentSolid.hasValue(x, y, z)) {
 						continue;
 					}
-					if (!volRegion.containsPoint(neighbor)) {
-						continue;
-					}
-					const voxel::Voxel &v = vol->voxel(neighbor);
-					if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
-						anchorSolid.setVoxel(neighbor, true);
+					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
+						const glm::ivec3 neighbor = glm::ivec3(x, y, z) + offset;
+						if (currentSolid.hasValue(neighbor.x, neighbor.y, neighbor.z)) {
+							continue;
+						}
+						if (!volRegion.containsPoint(neighbor)) {
+							continue;
+						}
+						const voxel::Voxel &v = vol->voxel(neighbor);
+						if (voxel::isBlocked(v.getMaterial()) && !(v.getFlags() & voxel::FlagOutline)) {
+							anchorSolid.setVoxel(neighbor, true);
+						}
 					}
 				}
 			}
 		}
 	}
 
-	// Save snapshot positions as a BitVolume before sculpt modifies currentSolid.
-	// Used later to distinguish original vs newly grown positions (O(1) bit test).
-	voxel::BitVolume snapshotSolid(currentSolid);
-
+	// Use _cachedBitVolume as snapshot reference (never mutated, avoids a full BitVolume copy).
 	if (_sculptMode == SculptMode::Erode) {
 		voxelutil::sculptErode(currentSolid, voxelMap, anchorSolid, _strength, _iterations);
 	} else if (_sculptMode == SculptMode::Grow) {
@@ -275,35 +581,35 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 		voxelutil::sculptBridgeGap(currentSolid, voxelMap, anchorSolid, fillVoxel);
 	} else if (_sculptMode == SculptMode::SquashToPlane && _flattenFace != voxel::FaceNames::Max) {
 		voxelutil::sculptSquashToPlane(currentSolid, voxelMap, _flattenFace, _squashPlaneCoord);
-	} else if (_sculptMode == SculptMode::Reskin && _skinVolume != nullptr && _flattenFace != voxel::FaceNames::Max) {
-		voxelutil::sculptReskin(currentSolid, voxelMap, *_skinVolume, _flattenFace, _reskinConfig);
 	}
 
-	// Write results using the collected snapshot entries - no hash lookups needed.
-	// Snapshot entries have the original positions and colors. After sculpt,
-	// currentSolid tells us what survived (BitVolume, O(1) bit test).
+	// Write-back: only write entries that actually CHANGED.
+	// - Removed entries (was solid, now not): write air
+	// - Modified entries (in voxelMap with different value): write new value
+	// - Unchanged entries: SKIP (volume already has correct values after history restore)
+	// This reduces 5.6M writes to ~100K for erode, saving massive history hash overhead.
 	const voxel::Voxel air;
 
-	// Pass 1: remove sculpted-away voxels + write surviving snapshot voxels.
-	// Read from voxelMap (not snapshot) so color changes from reskin are applied.
-	// For non-reskin modes, voxelMap entries match the snapshot for surviving positions.
-	for (const voxel::VoxelPosition &entry : snapshotEntries) {
+	// Pass 1: handle snapshot entries (removed or modified by sculpt)
+	for (const voxel::VoxelPosition &entry : _snapshotEntries) {
 		if (!currentSolid.hasValue(entry.pos.x, entry.pos.y, entry.pos.z)) {
-			_snapshotHelper.writeVoxel(wrapper, entry.pos, air);
-		} else if (voxelMap.hasVoxel(entry.pos)) {
-			voxel::Voxel v = voxelMap.voxel(entry.pos);
-			v.setFlags(voxel::FlagOutline);
-			_snapshotHelper.writeVoxel(wrapper, entry.pos, v);
-		} else {
-			voxel::Voxel v = entry.voxel;
-			v.setFlags(voxel::FlagOutline);
-			_snapshotHelper.writeVoxel(wrapper, entry.pos, v);
+			// Removed by sculpt - write air
+			writeVoxel(wrapper, entry.pos, air);
+		} else if (needsVoxelMap && voxelMap.hasVoxel(entry.pos)) {
+			// Check if the voxel was actually modified by comparing with original
+			const voxel::Voxel &mapVoxel = voxelMap.voxel(entry.pos);
+			if (mapVoxel.getColor() != entry.voxel.getColor() ||
+				mapVoxel.getMaterial() != entry.voxel.getMaterial() ||
+				mapVoxel.getNormal() != entry.voxel.getNormal()) {
+				voxel::Voxel v = mapVoxel;
+				v.setFlags(voxel::FlagOutline);
+				writeVoxel(wrapper, entry.pos, v);
+			}
 		}
+		// Else: unchanged, skip - volume already has the correct original value
 	}
 
-	// Pass 2: write newly grown voxels (added by sculpt, not in original snapshot).
-	// Scan the working region (may be expanded for reskin) with O(1) bit tests.
-	// Only new positions need voxelMap hash lookup for color.
+	// Pass 2: write newly grown voxels (not in original snapshot)
 	const glm::ivec3 &workLo = workRegion.getLowerCorner();
 	const glm::ivec3 &workHi = workRegion.getUpperCorner();
 	for (int z = workLo.z; z <= workHi.z; ++z) {
@@ -312,14 +618,14 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 				if (!currentSolid.hasValue(x, y, z)) {
 					continue;
 				}
-				if (snapshotSolid.hasValue(x, y, z)) {
+				if (_cachedBitVolume.hasValue(x, y, z)) {
 					continue;
 				}
 				const glm::ivec3 pos(x, y, z);
 				if (voxelMap.hasVoxel(x, y, z)) {
 					voxel::Voxel v = voxelMap.voxel(x, y, z);
 					v.setFlags(voxel::FlagOutline);
-					_snapshotHelper.writeVoxel(wrapper, pos, v);
+					writeVoxel(wrapper, pos, v);
 				}
 			}
 		}
@@ -328,22 +634,52 @@ void SculptBrush::applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext
 
 void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrapper, const BrushContext &ctx,
 						   const voxel::Region &) {
-	if (!_snapshotHelper.hasSnapshot()) {
+	if (!_hasSnapshot) {
 		return;
 	}
 	if (!_paramsDirty) {
 		return;
 	}
+
 	_paramsDirty = false;
+
+	// Fast path for commit: when MarkUndo is set, the volume already has the
+	// correct data from the NoUndo preview run. Just report the dirty region
+	// from _historyEntries so the undo system records the change.
+	if ((_sceneModifiedFlags & SceneModifiedFlags::MarkUndo) == SceneModifiedFlags::MarkUndo) {
+		if (!_historyEntries.empty()) {
+			for (const voxel::VoxelPosition &entry : _historyEntries) {
+				wrapper.addToDirtyRegion(entry.pos);
+			}
+		}
+		return;
+	}
 
 	// ExtendPlane uses additive painting - no history restore between strokes
 	if (_sculptMode == SculptMode::ExtendPlane) {
 		if (!_planeFitted && _flattenFace != voxel::FaceNames::Max) {
 			fitPlaneFromSnapshot();
+			if (_planeFitted) {
+				// Initialize history tracking for dedup in saveToHistory().
+				// Must happen before any painting so the first write to each position
+				// is recorded as the original value.
+				voxel::RawVolume *vol = wrapper.volume();
+				_historyRegion = _snapshotRegion;
+				_historyRegion.grow(_brushRadius + _removeAboveDepth + 2);
+				_historyRegion.cropTo(vol->region());
+				_historyBits = voxel::BitVolume(_historyRegion);
+			}
 		}
 		if (_planeFitted && _active) {
 			paintExtendPlane(wrapper, ctx);
 			_lastPaintPos = ctx.cursorPosition;
+			markDirty();
+		} else if (_planeFitted && !_active && !_historyEntries.empty()) {
+			// Commit path: _active is false, changes are already in the volume.
+			// Mark all modified positions as dirty so the undo system captures them.
+			for (const voxel::VoxelPosition &entry : _historyEntries) {
+				wrapper.addToDirtyRegion(entry.pos);
+			}
 			markDirty();
 		}
 		return;
@@ -351,11 +687,29 @@ void SculptBrush::generate(scenegraph::SceneGraph &, ModifierVolumeWrapper &wrap
 
 	voxel::RawVolume *vol = wrapper.volume();
 
-	// Restore previously modified state before re-applying
-	_snapshotHelper.restoreHistory(vol, wrapper);
+	// Restore previously modified state from flat history array (O(N) sequential iteration,
+	// no hash chain traversal). This undoes the previous sculpt so we re-apply from scratch.
+	for (const voxel::VoxelPosition &entry : _historyEntries) {
+		if (vol->setVoxel(entry.pos, entry.voxel)) {
+			wrapper.addToDirtyRegion(entry.pos);
+		}
+	}
+	_historyEntries.clear();
+
+	// Skip sculpt when the mode needs a face direction but none is set yet
+	const bool needsFace = modeNeedsFace(_sculptMode);
+	if (needsFace && _flattenFace == voxel::FaceNames::Max) {
+		return;
+	}
+
+	// Initialize history tracking BitVolume for this generate() pass.
+	// Sized to snapshot region + margin for modes that grow outward.
+	_historyRegion = _snapshotRegion;
+	_historyRegion.grow(_iterations + 2);
+	_historyRegion.cropTo(vol->region());
+	_historyBits = voxel::BitVolume(_historyRegion);
 
 	applySculpt(wrapper, ctx);
-	markDirty();
 }
 
 void SculptBrush::fitPlaneFromSnapshot() {
@@ -371,31 +725,21 @@ void SculptBrush::fitPlaneFromSnapshot() {
 	using HeightMap = core::DynamicMap<glm::ivec3, int, 1031, glm::hash<glm::ivec3>>;
 	HeightMap heightMap;
 
-	struct HeightCollector {
-		HeightMap *map;
-		int uAxis;
-		int vAxis;
-		int heightAxis;
-		bool fromPositive;
-		bool setVoxel(int x, int y, int z, const voxel::Voxel &) {
-			const glm::ivec3 pos(x, y, z);
-			glm::ivec3 key(pos);
-			key[heightAxis] = 0;
-			auto it = map->find(key);
-			if (it == map->end()) {
-				map->put(key, pos[heightAxis]);
+	for (const voxel::VoxelPosition &entry : _snapshotEntries) {
+		const glm::ivec3 &pos = entry.pos;
+		glm::ivec3 key(pos);
+		key[_planeHeightAxis] = 0;
+		auto it = heightMap.find(key);
+		if (it == heightMap.end()) {
+			heightMap.put(key, pos[_planeHeightAxis]);
+		} else {
+			if (fromPositive) {
+				it->value = glm::max(it->value, pos[_planeHeightAxis]);
 			} else {
-				if (fromPositive) {
-					it->value = glm::max(it->value, pos[heightAxis]);
-				} else {
-					it->value = glm::min(it->value, pos[heightAxis]);
-				}
+				it->value = glm::min(it->value, pos[_planeHeightAxis]);
 			}
-			return true;
 		}
-	};
-	HeightCollector collector{&heightMap, _planeUAxis, _planeVAxis, _planeHeightAxis, fromPositive};
-	_snapshotHelper.snapshot().copyTo(collector);
+	}
 
 	if (heightMap.empty()) {
 		_planeFitted = false;
@@ -461,7 +805,6 @@ void SculptBrush::paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushCo
 	voxel::RawVolume *vol = wrapper.volume();
 	const voxel::Region &volRegion = vol->region();
 	const bool fromPositive = voxel::isPositiveFace(_flattenFace);
-	const int step = fromPositive ? 1 : -1;
 
 	const int cursorU = ctx.cursorPosition[_planeUAxis];
 	const int cursorV = ctx.cursorPosition[_planeVAxis];
@@ -477,18 +820,7 @@ void SculptBrush::paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushCo
 	static constexpr int uvNeighborDV[] = {0, 0, -1, 1};
 	static constexpr int numUVNeighbors = 4;
 
-	// Precompute removal ray direction (perpendicular to fitted plane)
-	static constexpr float RayStep = 0.5f;
 	const voxel::Voxel air;
-	glm::vec3 removeNormal(0.0f);
-	const float removeLineLen = static_cast<float>(_removeAboveDepth);
-	if (_removeAboveDepth > 0) {
-		removeNormal[_planeUAxis] = -_planeGradU;
-		removeNormal[_planeVAxis] = -_planeGradV;
-		removeNormal[_planeHeightAxis] = 1.0f;
-		removeNormal *= static_cast<float>(step);
-		removeNormal = glm::normalize(removeNormal);
-	}
 
 	for (int u = cursorU - _brushRadius; u <= cursorU + _brushRadius; ++u) {
 		for (int v = cursorV - _brushRadius; v <= cursorV + _brushRadius; ++v) {
@@ -532,55 +864,36 @@ void SculptBrush::paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushCo
 				}
 			}
 
-			// Remove voxels along a thick 3D ray perpendicular to the plane.
-			// Only remove voxels that do NOT have FlagOutline (preserves selected
-			// and newly placed voxels).
+			// Remove voxels above the plane in this column. Iterate along the
+			// height axis from just above the fill span up to removeAboveDepth.
+			// Only removes non-outlined voxels so newly placed / selected voxels
+			// are preserved. Column-based removal avoids the lateral bleed that
+			// the old thick-ray approach caused.
 			if (_removeAboveDepth > 0) {
-				glm::vec3 origin;
-				origin[_planeUAxis] = static_cast<float>(u);
-				origin[_planeVAxis] = static_cast<float>(v);
-				origin[_planeHeightAxis] = static_cast<float>(hiH) + 0.5f * static_cast<float>(step);
-
-				glm::ivec3 prevPos(INT_MIN);
-				for (float t = 0.0f; t <= removeLineLen; t += RayStep) {
-					const glm::vec3 fp = origin + removeNormal * t;
-					const glm::ivec3 pos(static_cast<int>(glm::round(fp.x)),
-										 static_cast<int>(glm::round(fp.y)),
-										 static_cast<int>(glm::round(fp.z)));
-					if (pos == prevPos) {
+				const int clearStart = fromPositive ? hiH + 1 : loH - 1;
+				const int clearEnd = fromPositive
+					? hiH + _removeAboveDepth
+					: loH - _removeAboveDepth;
+				const int clearStep = fromPositive ? 1 : -1;
+				for (int h = clearStart; fromPositive ? (h <= clearEnd) : (h >= clearEnd); h += clearStep) {
+					glm::ivec3 pos;
+					pos[_planeUAxis] = u;
+					pos[_planeVAxis] = v;
+					pos[_planeHeightAxis] = h;
+					if (!volRegion.containsPoint(pos)) {
 						continue;
 					}
-					prevPos = pos;
-					// Clear center + 18 face/edge neighbors, but skip outlined voxels
-					if (volRegion.containsPoint(pos)) {
-						const voxel::Voxel &vx = vol->voxel(pos);
-						if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
-							_snapshotHelper.writeVoxel(wrapper, pos, air);
-						}
-					}
-					for (const glm::ivec3 &offset : voxel::arrayPathfinderFaces) {
-						const glm::ivec3 nPos = pos + offset;
-						if (volRegion.containsPoint(nPos)) {
-							const voxel::Voxel &vx = vol->voxel(nPos);
-							if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
-								_snapshotHelper.writeVoxel(wrapper, nPos, air);
-							}
-						}
-					}
-					for (const glm::ivec3 &offset : voxel::arrayPathfinderEdges) {
-						const glm::ivec3 nPos = pos + offset;
-						if (volRegion.containsPoint(nPos)) {
-							const voxel::Voxel &vx = vol->voxel(nPos);
-							if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
-								_snapshotHelper.writeVoxel(wrapper, nPos, air);
-							}
-						}
+					const voxel::Voxel &vx = vol->voxel(pos);
+					if (!voxel::isAir(vx.getMaterial()) && (vx.getFlags() & voxel::FlagOutline) == 0) {
+						writeVoxel(wrapper, pos, air);
 					}
 				}
 			}
 
-			// Place voxels at predicted plane height
-			if (canPlace) {
+			// Place voxels at predicted plane height. In remove-only mode the brush never
+			// places anything - it just carves away the voxels above the plane (handled by
+			// the remove-above pass above), so skip the placement entirely.
+			if (canPlace && !_removeOnly) {
 				for (int h = loH; h <= hiH; ++h) {
 					glm::ivec3 pos;
 					pos[_planeUAxis] = u;
@@ -606,7 +919,7 @@ void SculptBrush::paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushCo
 								break;
 							}
 						}
-						_snapshotHelper.writeVoxel(wrapper, pos, newVoxel);
+						writeVoxel(wrapper, pos, newVoxel);
 					}
 				}
 			}
@@ -631,30 +944,35 @@ void SculptBrush::setSculptMode(SculptMode mode) {
 	_paramsDirty = true;
 }
 
-void SculptBrush::setReskinSkinUpAxis(math::Axis axis) {
-	_reskinConfig.skinUpAxis = axis;
-	// Re-populate skin depth for the new axis
-	if (_skinVolume != nullptr) {
-		setSkinVolume(_skinVolume);
-	}
-	_paramsDirty = true;
-}
-
 void SculptBrush::setSkinVolume(const voxel::RawVolume *skinVolume) {
 	_skinVolume = skinVolume;
-	// Auto-populate skin depth from the skin volume's depth along the configured up axis
 	if (skinVolume != nullptr) {
 		const voxel::Region &sr = skinVolume->region();
-		const int upIdx = math::getIndexForAxis(_reskinConfig.skinUpAxis);
-		const int depthExtent = sr.getUpperCorner()[upIdx] - sr.getLowerCorner()[upIdx] + 1;
+		const glm::ivec3 extents = sr.getUpperCorner() - sr.getLowerCorner() + 1;
+		// Auto-detect depth axis from thinnest dimension (positive face = outward)
+		if (extents.x <= extents.y && extents.x <= extents.z) {
+			_reskinConfig.skinFace = voxel::FaceNames::PositiveX;
+		} else if (extents.z <= extents.x && extents.z <= extents.y) {
+			_reskinConfig.skinFace = voxel::FaceNames::PositiveZ;
+		} else {
+			_reskinConfig.skinFace = voxel::FaceNames::PositiveY;
+		}
+		const int upIdx = math::getIndexForAxis(voxel::faceToAxis(_reskinConfig.skinFace));
+		const int depthExtent = extents[upIdx];
 		_reskinConfig.skinDepth = glm::clamp(depthExtent, 1, MaxReskinDepth);
 	}
 	_paramsDirty = true;
 }
 
-void SculptBrush::setOwnedSkinVolume(voxel::RawVolume *skinVolume, const core::String &filePath) {
+void SculptBrush::setOwnedSkinVolume(voxel::RawVolume *skinVolume, const core::String &filePath,
+									 const palette::Palette *skinPalette) {
 	_ownedSkinVolume = skinVolume;
 	_skinFilePath = filePath;
+	if (skinPalette != nullptr) {
+		_skinPalette = *skinPalette;
+	} else {
+		_skinPalette = {};
+	}
 	setSkinVolume(skinVolume);
 }
 

--- a/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
+++ b/src/tools/voxedit/modules/voxedit-util/modifier/brush/SculptBrush.h
@@ -9,9 +9,14 @@
 #include "app/I18N.h"
 #include "core/ArrayLength.h"
 #include "core/GLM.h"
+#include "core/Optional.h"
 #include "core/ScopedPtr.h"
 #include "ui/IconsLucide.h"
 #include "core/String.h"
+#include "palette/Palette.h"
+#include "voxel/BitVolume.h"
+#include "voxel/DynamicVoxelArray.h"
+#include "voxel/SparseVolume.h"
 #include "voxel/Face.h"
 #include "voxel/Voxel.h"
 #include "voxelutil/VolumeSculpt.h"
@@ -32,6 +37,7 @@ enum class SculptMode : uint8_t {
 	SmoothAdditive,
 	SmoothErode,
 	SmoothGaussian,
+	SmoothWall,
 	BridgeGap,
 	SquashToPlane,
 	ExtendPlane,
@@ -42,17 +48,18 @@ enum class SculptMode : uint8_t {
 
 // clang-format off
 static constexpr const char *SculptModeStr[] = {
-	NC_("Sculpt Modes", "Erode"),        NC_("Sculpt Modes", "Grow"),
-	NC_("Sculpt Modes", "Flatten"),      NC_("Sculpt Modes", "Smooth Additive"),
-	NC_("Sculpt Modes", "Smooth Erode"), NC_("Sculpt Modes", "Smooth Gaussian"),
-	NC_("Sculpt Modes", "Bridge Gap"),   NC_("Sculpt Modes", "Squash to Plane"),
-	NC_("Sculpt Modes", "Extend Plane"), NC_("Sculpt Modes", "Reskin")};
+	NC_("Sculpt Modes", "Erode"),         NC_("Sculpt Modes", "Grow"),
+	NC_("Sculpt Modes", "Flatten"),       NC_("Sculpt Modes", "Smooth Additive"),
+	NC_("Sculpt Modes", "Smooth Erode"),  NC_("Sculpt Modes", "Smooth Gaussian"),
+	NC_("Sculpt Modes", "Smooth Wall"),   NC_("Sculpt Modes", "Bridge Gap"),
+	NC_("Sculpt Modes", "Squash to Plane"), NC_("Sculpt Modes", "Extend Plane"),
+	NC_("Sculpt Modes", "Reskin")};
 static_assert(lengthof(SculptModeStr) == (int)SculptMode::Max, "SculptModeStr size mismatch");
 
-static constexpr const char *SculptModeIcons[] = {ICON_LC_ERASER, ICON_LC_SPROUT,    ICON_LC_LAND_PLOT,
-                                                  ICON_LC_WAVES,  ICON_LC_WAVES,     ICON_LC_BLEND,
-                                                  ICON_LC_LINK,   ICON_LC_MINIMIZE_2, ICON_LC_EXPAND,
-                                                  ICON_LC_PALETTE};
+static constexpr const char *SculptModeIcons[] = {ICON_LC_ERASER,    ICON_LC_SPROUT,     ICON_LC_LAND_PLOT,
+                                                  ICON_LC_WAVES,     ICON_LC_WAVES,      ICON_LC_BLEND,
+                                                  ICON_LC_BRICK_WALL, ICON_LC_LINK,      ICON_LC_MINIMIZE_2,
+                                                  ICON_LC_EXPAND,    ICON_LC_PALETTE};
 static_assert(lengthof(SculptModeIcons) == (int)SculptMode::Max, "SculptModeIcons size mismatch");
 // clang-format on
 
@@ -77,14 +84,20 @@ private:
 	int _trimPerStep = 1;
 	int _kernelSize = 4;
 	float _sigma = 4.0f;
+	int _smoothWallClearDepth = MaxSmoothWallClearDepth; ///< 0 = don't clear, max = clear entire depth
+	voxelutil::SmoothWallInterp _smoothWallInterp = voxelutil::SmoothWallInterp::InverseDistance;
+	bool _smoothWallFillHoles = true; ///< Fill enclosed empty areas with interpolated heights
 	voxel::FaceNames _flattenFace = voxel::FaceNames::Max;
 	int _squashPlaneCoord = 0;
 	bool _active = false;
+	bool _hasSnapshot = false;
 	bool _paramsDirty = true;
 
 	// ExtendPlane parameters
 	int _removeAboveDepth = 0;
 	bool _extendOnly = true;
+	/** When set, ExtendPlane only removes voxels above the plane and never places new ones. */
+	bool _removeOnly = false;
 	int _brushRadius = 3;
 	float _planeGradU = 0.0f;
 	float _planeGradV = 0.0f;
@@ -102,14 +115,43 @@ private:
 	const voxel::RawVolume *_skinVolume = nullptr;
 	core::ScopedPtr<voxel::RawVolume> _ownedSkinVolume;
 	core::String _skinFilePath;
+	core::Optional<palette::Palette> _skinPalette;
 
-	SnapshotHelper _snapshotHelper;
+	// Original selected voxels captured at brush activation, stored as a flat array.
+	// Using DynamicVoxelArray instead of SparseVolume avoids O(N) hash insertions.
+	voxel::DynamicVoxelArray _snapshotEntries;
+	// Selection bounding box at capture time
+	voxel::Region _snapshotRegion;
+	// Volume region lower corner at snapshot capture time (to detect region shifts)
+	glm::ivec3 _capturedVolumeLower{0};
+
+	// Per-generate bookkeeping: tracks positions written during a single generate()
+	// call so the previous state can be restored before re-applying.
+	// Using BitVolume + flat array instead of SparseVolume avoids O(N) hash chain traversal
+	// per lookup/insert. For 5M+ entries this reduces history operations from ~30s to ~50ms.
+	voxel::DynamicVoxelArray _historyEntries;
+	voxel::BitVolume _historyBits;
+	voxel::Region _historyRegion;
+
+	// Cached data structures built from snapshot entries. Rebuilt when snapshot changes.
+	// Avoids rebuilding O(N) hash maps and bit arrays every frame.
+	bool _cachedBitVolumeValid = false;
+	voxel::BitVolume _cachedBitVolume;
+	voxel::SparseVolume _cachedVoxelMap;
+	bool _cachedVoxelMapValid = false;
+
+	void rebuildCachedBitVolume();
+	void rebuildCachedVoxelMap();
 
 	// Cached region for preview
 	voxel::Region _cachedRegion;
 	bool _cachedRegionValid = false;
 
+	void captureSnapshot(const voxel::RawVolume *volume, const voxel::Region &volRegion);
+	void adjustSnapshotForRegionShift(const glm::ivec3 &delta);
 	void applySculpt(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
+	void saveToHistory(voxel::RawVolume *vol, const glm::ivec3 &pos);
+	void writeVoxel(ModifierVolumeWrapper &wrapper, const glm::ivec3 &pos, const voxel::Voxel &voxel);
 	void fitPlaneFromSnapshot();
 	void paintExtendPlane(ModifierVolumeWrapper &wrapper, const BrushContext &ctx);
 
@@ -177,33 +219,47 @@ public:
 	float sigma() const;
 	void setSigma(float sigma);
 
+	// SmoothWall accessors
+	static constexpr int MaxSmoothWallClearDepth = 256;
+	int smoothWallClearDepth() const;
+	void setSmoothWallClearDepth(int depth);
+	voxelutil::SmoothWallInterp smoothWallInterp() const;
+	void setSmoothWallInterp(voxelutil::SmoothWallInterp interp);
+	bool smoothWallFillHoles() const;
+	void setSmoothWallFillHoles(bool fillHoles);
+
 	// ExtendPlane accessors
 	static constexpr int MaxBrushRadius = 32;
-	static constexpr int MaxRemoveAboveDepth = 32;
+	static constexpr int MaxRemoveAboveDepth = 64;
 	int removeAboveDepth() const;
 	void setRemoveAboveDepth(int depth);
 	bool extendOnly() const;
 	void setExtendOnly(bool extend);
+	bool removeOnly() const;
+	void setRemoveOnly(bool removeOnly);
 	int brushRadius() const;
 	void setBrushRadius(int radius);
 	bool planeFitted() const;
 
 	// Reskin accessors
 	static constexpr int MaxReskinDepth = 32;
+	static constexpr int MaxReskinRepeat = 64;
 	const voxelutil::ReskinConfig &reskinConfig() const;
 	void setReskinMode(voxelutil::ReskinMode mode);
 	void setReskinFollow(voxelutil::ReskinFollow follow);
-	void setReskinAnchor(voxelutil::ReskinAnchor anchor);
 	void setReskinRotation(voxelutil::ReskinRotation rotation);
 	void setReskinTile(voxelutil::ReskinTile tile);
-	void setReskinMirrorU(bool mirror);
-	void setReskinMirrorV(bool mirror);
 	void setReskinOffsetU(int offset);
 	void setReskinOffsetV(int offset);
 	void setReskinSkinDepth(int depth);
 	void setReskinZOffset(int offset);
 	void setReskinInvertSkin(bool invert);
-	void setReskinSkinUpAxis(math::Axis axis);
+	void cycleReskinFace();
+	void cycleReskinAnchor();
+	void setReskinPreview(bool preview);
+	void setReskinMaxRepeatU(int count);
+	void setReskinMaxRepeatV(int count);
+	void setReskinSkinFace(voxel::FaceNames face);
 
 	/**
 	 * @brief Set the skin volume for reskin mode.
@@ -214,10 +270,12 @@ public:
 	/**
 	 * @brief Set an owned skin volume loaded from a file. The brush takes ownership.
 	 */
-	void setOwnedSkinVolume(voxel::RawVolume *skinVolume, const core::String &filePath);
+	void setOwnedSkinVolume(voxel::RawVolume *skinVolume, const core::String &filePath,
+							const palette::Palette *skinPalette = nullptr);
 
 	const voxel::RawVolume *skinVolume() const;
 	const core::String &skinFilePath() const;
+	const palette::Palette *skinPalette() const;
 };
 
 inline bool SculptBrush::managesOwnSelection() const {
@@ -231,7 +289,7 @@ inline bool SculptBrush::wantsContinuousExecution() const {
 inline bool SculptBrush::modeNeedsFace(SculptMode mode) {
 	return mode == SculptMode::Flatten || mode == SculptMode::SmoothAdditive || mode == SculptMode::SmoothErode ||
 		   mode == SculptMode::SmoothGaussian || mode == SculptMode::SquashToPlane || mode == SculptMode::ExtendPlane ||
-		   mode == SculptMode::Reskin;
+		   mode == SculptMode::Reskin || mode == SculptMode::SmoothWall;
 }
 
 inline SculptMode SculptBrush::sculptMode() const {
@@ -257,7 +315,7 @@ inline void SculptBrush::setIterations(int iterations) {
 }
 
 inline bool SculptBrush::hasSnapshot() const {
-	return _snapshotHelper.hasSnapshot();
+	return _hasSnapshot;
 }
 
 inline voxel::FaceNames SculptBrush::flattenFace() const {
@@ -309,6 +367,33 @@ inline void SculptBrush::setSigma(float sigma) {
 	_paramsDirty = true;
 }
 
+inline int SculptBrush::smoothWallClearDepth() const {
+	return _smoothWallClearDepth;
+}
+
+inline void SculptBrush::setSmoothWallClearDepth(int depth) {
+	_smoothWallClearDepth = glm::clamp(depth, 0, MaxSmoothWallClearDepth);
+	_paramsDirty = true;
+}
+
+inline voxelutil::SmoothWallInterp SculptBrush::smoothWallInterp() const {
+	return _smoothWallInterp;
+}
+
+inline void SculptBrush::setSmoothWallInterp(voxelutil::SmoothWallInterp interp) {
+	_smoothWallInterp = interp;
+	_paramsDirty = true;
+}
+
+inline bool SculptBrush::smoothWallFillHoles() const {
+	return _smoothWallFillHoles;
+}
+
+inline void SculptBrush::setSmoothWallFillHoles(bool fillHoles) {
+	_smoothWallFillHoles = fillHoles;
+	_paramsDirty = true;
+}
+
 inline const voxelutil::ReskinConfig &SculptBrush::reskinConfig() const {
 	return _reskinConfig;
 }
@@ -323,11 +408,6 @@ inline void SculptBrush::setReskinFollow(voxelutil::ReskinFollow follow) {
 	_paramsDirty = true;
 }
 
-inline void SculptBrush::setReskinAnchor(voxelutil::ReskinAnchor anchor) {
-	_reskinConfig.anchor = anchor;
-	_paramsDirty = true;
-}
-
 inline void SculptBrush::setReskinRotation(voxelutil::ReskinRotation rotation) {
 	_reskinConfig.rotation = rotation;
 	_paramsDirty = true;
@@ -338,13 +418,30 @@ inline void SculptBrush::setReskinTile(voxelutil::ReskinTile tile) {
 	_paramsDirty = true;
 }
 
-inline void SculptBrush::setReskinMirrorU(bool mirror) {
-	_reskinConfig.mirrorU = mirror;
+inline void SculptBrush::setReskinPreview(bool preview) {
+	_reskinConfig.preview = preview;
 	_paramsDirty = true;
 }
 
-inline void SculptBrush::setReskinMirrorV(bool mirror) {
-	_reskinConfig.mirrorV = mirror;
+inline void SculptBrush::setReskinMaxRepeatU(int count) {
+	_reskinConfig.maxRepeatU = glm::clamp(count, 0, MaxReskinRepeat);
+	_paramsDirty = true;
+}
+
+inline void SculptBrush::setReskinMaxRepeatV(int count) {
+	_reskinConfig.maxRepeatV = glm::clamp(count, 0, MaxReskinRepeat);
+	_paramsDirty = true;
+}
+
+inline void SculptBrush::setReskinSkinFace(voxel::FaceNames face) {
+	_reskinConfig.skinFace = face;
+	// Re-populate skin depth for the new axis
+	if (_skinVolume != nullptr) {
+		const voxel::Region &sr = _skinVolume->region();
+		const int upIdx = math::getIndexForAxis(voxel::faceToAxis(face));
+		const int depthExtent = sr.getUpperCorner()[upIdx] - sr.getLowerCorner()[upIdx] + 1;
+		_reskinConfig.skinDepth = glm::clamp(depthExtent, 1, MaxReskinDepth);
+	}
 	_paramsDirty = true;
 }
 
@@ -373,6 +470,29 @@ inline void SculptBrush::setReskinInvertSkin(bool invert) {
 	_paramsDirty = true;
 }
 
+inline void SculptBrush::cycleReskinFace() {
+	// Cycle through: PositiveX, NegativeX, PositiveY, NegativeY, PositiveZ, NegativeZ
+	static constexpr voxel::FaceNames faces[] = {
+		voxel::FaceNames::PositiveX, voxel::FaceNames::NegativeX,
+		voxel::FaceNames::PositiveY, voxel::FaceNames::NegativeY,
+		voxel::FaceNames::PositiveZ, voxel::FaceNames::NegativeZ,
+	};
+	static constexpr int numFaces = 6;
+	for (int i = 0; i < numFaces; ++i) {
+		if (faces[i] == _reskinConfig.skinFace) {
+			setReskinSkinFace(faces[(i + 1) % numFaces]);
+			return;
+		}
+	}
+	setReskinSkinFace(voxel::FaceNames::PositiveX);
+}
+
+inline void SculptBrush::cycleReskinAnchor() {
+	int next = ((int)_reskinConfig.anchor + 1) % (int)voxelutil::ReskinAnchor::Max;
+	_reskinConfig.anchor = (voxelutil::ReskinAnchor)next;
+	_paramsDirty = true;
+}
+
 inline int SculptBrush::removeAboveDepth() const {
 	return _removeAboveDepth;
 }
@@ -388,6 +508,14 @@ inline bool SculptBrush::extendOnly() const {
 
 inline void SculptBrush::setExtendOnly(bool extend) {
 	_extendOnly = extend;
+}
+
+inline bool SculptBrush::removeOnly() const {
+	return _removeOnly;
+}
+
+inline void SculptBrush::setRemoveOnly(bool removeOnly) {
+	_removeOnly = removeOnly;
 }
 
 inline int SculptBrush::brushRadius() const {
@@ -408,6 +536,10 @@ inline const voxel::RawVolume *SculptBrush::skinVolume() const {
 
 inline const core::String &SculptBrush::skinFilePath() const {
 	return _skinFilePath;
+}
+
+inline const palette::Palette *SculptBrush::skinPalette() const {
+	return _skinPalette.value();
 }
 
 } // namespace voxedit

--- a/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
+++ b/src/tools/voxedit/modules/voxedit-util/tests/SculptBrushTest.cpp
@@ -48,6 +48,7 @@ TEST_F(SculptBrushTest, testErodeRemovesProtrusion) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Erode);
 	// strength=0.5 -> removeThreshold=2: removes voxels with 0-1 solid face-neighbors
 	brush.setStrength(0.5f);
@@ -92,6 +93,7 @@ TEST_F(SculptBrushTest, testErodePreservesFlatSurface) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Erode);
 	brush.setStrength(0.4f);
 	brush.setIterations(10);
@@ -130,6 +132,7 @@ TEST_F(SculptBrushTest, testErodeReversible) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Erode);
 
 	BrushContext ctx;
@@ -175,6 +178,7 @@ TEST_F(SculptBrushTest, testErodePreservesUnselected) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Erode);
 	brush.setStrength(1.0f);
 	brush.setIterations(3);
@@ -215,6 +219,7 @@ TEST_F(SculptBrushTest, testGrowFillsGap) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Grow);
 	// strength=1.0 -> addThreshold=1 (any air touching a solid voxel)
 	brush.setStrength(1.0f);
@@ -251,6 +256,7 @@ TEST_F(SculptBrushTest, testFlattenRemovesLayers) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Flatten);
 	brush.setIterations(1);
 
@@ -294,6 +300,7 @@ TEST_F(SculptBrushTest, testFlattenReversible) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::Flatten);
 	brush.setIterations(2);
 
@@ -336,6 +343,7 @@ TEST_F(SculptBrushTest, testExtendPlaneFlatSurface) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::ExtendPlane);
 	brush.setBrushRadius(2);
 
@@ -380,6 +388,7 @@ TEST_F(SculptBrushTest, testExtendPlaneSlopedSurface) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::ExtendPlane);
 	brush.setBrushRadius(0);
 	brush.setExtendOnly(false);
@@ -428,6 +437,7 @@ TEST_F(SculptBrushTest, testExtendPlaneRemoveAbove) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::ExtendPlane);
 	brush.setBrushRadius(1);
 	brush.setRemoveAboveDepth(2);
@@ -466,6 +476,58 @@ TEST_F(SculptBrushTest, testExtendPlaneRemoveAbove) {
 	brush.shutdown();
 }
 
+TEST_F(SculptBrushTest, testExtendPlaneRemoveOnly) {
+	// Remove-only: the brush must never place voxels, only carve away the ones above the plane.
+	voxel::RawVolume volume(voxel::Region(-10, 10));
+
+	for (int x = -2; x <= 2; ++x) {
+		for (int z = -2; z <= 2; ++z) {
+			volume.setVoxel(x, 0, z, selectedVoxel());
+		}
+	}
+	// Stack above at x=0
+	volume.setVoxel(0, 1, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+	volume.setVoxel(0, 2, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+	volume.setVoxel(0, 5, 0, voxel::createVoxel(voxel::VoxelType::Generic, 5));
+
+	scenegraph::SceneGraphNode node(scenegraph::SceneGraphNodeType::Model);
+	node.setUnownedVolume(&volume);
+
+	SculptBrush brush;
+	ASSERT_TRUE(brush.init());
+	brush.onActivated();
+	brush.setSculptMode(SculptMode::ExtendPlane);
+	brush.setBrushRadius(1);
+	brush.setRemoveAboveDepth(2);
+	brush.setRemoveOnly(true);
+
+	BrushContext ctx;
+	ctx.targetVolumeRegion = volume.region();
+	ctx.cursorFace = voxel::FaceNames::PositiveY;
+
+	// First click at (0,0,0): fits the plane and carves the stack above (within depth=2).
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+	ASSERT_TRUE(brush.planeFitted());
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 1, 0).getMaterial())) << "Voxel above the plane should be removed";
+	EXPECT_TRUE(voxel::isAir(volume.voxel(0, 2, 0).getMaterial())) << "Voxel above the plane should be removed";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 5, 0).getMaterial())) << "Voxel beyond depth=2 should survive";
+	EXPECT_TRUE(voxel::isBlocked(volume.voxel(0, 0, 0).getMaterial())) << "The plane surface itself must NOT be removed";
+
+	// Paint over air at the plane height where extend would normally place a voxel.
+	ctx.cursorPosition = glm::ivec3(3, 0, 0);
+	ASSERT_TRUE(brush.beginBrush(ctx));
+	executeSculpt(brush, node, ctx);
+	brush.endBrush(ctx);
+
+	EXPECT_TRUE(voxel::isAir(volume.voxel(3, 0, 0).getMaterial()))
+		<< "Remove-only must not place any voxel where extend normally would";
+
+	brush.shutdown();
+}
+
 TEST_F(SculptBrushTest, testExtendPlaneNoPlaneFitted) {
 	// Without clicking a face, painting should be a no-op
 	voxel::RawVolume volume(voxel::Region(-10, 10));
@@ -481,6 +543,7 @@ TEST_F(SculptBrushTest, testExtendPlaneNoPlaneFitted) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::ExtendPlane);
 	brush.setBrushRadius(2);
 
@@ -517,6 +580,7 @@ TEST_F(SculptBrushTest, testExtendPlaneExtendOnly) {
 
 	SculptBrush brush;
 	ASSERT_TRUE(brush.init());
+	brush.onActivated();
 	brush.setSculptMode(SculptMode::ExtendPlane);
 	brush.setBrushRadius(0);
 	ASSERT_TRUE(brush.extendOnly());


### PR DESCRIPTION
Adds the SmoothWall sculpt mode and a performance rewrite of the sculpt brush snapshot/history, on top of the existing sculpt modes.

## SmoothWall
- New `SculptMode::SmoothWall`: interpolates interior wall-column heights from the edge columns so a rough wall surface flattens while the edges are preserved for seamless blending.
- Interpolation modes: Linear / InverseDistance (default) / EdgeAware; optional hole filling; configurable clear depth.
- `voxelutil::sculptSmoothWall` implementation and `SmoothWallInterp` enum.
- BrushPanel UI (interpolation dropdown, fill-holes, clear-depth) and a `g_sculpt.smoothwall` Lua binding with json help.

## Snapshot / history performance
- Replace the SparseVolume-based snapshot/history with a flat `DynamicVoxelArray` + `BitVolume`, with cached rebuild. For multi-million-voxel selections this cuts per-generate history work from seconds to milliseconds, which benefits every sculpt mode.

## Reskin completion (these were declared/tested but unimplemented)
- Implement `ReskinConfig::invertSkin`: a solid skin cell is treated as absent and vice versa; an inverted "present" cell without a skin color preserves the existing voxel instead of stamping one.
- Fix the skin-depth base mapping so skin layer 0 lands on the surface and deeper layers grow outward for both positive and negative faces (the world direction is already carried by `outwardStep`).
- Reskin follow auto-detects the depth axis from the thinnest dimension and adds the `CornerAverage` follow mode.

## Tests
- 65 `VolumeSculptTest` (including SmoothWall coverage and the three previously failing reskin cases) and 13 `SculptBrushTest` pass.

Built and tested against the release tree.